### PR TITLE
catch TypeError in experiment targeting and treat as non-match

### DIFF
--- a/baseplate/experiments/targeting/tree_targeting.py
+++ b/baseplate/experiments/targeting/tree_targeting.py
@@ -51,9 +51,12 @@ class EqualNode(Targeting):
 
     def evaluate(self, **kwargs):
         candidate_value = kwargs.get(self._accepted_key)
-        if candidate_value in self._accepted_values:
-            return True
-
+        try:
+            if candidate_value in self._accepted_values:
+                return True
+        except TypeError:
+            pass
+            
         return False
 
 

--- a/baseplate/experiments/targeting/tree_targeting.py
+++ b/baseplate/experiments/targeting/tree_targeting.py
@@ -5,6 +5,7 @@ from .base import Targeting
 
 logger = logging.getLogger(__name__)
 
+
 class TargetingNodeError(Exception):
     pass
 

--- a/baseplate/experiments/targeting/tree_targeting.py
+++ b/baseplate/experiments/targeting/tree_targeting.py
@@ -60,7 +60,7 @@ class EqualNode(Targeting):
             if candidate_value in self._accepted_values:
                 return True
         except TypeError as err:
-            logger.warn(err)
+            logger.warning(err)
 
         return False
 

--- a/baseplate/experiments/targeting/tree_targeting.py
+++ b/baseplate/experiments/targeting/tree_targeting.py
@@ -1,5 +1,9 @@
+import logging
+
 from .base import Targeting
 
+
+logger = logging.getLogger(__name__)
 
 class TargetingNodeError(Exception):
     pass
@@ -54,9 +58,9 @@ class EqualNode(Targeting):
         try:
             if candidate_value in self._accepted_values:
                 return True
-        except TypeError:
-            pass
-            
+        except TypeError as err:
+            logger.warn(err)
+
         return False
 
 


### PR DESCRIPTION
when targeting on strings and attempting to match a long integer,
a TypeError can be thrown. In those cases, catch it and treat as
a non-match.