### PR TITLE
Add engine_from_config to sqlalchemy integration

### DIFF
--- a/baseplate/context/sqlalchemy.py
+++ b/baseplate/context/sqlalchemy.py
@@ -61,7 +61,8 @@ def engine_from_config(app_config, secrets=None, prefix="database.", **kwargs):
 
     if options.url:
         return create_engine(options.url)
-    elif not options.drivername:
+
+    if not options.drivername:
         raise config.ConfigurationError(
             "drivername",
             AttributeError("'drivername' is required if 'url' is not set"),

--- a/baseplate/context/sqlalchemy.py
+++ b/baseplate/context/sqlalchemy.py
@@ -56,21 +56,20 @@ def engine_from_config(app_config, secrets, prefix="database.", **kwargs):
             "query": config.DictOf(config.String),  # optional
         }})
     options = getattr(cfg, config_prefix)
-    url_params = dict(drivername=options.drivername)
+    kwargs.setdefault("drivername", options.drivername)
     if options.username:
-        url_params["username"] = options.username
+        kwargs.setdefault("username", options.username)
     if options.password_secret:
-        url_params["password"] = secrets.get_simple(options.password_secret).decode("utf-8")
+        kwargs.setdefault("password", secrets.get_simple(options.password_secret).decode("utf-8"))
     if options.host:
-        url_params["host"] = options.host
+        kwargs.setdefault("host", options.host)
     if options.port:
-        url_params["port"] = options.port
+        kwargs.setdefault("port", options.port)
     if options.database:
-        url_params["database"] = options.database
+        kwargs.setdefault("database", options.database)
     if options.query:
-        url_params["query"] = options.query
-    url_params.update(kwargs)
-    return create_engine(URL(**url_params))
+        kwargs.setdefault("query", options.query)
+    return create_engine(URL(**kwargs))
 
 
 class SQLAlchemyEngineContextFactory(ContextFactory):

--- a/baseplate/context/sqlalchemy.py
+++ b/baseplate/context/sqlalchemy.py
@@ -12,7 +12,7 @@ from baseplate.context import ContextFactory
 from baseplate.core import ServerSpan, SpanObserver
 
 
