### PR TITLE
Add java namespace to baseplate.thrift

### DIFF
--- a/baseplate/thrift/baseplate.thrift
+++ b/baseplate/thrift/baseplate.thrift
@@ -1,5 +1,7 @@
 namespace py baseplate.thrift
 
+namespace java com.reddit.baseplate
+
 /** The base for any baseplate-based service.
 
 Your service should inherit from this one so that common tools can interact


### PR DESCRIPTION
There's no way to specify java namespace to thrift compiler command,
line, and without proper java namespace the generated java code will be
kinda unusable, especially when this file is imported by other thrift
files.

The added java namespace should be a no-op for non-java thrift compiler
actions.