### PR TITLE
Check trace header sampled value in both byte and str

### DIFF
--- a/baseplate/integration/pyramid/__init__.py
+++ b/baseplate/integration/pyramid/__init__.py
@@ -218,7 +218,7 @@ class BaseplateConfigurator(object):
 
     def _get_trace_info(self, headers):
         extracted_values = TraceInfo.extract_upstream_header_values(TRACE_HEADER_NAMES, headers)
-        sampled = bool(extracted_values.get("sampled") == b"1")
+        sampled = bool(extracted_values.get("sampled") in {b"1", "1"})
         flags = extracted_values.get("flags", None)
         return TraceInfo.from_upstream(
             int(extracted_values["trace_id"]),


### PR DESCRIPTION
Regarding to the change before https://github.com/reddit/baseplate.py/pull/223/files#diff-d1382533c32ca95376190e31679acc05R157 made the str compare with byte, but which is incompatible with python3. so we need to compare with byte and also compare with python3 str