### PR TITLE
Add a new thrift build command that works with multiple thrift files

### DIFF
--- a/baseplate/integration/thrift/command.py
+++ b/baseplate/integration/thrift/command.py
@@ -55,6 +55,45 @@ class BuildThriftCommand(Command):
 
                 self.copy_tree(input_package, output_package)
 
+class NewBuildThriftCommand(Command):
+    description = "Generate Python code from Thrift IDL."
+    user_options = [
+        ("build-base=", "b", "base directory for build library"),
+    ]
+
+    def initialize_options(self):
+        self.build_base = None
+
+    def finalize_options(self):
+        self.set_undefined_options("build",
+            ("build_base", "build_base"),
+        )
+
+    def run(self):
+        if self.dry_run:
+            return
+
+        temp_dir = os.path.join(self.build_base, "thrift")
+        self.mkpath(temp_dir)
+
+        for package in self.distribution.packages:
+            package_dir = os.path.join(*package.split("."))
+
+            for thriftfile in glob.glob(os.path.join(package_dir, "*.thrift")):
+                subprocess.check_call([
+                    "thrift1",
+                    "-strict",
+                    "-gen", "py:utf8strings,slots,new_style",
+                    "-out", temp_dir,
+                    "-I", os.path.dirname(baseplate.thrift.__file__),
+                    thriftfile,
+                ])
+
+                module_name = os.path.splitext(os.path.basename(thriftfile))[0]
+                input_package = os.path.join(temp_dir, module_name)
+                output_package = os.path.join(package_dir, module_name)
+                self.copy_tree(input_package, output_package)
+
 
 class ThriftBuildPyCommand(build_py):
     def run(self):


### PR DESCRIPTION
The original command to build Thrift, `ThriftBuildPyCommand`, is too smart that it renames the generated python module with the `_thrift` suffix. When you only have one thrift file it works fine, but the moment you need to include a different thrift file it creates a huge problem.

For instance, if thrift file `a` includes `sub_a`, in the *generated* python file by thrift compiler, it `import sub_a`, and yet we are generating a python module called `sub_a_thrift`, so the generated py files are effectively broken. 

This issue is observed across Reddit, leading to a ton of ad hoc solutions that plagued the organization.

Unfortunately it is not easy to just kill the `_thrift` suffix in the original command, as many teams are using `import xx_thrift.ttypes ` in their python code.  Changing the original command would lead to an incompatible upgrade when we bump up baseplate version.

This is not ideal but going forward, we should discourage people from using the original command and use the new one. It is developer's responsibility to avoid namespace collision, the framework does not need to be that smart. 

👓 @spladug @mattknox @ckwang8128 