### PR TITLE
Expect 'sampled' header to be unicode already

### DIFF
--- a/baseplate/integration/pyramid/__init__.py
+++ b/baseplate/integration/pyramid/__init__.py
@@ -218,7 +218,7 @@ class BaseplateConfigurator(object):
 
     def _get_trace_info(self, headers):
         extracted_values = TraceInfo.extract_upstream_header_values(TRACE_HEADER_NAMES, headers)
-        sampled = bool(extracted_values.get("sampled") == b"1")
+        sampled = bool(extracted_values.get("sampled") == "1")
         flags = extracted_values.get("flags", None)
         return TraceInfo.from_upstream(
             int(extracted_values["trace_id"]),

--- a/tests/integration/pyramid_tests.py
+++ b/tests/integration/pyramid_tests.py
@@ -160,7 +160,7 @@ class ConfiguratorTests(unittest.TestCase):
             "X-Trace": "1234",
             "X-Parent": "2345",
             "X-Span": "3456",
-            "X-Sampled": b"1",
+            "X-Sampled": "1",
             "X-Flags": "1",
         })
 
@@ -185,7 +185,7 @@ class ConfiguratorTests(unittest.TestCase):
             "X-B3-TraceId": "1234",
             "X-B3-ParentSpanId": "2345",
             "X-B3-SpanId": "3456",
-            "X-B3-Sampled": b"1",
+            "X-B3-Sampled": "1",
             "X-B3-Flags": "1",
         })
 


### PR DESCRIPTION
I added a print statement to L221 of baseplate/integration/pyramid/__init__.py and confirmed that the header is always a unicode object by the time it gets there in both Py2.7 and Py3.7. I don't know why I did this with a byte string, other than potentially stupidly mimicing the `.decode("utf8")` that was there before my change. That apparently was an unnecessary no-op.

This should fix #278 by properly parsing the header.

cc: @suzie-su 