### PR TITLE
Removed typo of 'r' to fix issue #276.

### DIFF
--- a/baseplate/experiments/__init__.py
+++ b/baseplate/experiments/__init__.py
@@ -122,7 +122,7 @@ class Experiments(object):
 
     def variant(self, name, user=None, bucketing_event_override=None,
                 **kwargs):
-        r"""Return which variant, if any, is active.
+        """Return which variant, if any, is active.
 
         If a variant is active, a bucketing event will be logged to the event
         pipeline unless any one of the following conditions are met:


### PR DESCRIPTION
Issue #276 stated that a typo had been intoduced to baseplate/experiments/__init__.py in commit 29d99fc.

This PR fixes the typo in order to close #276. 

> T54
> /u/Tensouder54