-def engine_from_config(app_config, secrets, prefix="database.", **kwargs):
+def engine_from_config(app_config, secrets=None, prefix="database.", **kwargs):
     """Make an Engine from a configuration dictionary.
 
     The keys useful to :py:func:`engine_from_config` should be prefixed, e.g.
@@ -71,6 +71,9 @@ def engine_from_config(app_config, secrets, prefix="database.", **kwargs):
     if options.username:
         kwargs.setdefault("username", options.username)
     if options.password_secret:
+        if not secrets:
+            raise TypeError("'secrets' is a required argument to 'engine_from_config' "
+                            "if 'password_secret' is set")
         kwargs.setdefault("password", secrets.get_simple(options.password_secret).decode("utf-8"))
     if options.host:
         kwargs.setdefault("host", options.host)

--- a/baseplate/context/sqlalchemy.py
+++ b/baseplate/context/sqlalchemy.py
@@ -13,7 +13,7 @@ from baseplate.core import ServerSpan, SpanObserver
 
 
 def engine_from_config(app_config, secrets=None, prefix="database."):
-    """Make an :py:class:`sqlalchemy.engine.Engine` from a configuration dictionary.
+    """Make an :py:class:`~sqlalchemy.engine.Engine` from a configuration dictionary.
 
     The keys useful to :py:func:`engine_from_config` should be prefixed, e.g.
     ``database.url``, etc. The ``prefix`` argument specifies the prefix used to

--- a/baseplate/context/sqlalchemy.py
+++ b/baseplate/context/sqlalchemy.py
@@ -22,10 +22,10 @@ def engine_from_config(app_config, secrets=None, prefix="database."):
     Supported keys:
 
     * ``url``: the connection URL to the database, passed to
-        :py:func:`sqlalchemy.engine.url.make_url` to create the
-        :py:class:`sqlalchemy.engine.url.URL` used to connect to the database.
+        :py:func:`~sqlalchemy.engine.url.make_url` to create the
+        :py:class:`~sqlalchemy.engine.url.URL` used to connect to the database.
     * ``credentials_secret`` (optional): the key used to retrieve the database
-        credentials from ``secrets`` as a :py:class:`baseplate.secrets.CredentialSecret`.
+        credentials from ``secrets`` as a :py:class:`~baseplate.secrets.CredentialSecret`.
         If this is supplied, any credentials given in ``url`` we be replaced by
         these.
 

--- a/baseplate/context/sqlalchemy.py
+++ b/baseplate/context/sqlalchemy.py
@@ -13,7 +13,7 @@ from baseplate.core import ServerSpan, SpanObserver
 
 
 def engine_from_config(app_config, secrets=None, prefix="database."):
-    """Make an Engine from a configuration dictionary.
+    """Make an :py:class:`sqlalchemy.engine.Engine` from a configuration dictionary.
 
     The keys useful to :py:func:`engine_from_config` should be prefixed, e.g.
     ``database.url``, etc. The ``prefix`` argument specifies the prefix used to

--- a/baseplate/context/sqlalchemy.py
+++ b/baseplate/context/sqlalchemy.py
@@ -4,7 +4,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 from sqlalchemy import create_engine, event
-from sqlalchemy.engine.url import create_url
+from sqlalchemy.engine.url import make_url
 from sqlalchemy.orm import Session
 
 from baseplate import config
@@ -21,7 +21,7 @@ def engine_from_config(app_config, secrets=None, prefix="database."):
 
     Supported keys:
 
-    * ``url``: the connection URL to the database, passed to :py:func:`sqlalchemy.engine.url.create_url`
+    * ``url``: the connection URL to the database, passed to :py:func:`sqlalchemy.engine.url.make_url`
         to create the :py:class:`sqlalchemy.engine.url.URL` used to connect to the
         database.
     * ``credentials_secret`` (optional): the key used to retrieve the database
@@ -38,7 +38,7 @@ def engine_from_config(app_config, secrets=None, prefix="database."):
             "credentials_secret": config.Optional(config.String),
         }})
     options = getattr(cfg, config_prefix)
-    url = create_url(options.url)
+    url = make_url(options.url)
 
     if options.credentials_secret:
         if not secrets:

--- a/baseplate/context/sqlalchemy.py
+++ b/baseplate/context/sqlalchemy.py
@@ -21,9 +21,9 @@ def engine_from_config(app_config, secrets=None, prefix="database."):
 
     Supported keys:
 
-    * ``url``: the connection URL to the database, passed to :py:func:`sqlalchemy.engine.url.make_url`
-        to create the :py:class:`sqlalchemy.engine.url.URL` used to connect to the
-        database.
+    * ``url``: the connection URL to the database, passed to
+        :py:func:`sqlalchemy.engine.url.make_url` to create the
+        :py:class:`sqlalchemy.engine.url.URL` used to connect to the database.
     * ``credentials_secret`` (optional): the key used to retrieve the database
         credentials from ``secrets`` as a :py:class:`baseplate.secrets.CredentialSecret`.
         If this is supplied, any credentials given in ``url`` we be replaced by

--- a/baseplate/context/sqlalchemy.py
+++ b/baseplate/context/sqlalchemy.py
@@ -7,12 +7,9 @@ from sqlalchemy import create_engine, event
 from sqlalchemy.engine.url import URL
 from sqlalchemy.orm import Session
 
-from .. import config
-from ..context import ContextFactory
-from ..core import (
-    ServerSpan,
-    SpanObserver,
-)
+from baseplate import config
+from baseplate.context import ContextFactory
+from baseplate.core import ServerSpan, SpanObserver
 
 
 def engine_from_config(app_config, secrets, prefix="database.", **kwargs):

--- a/docs/baseplate/context/sqlalchemy.rst
+++ b/docs/baseplate/context/sqlalchemy.rst
@@ -6,16 +6,7 @@
 Configuration Parsing
 ---------------------
 
-.. function:: sqlalchemy.engine_from_config(configuration, prefix='sqlalchemy.', **kwargs)
-
-   Make an engine from a configuration dictionary.
-
-   The keys useful to :py:func:`~sqlalchemy.engine_from_config` should be
-   prefixed, e.g. ``sqlalchemy.url`` etc. The ``prefix`` argument specifies the
-   prefix used to filter keys. Each key is mapped to a corresponding keyword
-   argument on :py:func:`~sqlalchemy.create_engine`. Any keyword arguments
-   given to this function will be passed through. Keyword arguments take
-   precedence over the configuration file.
+.. autofunction:: baseplate.context.sqlalchemy.engine_from_config
 
 
 Classes

--- a/tests/integration/sqlalchemy_tests.py
+++ b/tests/integration/sqlalchemy_tests.py
@@ -6,13 +6,14 @@ from __future__ import unicode_literals
 import unittest
 
 try:
-    from sqlalchemy import create_engine, Column, Integer, String
+    from sqlalchemy import Column, Integer, String
     from sqlalchemy.exc import OperationalError
     from sqlalchemy.ext.declarative import declarative_base
 except ImportError:
     raise unittest.SkipTest("sqlalchemy is not installed")
 
 from baseplate.context.sqlalchemy import (
+    engine_from_config,
     SQLAlchemyEngineContextFactory,
     SQLAlchemySessionContextFactory,
 )
@@ -34,7 +35,7 @@ class TestObject(Base):
 
 class SQLAlchemyEngineTests(unittest.TestCase):
     def setUp(self):
-        engine = create_engine("sqlite://")  # in-memory db
+        engine = engine_from_config({"database.drivername": "sqlite"}, secrets=mock.Mock())  # in-memory db
         Base.metadata.create_all(bind=engine)
         factory = SQLAlchemyEngineContextFactory(engine)
 
@@ -85,7 +86,7 @@ class SQLAlchemyEngineTests(unittest.TestCase):
 
 class SQLAlchemySessionTests(unittest.TestCase):
     def setUp(self):
-        engine = create_engine("sqlite://")  # in-memory db
+        engine = engine_from_config({"database.drivername": "sqlite"}, secrets=mock.Mock())  # in-memory db
         Base.metadata.create_all(bind=engine)
         factory = SQLAlchemySessionContextFactory(engine)
 

--- a/tests/integration/sqlalchemy_tests.py
+++ b/tests/integration/sqlalchemy_tests.py
@@ -35,7 +35,7 @@ class TestObject(Base):
 
 class SQLAlchemyEngineTests(unittest.TestCase):
     def setUp(self):
-        engine = engine_from_config({"database.drivername": "sqlite"}, secrets=mock.Mock())  # in-memory db
+        engine = engine_from_config({"database.url": "sqlite://"})  # in-memory db
         Base.metadata.create_all(bind=engine)
         factory = SQLAlchemyEngineContextFactory(engine)
 
@@ -86,7 +86,7 @@ class SQLAlchemyEngineTests(unittest.TestCase):
 
 class SQLAlchemySessionTests(unittest.TestCase):
     def setUp(self):
-        engine = engine_from_config({"database.drivername": "sqlite"}, secrets=mock.Mock())  # in-memory db
+        engine = engine_from_config({"database.url": "sqlite://"})  # in-memory db
         Base.metadata.create_all(bind=engine)
         factory = SQLAlchemySessionContextFactory(engine)
 

--- a/tests/unit/context/sqlalchemy_tests.py
+++ b/tests/unit/context/sqlalchemy_tests.py
@@ -37,17 +37,17 @@ class EngineFromConfigTests(unittest.TestCase):
         self.secrets = secrets
 
     def test_drivername_only(self):
-        engine = engine_from_config({"database.drivername": "sqlite"}, self.secrets)
+        engine = engine_from_config({"database.drivername": "sqlite"})
         self.assertEqual(engine.url, URL("sqlite"))
 
     def test_url(self):
-        engine = engine_from_config({"database.url": "sqlite://"}, self.secrets)
+        engine = engine_from_config({"database.url": "sqlite://"})
         self.assertEqual(engine.url, URL("sqlite"))
 
     @mock.patch('baseplate.context.sqlalchemy.create_engine')
     def test_drivername_missing(self, create_engine_mock):
         with self.assertRaises(ConfigurationError):
-            engine_from_config({"database.username": "reddit"}, self.secrets)
+            engine_from_config({"database.username": "reddit"})
         self.assertEqual(create_engine_mock.call_count, 0)
 
     @mock.patch('baseplate.context.sqlalchemy.create_engine')
@@ -151,4 +151,20 @@ class EngineFromConfigTests(unittest.TestCase):
                 query={"fizz": "buzz"},
                 unsupported="oops",
             )
+        self.assertEqual(create_engine_mock.call_count, 0)
+
+    @mock.patch('baseplate.context.sqlalchemy.create_engine')
+    def test_secrets_required_with_password_secret(self, create_engine_mock):
+        app_config = {
+            "database.drivername": "postgresql",
+            "database.username": "reddit",
+            "database.password_secret": "secret/sql/password",
+            "database.host": "database.local",
+            "database.port": "8000",
+            "database.database": "test",
+            "database.query.foo": "bar",
+            "database.query.hello": "world",
+        }
+        with self.assertRaises(TypeError):
+            engine_from_config(app_config)
         self.assertEqual(create_engine_mock.call_count, 0)

--- a/tests/unit/context/sqlalchemy_tests.py
+++ b/tests/unit/context/sqlalchemy_tests.py
@@ -1,0 +1,147 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import unittest
+
+try:
+    from sqlalchemy.engine.url import URL
+except ImportError:
+    raise unittest.SkipTest("sqlalchemy is not installed")
+
+from baseplate.context.sqlalchemy import engine_from_config
+from baseplate.file_watcher import FileWatcher
+from baseplate.secrets.store import SecretsStore
+
+from ... import mock
+
+class EngineFromConfigTests(unittest.TestCase):
+    def setUp(self):
+        mock_filewatcher = mock.Mock(spec=FileWatcher)
+        mock_filewatcher.get_data.return_value = {
+            "secrets": {
+                "secret/sql/password": {
+                    "type": "simple",
+                    "value": "password",
+                },
+            },
+            "vault": {
+                "token": "test",
+                "url": "http://vault.example.com:8200/",
+            }
+        }
+        secrets = SecretsStore("/secrets")
+        secrets._filewatcher = mock_filewatcher
+        self.secrets = secrets
+
+    def test_database_only(self):
+        engine = engine_from_config({"database.drivername": "sqlite"}, self.secrets)
+        self.assertEqual(engine.url, URL("sqlite"))
+
+    @mock.patch('baseplate.context.sqlalchemy.create_engine')
+    def test_no_query(self, create_engine_mock):
+        app_config = {
+            "database.drivername": "postgresql",
+            "database.username": "reddit",
+            "database.password_secret": "secret/sql/password",
+            "database.host": "database.local",
+            "database.port": "8000",
+            "database.database": "test",
+        }
+        engine_from_config(app_config, self.secrets)
+        create_engine_mock.assert_called_once_with(URL(
+            drivername="postgresql",
+            username="reddit",
+            password="password",
+            host="database.local",
+            port=8000,
+            database="test",
+        ))
+
+    @mock.patch('baseplate.context.sqlalchemy.create_engine')
+    def test_query(self, create_engine_mock):
+        app_config = {
+            "database.drivername": "postgresql",
+            "database.username": "reddit",
+            "database.password_secret": "secret/sql/password",
+            "database.host": "database.local",
+            "database.port": "8000",
+            "database.database": "test",
+            "database.query.foo": "bar",
+            "database.query.hello": "world",
+        }
+        engine_from_config(app_config, self.secrets)
+        create_engine_mock.assert_called_once_with(URL(
+            drivername="postgresql",
+            username="reddit",
+            password="password",
+            host="database.local",
+            port=8000,
+            database="test",
+            query={"foo": "bar", "hello": "world"},
+        ))
+
+    @mock.patch('baseplate.context.sqlalchemy.create_engine')
+    def test_kwarg_override(self, create_engine_mock):
+        app_config = {
+            "database.drivername": "postgresql",
+            "database.username": "reddit",
+            "database.password_secret": "secret/sql/password",
+            "database.host": "database.local",
+            "database.port": "8000",
+            "database.database": "test",
+            "database.query.foo": "bar",
+            "database.query.hello": "world",
+        }
+        engine_from_config(
+            app_config,
+            self.secrets,
+            drivername="mysql",
+            username="foo",
+            password="bar",
+            host="mydb.local",
+            port=9000,
+            database="db",
+            query={"fizz": "buzz"},
+        )
+        create_engine_mock.assert_called_once_with(URL(
+            drivername="mysql",
+            username="foo",
+            password="bar",
+            host="mydb.local",
+            port=9000,
+            database="db",
+            query={"fizz": "buzz"},
+        ))
+
+    @mock.patch('baseplate.context.sqlalchemy.create_engine')
+    def test_unsupported_kwarg_override(self, create_engine_mock):
+        app_config = {
+            "database.drivername": "postgresql",
+            "database.username": "reddit",
+            "database.password_secret": "secret/sql/password",
+            "database.host": "database.local",
+            "database.port": "8000",
+            "database.database": "test",
+            "database.query.foo": "bar",
+            "database.query.hello": "world",
+        }
+        with self.assertRaises(TypeError):
+            engine_from_config(
+                app_config,
+                self.secrets,
+                drivername="mysql",
+                username="foo",
+                password="bar",
+                host="mydb.local",
+                port=9000,
+                database="db",
+                query={"fizz": "buzz"},
+                unsupported="oops",
+            )
+        self.assertEqual(create_engine_mock.call_count, 0)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This allows us to specify the different connection params and fetch the password from a SecretsStore.

👓 @spladug @bsimpson63 