### PR TITLE
Lazily create context attributes attached via baseplate.add_to_context

### DIFF
--- a/baseplate/context/__init__.py
+++ b/baseplate/context/__init__.py
@@ -51,8 +51,9 @@ class ContextObserver(BaseplateObserver):
         self.context_factory = context_factory
 
     def on_server_span_created(self, context, server_span):
-        context_attr = self.context_factory.make_object_for_context(self.name, server_span)
-        setattr(context, self.name, context_attr)
+        def context_attr(_self):
+            return self.context_factory.make_object_for_context(self.name, server_span)
+        context.add_lazy_attribute(self.name, context_attr)
         server_span.register(ContextSpanObserver(self.name, self.context_factory))
 
 

--- a/baseplate/integration/__init__.py
+++ b/baseplate/integration/__init__.py
@@ -5,6 +5,39 @@ application frameworks.
 
 """
 from .wrapped_context import WrappedRequestContext
+
+
+class _LazyAttributesMixin(object):
+    """A mixin that allows instances to add a lazily evaluated attribute
+       through `add_lazy_property`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super(_LazyAttributesMixin, self).__init__(*args, **kwargs)
+        self._lazy_attributes = {}
+
+    # Called when an attribute is missing
+    def __getattr__(self, name):
+        try:
+            lazy_fn = self._lazy_attributes[name]
+        except KeyError:
+            return super(_LazyAttributesMixin, self).__getattr__(name)
+
+        prop_value = lazy_fn(self)
+        setattr(self, name, prop_value)
+        return prop_value
+
+    def add_lazy_attribute(self, name, lazy_fn):
+        """Add a lazily evaluated attribute to this instance.
+
+        :param str name: The name of the attribute.
+        :param func lazy_fn: The function to invoke when the attribute is fist accessed.
+            This function will receive the instance as its first argument.
+
+        """
+        self._lazy_attributes[name] = lazy_fn
+
+
 __all__ = [
     "WrappedRequestContext",
 ]

--- a/baseplate/integration/thrift/__init__.py
+++ b/baseplate/integration/thrift/__init__.py
@@ -27,6 +27,7 @@ import sys
 from thrift.Thrift import TProcessorEventHandler
 
 from ...core import TraceInfo
+from baseplate.integration import _LazyAttributesMixin
 
 
 TRACE_HEADER_NAMES = {
@@ -38,7 +39,7 @@ TRACE_HEADER_NAMES = {
 }
 
 
-class RequestContext(object):
+class RequestContext(_LazyAttributesMixin):
     pass
 
 

--- a/tests/integration/cassandra_tests.py
+++ b/tests/integration/cassandra_tests.py
@@ -16,6 +16,7 @@ except ImportError:
 
 from baseplate.context.cassandra import CassandraContextFactory
 from baseplate.core import Baseplate
+from baseplate.integration.thrift import RequestContext
 
 from . import TestBaseplateObserver, skip_if_server_unavailable
 from .. import mock
@@ -49,7 +50,7 @@ class CassandraTests(unittest.TestCase):
         baseplate.register(self.baseplate_observer)
         baseplate.add_to_context("cassandra", factory)
 
-        self.context = mock.Mock()
+        self.context = RequestContext()
         self.server_span = baseplate.make_server_span(self.context, "test")
 
     def test_simple_query(self):

--- a/tests/integration/hvac_tests.py
+++ b/tests/integration/hvac_tests.py
@@ -13,6 +13,7 @@ except ImportError:
 from baseplate.context.hvac import hvac_factory_from_config
 from baseplate.secrets import SecretsStore
 from baseplate.core import Baseplate
+from baseplate.integration.thrift import RequestContext
 
 from . import TestBaseplateObserver, skip_if_server_unavailable
 from .. import mock
@@ -36,7 +37,7 @@ class HvacTests(unittest.TestCase):
         baseplate.register(self.baseplate_observer)
         baseplate.add_to_context("vault", factory)
 
-        self.context = mock.Mock()
+        self.context = RequestContext()
         self.server_span = baseplate.make_server_span(self.context, "test")
 
     def test_simple(self):

--- a/tests/integration/memcache_tests.py
+++ b/tests/integration/memcache_tests.py
@@ -14,6 +14,7 @@ except ImportError:
 from baseplate.context.memcache import (MemcacheContextFactory,
     MonitoredMemcacheConnection, make_keys_str)
 from baseplate.core import Baseplate, LocalSpan, ServerSpan
+from baseplate.integration.thrift import RequestContext
 
 from . import TestBaseplateObserver, skip_if_server_unavailable
 from .. import mock
@@ -33,7 +34,7 @@ class MemcacheIntegrationTests(unittest.TestCase):
         baseplate.register(self.baseplate_observer)
         baseplate.add_to_context("memcache", factory)
 
-        self.context = mock.Mock()
+        self.context = RequestContext()
         self.server_span = baseplate.make_server_span(self.context, "test")
 
     def test_simple(self):

--- a/tests/integration/redis_tests.py
+++ b/tests/integration/redis_tests.py
@@ -20,6 +20,7 @@ from .. import mock
 
 from baseplate.context.redis import MessageQueue
 from baseplate.message_queue import TimedOutError
+from baseplate.integration.thrift import RequestContext
 
 
 skip_if_server_unavailable("redis", 6379)
@@ -36,7 +37,7 @@ class RedisIntegrationTests(unittest.TestCase):
         baseplate.register(self.baseplate_observer)
         baseplate.add_to_context("redis", factory)
 
-        self.context = mock.Mock()
+        self.context = RequestContext()
         self.server_span = baseplate.make_server_span(self.context, "test")
 
     def test_simple_command(self):

--- a/tests/integration/sqlalchemy_tests.py
+++ b/tests/integration/sqlalchemy_tests.py
@@ -17,6 +17,7 @@ from baseplate.context.sqlalchemy import (
     SQLAlchemySessionContextFactory,
 )
 from baseplate.core import Baseplate
+from baseplate.integration.thrift import RequestContext
 
 from . import TestBaseplateObserver
 from .. import mock
@@ -44,7 +45,7 @@ class SQLAlchemyEngineTests(unittest.TestCase):
         baseplate.register(self.baseplate_observer)
         baseplate.add_to_context("db", factory)
 
-        self.context = mock.Mock()
+        self.context = RequestContext()
         self.server_span = baseplate.make_server_span(self.context, "test")
 
     def test_simple_query(self):
@@ -95,7 +96,7 @@ class SQLAlchemySessionTests(unittest.TestCase):
         baseplate.register(self.baseplate_observer)
         baseplate.add_to_context("db", factory)
 
-        self.context = mock.Mock()
+        self.context = RequestContext()
         self.server_span = baseplate.make_server_span(self.context, "test")
 
     def test_simple_session(self):

--- a/tests/unit/context/tests.py
+++ b/tests/unit/context/tests.py
@@ -11,6 +11,7 @@ from baseplate.core import (
     Span,
 )
 from baseplate.integration import WrappedRequestContext
+from baseplate.integration.thrift import RequestContext
 
 from ... import mock
 
@@ -18,7 +19,7 @@ from ... import mock
 class ContextObserverTests(unittest.TestCase):
     def test_add_to_context(self):
         mock_factory = mock.Mock(spec=ContextFactory)
-        mock_context = mock.Mock()
+        mock_context = RequestContext()
         mock_span = mock.Mock(spec=Span)
 
         observer = ContextObserver("some_attribute", mock_factory)


### PR DESCRIPTION
Same as https://github.com/reddit/baseplate/pull/253, but rebased on 0.28