### PR TITLE
Use setuptools_scm to determine version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,9 +8,13 @@ setup(
     author_email="neil@reddit.com",
     license="BSD",
     url="https://baseplate.readthedocs.io/en/stable/",
-    version="0.29.0",
+    use_scm_version=True,
 
     packages=find_packages(exclude=["tests", "tests.*"]),
+
+    setup_requires=[
+        "setuptools_scm",
+    ],
 
     install_requires=[
         "enum34; python_version <= '3.4'",


### PR DESCRIPTION
This bases versions entirely off of git tags in our case so we never
need to update the source code with version changes again.

setuptools_scm is "the blessed package" for doing this (it's provided by the pypa org who are the main python packaging people). Here's the PEP-440 compliant versioning scheme: https://github.com/pypa/setuptools_scm#default-versioning-scheme

For us, this means that on tagged commits we get a version like `0.30.0` while between releases we get a version like `0.29.1.dev27+ga5f929e` (it increments the last version component and adds the dev suffix including distance from the tagged commit and short commit id).

:eyeglasses: @ckwang8128 @bsimpson63 @pacejackson 