### PR TITLE
Pass extra baseplate-script args to invoked script

### DIFF
--- a/baseplate/server/__init__.py
+++ b/baseplate/server/__init__.py
@@ -237,11 +237,14 @@ def load_and_run_script():
     parser.add_argument(
         "entrypoint", type=_load_factory, help="function to call, e.g. module.path:fn_name"
     )
+    parser.add_argument(
+        'args', nargs=argparse.REMAINDER, help="arguments to pass along to the invoked script"
+    )
 
     args = parser.parse_args(sys.argv[1:])
     config = read_config(args.config_file, server_name=None, app_name=args.app_name)
     configure_logging(config, args.debug)
-    args.entrypoint(config.app)
+    args.entrypoint(config.app, *args.args)
 
 
 def load_and_run_tshell():

--- a/baseplate/server/__init__.py
+++ b/baseplate/server/__init__.py
@@ -266,7 +266,7 @@ def _fn_accepts_additional_args(script_fn, fn_args):
 
     allows_additional_args = allows_var_args or positional_arg_count > 1
 
-    if positional_arg_count < 1:
+    if positional_arg_count < 1 and not allows_var_args:
         raise ValueError('script function accepts too few positional arguments')
     elif positional_arg_count > 2:
         raise ValueError('script function accepts too many positional arguments')

--- a/baseplate/server/__init__.py
+++ b/baseplate/server/__init__.py
@@ -268,9 +268,9 @@ def _fn_accepts_additional_args(script_fn, fn_args):
 
     if positional_arg_count < 1 and not allows_var_args:
         raise ValueError("script function accepts too few positional arguments")
-    elif positional_arg_count > 2:
+    if positional_arg_count > 2:
         raise ValueError("script function accepts too many positional arguments")
-    elif additional_args_provided and not allows_additional_args:
+    if additional_args_provided and not allows_additional_args:
         raise ValueError(
             "script function does not accept additional arguments, "
             "but additional arguments were provided"

--- a/baseplate/server/__init__.py
+++ b/baseplate/server/__init__.py
@@ -239,7 +239,7 @@ def load_and_run_script():
         "entrypoint", type=_load_factory, help="function to call, e.g. module.path:fn_name"
     )
     parser.add_argument(
-        'args', nargs=argparse.REMAINDER, help="arguments to pass along to the invoked script"
+        "args", nargs=argparse.REMAINDER, help="arguments to pass along to the invoked script"
     )
 
     args = parser.parse_args(sys.argv[1:])
@@ -267,12 +267,14 @@ def _fn_accepts_additional_args(script_fn, fn_args):
     allows_additional_args = allows_var_args or positional_arg_count > 1
 
     if positional_arg_count < 1 and not allows_var_args:
-        raise ValueError('script function accepts too few positional arguments')
+        raise ValueError("script function accepts too few positional arguments")
     elif positional_arg_count > 2:
-        raise ValueError('script function accepts too many positional arguments')
+        raise ValueError("script function accepts too many positional arguments")
     elif additional_args_provided and not allows_additional_args:
-        raise ValueError('script function does not accept additional arguments, '
-                         'but additional arguments were provided')
+        raise ValueError(
+            "script function does not accept additional arguments, "
+            "but additional arguments were provided"
+        )
 
     return allows_additional_args
 

--- a/docs/cli/script.rst
+++ b/docs/cli/script.rst
@@ -38,15 +38,19 @@ and a small script, ``printer.py``:
 
 .. code-block:: python
 
-   def run(app_config):
-       print(app_config["message"])
+   def run(app_config, *args):
+       parser = argparse.ArgumentParser()
+       parser.add_argument("name")
+       args = parser.parse_args(args)
+
+       print('%s %s' % (app_config["message"], args.name))
 
 You can run the script with various configurations:
 
 .. code-block:: text
 
-   $ baseplate-script printer.ini printer:run
-   Hello!
+   $ baseplate-script printer.ini printer:run Goodbye.
+   Hello! Goodbye.
 
-   $ baseplate-script printer.ini --app-name=bizarro printer:run
-   !olleH
+   $ baseplate-script printer.ini --app-name=bizarro printer:run Goodbye.
+   !olleH Goodbye.

