### PR TITLE
Add CredentialSecret class to documentation

### DIFF
--- a/baseplate/secrets/__init__.py
+++ b/baseplate/secrets/__init__.py
@@ -7,6 +7,7 @@ from __future__ import unicode_literals
 
 from .store import (
     CorruptSecretError,
+    CredentialSecret,
     SecretNotFoundError,
     SecretsNotAvailableError,
     SecretsStore,
@@ -17,6 +18,7 @@ from .store import (
 
 __all__ = [
     "CorruptSecretError",
+    "CredentialSecret",
     "SecretNotFoundError",
     "SecretsNotAvailableError",
     "SecretsStore",

--- a/docs/baseplate/secrets.rst
+++ b/docs/baseplate/secrets.rst
@@ -35,6 +35,9 @@ fetcher daemon.
 .. autoclass:: VersionedSecret
    :members:
 
+.. autoclass:: CredentialSecret
+   :members:
+
 Exceptions
 ~~~~~~~~~~
 


### PR DESCRIPTION
While prepping for 0.30 release, I noticed that the `CredentialSecret` link here is dead. The class needed to be added to the sphinx docs. 

https://baseplate.readthedocs.io/en/latest/baseplate/secrets.html#baseplate.secrets.SecretsStore.get_credentials