### PR TITLE
Activate readline in baseplate-tshell

### DIFF
--- a/baseplate/server/__init__.py
+++ b/baseplate/server/__init__.py
@@ -263,5 +263,14 @@ def load_and_run_tshell():
         import code
         newbanner = "Baseplate Interactive Shell\nPython {}\n\n".format(sys.version)
         banner = newbanner + banner
+
+        # import this just for its side-effects (of enabling nice keyboard
+        # movement while editing text)
+        try:
+            import readline
+            del readline
+        except ImportError:
+            pass
+
         shell = code.InteractiveConsole(locals=env)
         shell.interact(banner)


### PR DESCRIPTION
This only kicks in when IPython isn't available, but it gives much nicer
keyboard movement when editing text.

Fixes #240

Before, when hitting Ctrl+A to move to the beginning of the line:

```
Baseplate Interactive Shell
Python 3.7.3 (default, Mar 26 2019, 00:55:50) 
[GCC 7.3.0]

Available Objects:

  app          This project's app instance
  context      The context for this shell instance's span
>>> foo^A^A^A
```

afterwards the cursor just moves.