--- a/docs/cli/script.rst
+++ b/docs/cli/script.rst
@@ -38,7 +38,7 @@ and a small script, ``printer.py``:
 
 .. code-block:: python
 
-   def run(app_config, *args):
+   def run(app_config, args):
        parser = argparse.ArgumentParser()
        parser.add_argument("name")
        args = parser.parse_args(args)

--- a/tests/unit/server/server_tests.py
+++ b/tests/unit/server/server_tests.py
@@ -82,24 +82,52 @@ class LoadFactoryTests(unittest.TestCase):
 
 
 class CheckFnSignatureTests(unittest.TestCase):
-    def test_no_args(self):
-        def foo(app_config):
-            pass
-        server._check_fn_signature(foo, [])
-        with self.assertRaises(ValueError):
-            server._check_fn_signature(foo, ['extra_arg'])
 
-    def test_positional_args(self):
-        def foo(app_config, arg1, arg2):
-            pass
-        server._check_fn_signature(foo, ['arg1', 'arg2'])
-        with self.assertRaises(ValueError):
-            server._check_fn_signature(foo, ['arg1'])
+    # def test_no_args(self):
+    #     def foo():
+    #         pass
+    #     with self.assertRaises(ValueError):
+    #         server._fn_accepts_additional_args(foo, [])
 
-    def test_varargs_and_kwargs(self):
-        def foo(app_config, arg1, *arg2, **kwargs):
+    # def test_var_args(self):
+    #     def foo(*args):
+    #         pass
+    #     server._fn_accepts_additional_args(foo, [])
+    #     server._fn_accepts_additional_args(foo, ['arg1'])
+    #     server._fn_accepts_additional_args(foo, ['arg1', 'arg2'])
+
+    # def test_config_arg_only(self):
+    #     def foo(app_config):
+    #         pass
+    #     server._fn_accepts_additional_args(foo, [])
+    #     with self.assertRaises(ValueError):
+    #         server._fn_accepts_additional_args(foo, ['extra_arg'])
+
+    # def test_config_arg_with_var_args(self):
+    #     def foo(app_config, *args):
+    #         pass
+    #     server._fn_accepts_additional_args(foo, [])
+    #     server._fn_accepts_additional_args(foo, ['arg1'])
+    #     server._fn_accepts_additional_args(foo, ['arg1', 'arg2'])
+
+    def test_additional_args(self):
+        def foo(app_config, args):
             pass
-        server._check_fn_signature(foo, ['arg1', 'arg2', 'arg3'])
-        server._check_fn_signature(foo, ['arg1'])
-        with self.assertRaises(ValueError):
-            server._check_fn_signature(foo, [])
+        server._fn_accepts_additional_args(foo, [])
+        server._fn_accepts_additional_args(foo, ['arg1'])
+        server._fn_accepts_additional_args(foo, ['arg1', 'arg2'])
+
+    # def test_additional_args_with_var_args(self):
+    #     def foo(app_config, args, *extra):
+    #         pass
+    #     server._fn_accepts_additional_args(foo, [])
+    #     server._fn_accepts_additional_args(foo, ['arg1'])
+    #     server._fn_accepts_additional_args(foo, ['arg1', 'arg2'])
+
+    # def test_kwargs(self):
+    #     def foo(app_config, arg1, *, bar, **kwargs):
+    #         pass
+    #     server._fn_accepts_additional_args(foo, [])
+    #     server._fn_accepts_additional_args(foo, ['arg1', 'arg2', 'arg3'])
+    #     server._fn_accepts_additional_args(foo, ['arg1'])
+

--- a/tests/unit/server/server_tests.py
+++ b/tests/unit/server/server_tests.py
@@ -82,51 +82,57 @@ class LoadFactoryTests(unittest.TestCase):
 
 
 class CheckFnSignatureTests(unittest.TestCase):
-
     def test_no_args(self):
         def foo():
             pass
+
         with self.assertRaises(ValueError):
             server._fn_accepts_additional_args(foo, [])
 
     def test_var_args(self):
         def foo(*args):
             pass
+
         server._fn_accepts_additional_args(foo, [])
-        server._fn_accepts_additional_args(foo, ['arg1'])
-        server._fn_accepts_additional_args(foo, ['arg1', 'arg2'])
+        server._fn_accepts_additional_args(foo, ["arg1"])
+        server._fn_accepts_additional_args(foo, ["arg1", "arg2"])
 
     def test_config_arg_only(self):
         def foo(app_config):
             pass
+
         server._fn_accepts_additional_args(foo, [])
         with self.assertRaises(ValueError):
-            server._fn_accepts_additional_args(foo, ['extra_arg'])
+            server._fn_accepts_additional_args(foo, ["extra_arg"])
 
     def test_config_arg_with_var_args(self):
         def foo(app_config, *args):
             pass
+
         server._fn_accepts_additional_args(foo, [])
-        server._fn_accepts_additional_args(foo, ['arg1'])
-        server._fn_accepts_additional_args(foo, ['arg1', 'arg2'])
+        server._fn_accepts_additional_args(foo, ["arg1"])
+        server._fn_accepts_additional_args(foo, ["arg1", "arg2"])
 
     def test_additional_args(self):
         def foo(app_config, args):
             pass
+
         server._fn_accepts_additional_args(foo, [])
-        server._fn_accepts_additional_args(foo, ['arg1'])
-        server._fn_accepts_additional_args(foo, ['arg1', 'arg2'])
+        server._fn_accepts_additional_args(foo, ["arg1"])
+        server._fn_accepts_additional_args(foo, ["arg1", "arg2"])
 
     def test_additional_args_with_var_args(self):
         def foo(app_config, args, *extra):
             pass
+
         server._fn_accepts_additional_args(foo, [])
-        server._fn_accepts_additional_args(foo, ['arg1'])
-        server._fn_accepts_additional_args(foo, ['arg1', 'arg2'])
+        server._fn_accepts_additional_args(foo, ["arg1"])
+        server._fn_accepts_additional_args(foo, ["arg1", "arg2"])
 
     def test_kwargs(self):
         def foo(app_config, arg1, *, bar, **kwargs):
             pass
+
         server._fn_accepts_additional_args(foo, [])
-        server._fn_accepts_additional_args(foo, ['arg1', 'arg2', 'arg3'])
-        server._fn_accepts_additional_args(foo, ['arg1'])
+        server._fn_accepts_additional_args(foo, ["arg1", "arg2", "arg3"])
+        server._fn_accepts_additional_args(foo, ["arg1"])

--- a/tests/unit/server/server_tests.py
+++ b/tests/unit/server/server_tests.py
@@ -79,3 +79,27 @@ class LoadFactoryTests(unittest.TestCase):
 
         self.assertEqual(import_module.call_args, mock.call("package.module"))
         self.assertEqual(factory, import_module.return_value.default_name)
+
+
+class CheckFnSignatureTests(unittest.TestCase):
+    def test_no_args(self):
+        def foo(app_config):
+            pass
+        server._check_fn_signature(foo, [])
+        with self.assertRaises(ValueError):
+            server._check_fn_signature(foo, ['extra_arg'])
+
+    def test_positional_args(self):
+        def foo(app_config, arg1, arg2):
+            pass
+        server._check_fn_signature(foo, ['arg1', 'arg2'])
+        with self.assertRaises(ValueError):
+            server._check_fn_signature(foo, ['arg1'])
+
+    def test_varargs_and_kwargs(self):
+        def foo(app_config, arg1, *arg2, **kwargs):
+            pass
+        server._check_fn_signature(foo, ['arg1', 'arg2', 'arg3'])
+        server._check_fn_signature(foo, ['arg1'])
+        with self.assertRaises(ValueError):
+            server._check_fn_signature(foo, [])

--- a/tests/unit/server/server_tests.py
+++ b/tests/unit/server/server_tests.py
@@ -83,32 +83,32 @@ class LoadFactoryTests(unittest.TestCase):
 
 class CheckFnSignatureTests(unittest.TestCase):
 
-    # def test_no_args(self):
-    #     def foo():
-    #         pass
-    #     with self.assertRaises(ValueError):
-    #         server._fn_accepts_additional_args(foo, [])
+    def test_no_args(self):
+        def foo():
+            pass
+        with self.assertRaises(ValueError):
+            server._fn_accepts_additional_args(foo, [])
 
-    # def test_var_args(self):
-    #     def foo(*args):
-    #         pass
-    #     server._fn_accepts_additional_args(foo, [])
-    #     server._fn_accepts_additional_args(foo, ['arg1'])
-    #     server._fn_accepts_additional_args(foo, ['arg1', 'arg2'])
+    def test_var_args(self):
+        def foo(*args):
+            pass
+        server._fn_accepts_additional_args(foo, [])
+        server._fn_accepts_additional_args(foo, ['arg1'])
+        server._fn_accepts_additional_args(foo, ['arg1', 'arg2'])
 
-    # def test_config_arg_only(self):
-    #     def foo(app_config):
-    #         pass
-    #     server._fn_accepts_additional_args(foo, [])
-    #     with self.assertRaises(ValueError):
-    #         server._fn_accepts_additional_args(foo, ['extra_arg'])
+    def test_config_arg_only(self):
+        def foo(app_config):
+            pass
+        server._fn_accepts_additional_args(foo, [])
+        with self.assertRaises(ValueError):
+            server._fn_accepts_additional_args(foo, ['extra_arg'])
 
-    # def test_config_arg_with_var_args(self):
-    #     def foo(app_config, *args):
-    #         pass
-    #     server._fn_accepts_additional_args(foo, [])
-    #     server._fn_accepts_additional_args(foo, ['arg1'])
-    #     server._fn_accepts_additional_args(foo, ['arg1', 'arg2'])
+    def test_config_arg_with_var_args(self):
+        def foo(app_config, *args):
+            pass
+        server._fn_accepts_additional_args(foo, [])
+        server._fn_accepts_additional_args(foo, ['arg1'])
+        server._fn_accepts_additional_args(foo, ['arg1', 'arg2'])
 
     def test_additional_args(self):
         def foo(app_config, args):
@@ -117,17 +117,16 @@ class CheckFnSignatureTests(unittest.TestCase):
         server._fn_accepts_additional_args(foo, ['arg1'])
         server._fn_accepts_additional_args(foo, ['arg1', 'arg2'])
 
-    # def test_additional_args_with_var_args(self):
-    #     def foo(app_config, args, *extra):
-    #         pass
-    #     server._fn_accepts_additional_args(foo, [])
-    #     server._fn_accepts_additional_args(foo, ['arg1'])
-    #     server._fn_accepts_additional_args(foo, ['arg1', 'arg2'])
+    def test_additional_args_with_var_args(self):
+        def foo(app_config, args, *extra):
+            pass
+        server._fn_accepts_additional_args(foo, [])
+        server._fn_accepts_additional_args(foo, ['arg1'])
+        server._fn_accepts_additional_args(foo, ['arg1', 'arg2'])
 
-    # def test_kwargs(self):
-    #     def foo(app_config, arg1, *, bar, **kwargs):
-    #         pass
-    #     server._fn_accepts_additional_args(foo, [])
-    #     server._fn_accepts_additional_args(foo, ['arg1', 'arg2', 'arg3'])
-    #     server._fn_accepts_additional_args(foo, ['arg1'])
-
+    def test_kwargs(self):
+        def foo(app_config, arg1, *, bar, **kwargs):
+            pass
+        server._fn_accepts_additional_args(foo, [])
+        server._fn_accepts_additional_args(foo, ['arg1', 'arg2', 'arg3'])
+        server._fn_accepts_additional_args(foo, ['arg1'])


### PR DESCRIPTION
Fixes part 1 of https://github.com/reddit/baseplate.py/issues/58

This allows users to pass additional args to the invoked script. This should continue to work if no additional args are passed. This allows scripts to parse these args as they usually would with argparse:

```
def run(app_config, *args):
  parser = argparse.ArgumentParser()
  # parser.add_arguments
  args = parser.parse_args(args)
  
```