### PR TITLE
Add mypy infrastructure and type up the metrics module

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -12,6 +12,7 @@ steps:
           - pip install $PIP_OPTIONS -r requirements-lint.txt
           - flake8
           - pylint baseplate/
+          - mypy baseplate/
 
 ---
 kind: pipeline

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ test:
 lint:
 	flake8
 	pylint baseplate/
+	mypy baseplate/
 
 checks: tests lint spelling
 

--- a/baseplate/metrics.py
+++ b/baseplate/metrics.py
@@ -301,7 +301,7 @@ class Counter:
         self.transport = transport
         self.name = name
 
-    def increment(self, delta: float = 1, sample_rate: float = 1.0) -> None:
+    def increment(self, delta: float = 1.0, sample_rate: float = 1.0) -> None:
         """Increment the counter.
 
         :param delta: The amount to increase the counter by.
@@ -310,7 +310,7 @@ class Counter:
         """
         self.send(delta, sample_rate)
 
-    def decrement(self, delta: float = 1, sample_rate: float = 1.0) -> None:
+    def decrement(self, delta: float = 1.0, sample_rate: float = 1.0) -> None:
         """Decrement the counter.
 
         This is equivalent to :py:meth:`increment` with delta negated.
@@ -356,9 +356,9 @@ class BatchCounter(Counter):
 
     def __init__(self, transport: Transport, name: bytes):
         super(BatchCounter, self).__init__(transport, name)
-        self.packets: DefaultDict[float, float] = collections.defaultdict(int)
+        self.packets: DefaultDict[float, float] = collections.defaultdict(float)
 
-    def increment(self, delta: float = 1, sample_rate: float = 1.0) -> None:
+    def increment(self, delta: float = 1.0, sample_rate: float = 1.0) -> None:
         """Increment the counter.
 
         :param delta: The amount to increase the counter by.
@@ -367,7 +367,7 @@ class BatchCounter(Counter):
         """
         self.packets[sample_rate] += delta
 
-    def decrement(self, delta: float = 1, sample_rate: float = 1.0) -> None:
+    def decrement(self, delta: float = 1.0, sample_rate: float = 1.0) -> None:
         """Decrement the counter.
 
         This is equivalent to :py:meth:`increment` with delta negated.

--- a/baseplate/server/wsgi.py
+++ b/baseplate/server/wsgi.py
@@ -11,10 +11,10 @@ from baseplate.server import runtime_monitor, _load_factory
 
 try:
     # pylint: disable=no-name-in-module
-    from gevent.pywsgi import LoggingLogAdapter
+    from gevent.pywsgi import LoggingLogAdapter  # type: ignore
 except ImportError:
     # LoggingLogAdapter is from gevent 1.1+
-    class LoggingLogAdapter:
+    class LoggingLogAdapter:  # type: ignore
         def __init__(self, logger_, level):
             self._logger = logger_
             self._level = level

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,6 +20,7 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.doctest",
     "sphinx.ext.intersphinx",
+    "sphinx_autodoc_typehints",
 ]
 
 intersphinx_mapping = {

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -12,4 +12,5 @@ pyparsing==2.3.1
 pytz==2018.9
 snowballstemmer==1.2.1
 Sphinx==1.8.5
+sphinx-autodoc-typehints==1.6.0
 sphinxcontrib-websupport==1.1.0

--- a/requirements-lint.txt
+++ b/requirements-lint.txt
@@ -7,7 +7,10 @@ flake8-docstrings==1.3.0
 flake8-polyfill==1.0.2
 isort==4.3.16
 lazy-object-proxy==1.3.1
+lxml==4.3.3
 mccabe==0.6.1
+mypy==0.701
+mypy-extensions==0.4.1
 pycodestyle==2.5.0
 pydocstyle==3.0.0
 pyflakes==2.1.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,5 +35,13 @@ exclude =
     tests/
     .tox/
 
+[mypy]
+python_version = 3.6
+ignore_missing_imports = True
+html_report = build/mypy
+
+[mypy-baseplate.thrift.*]
+ignore_errors = true
+
 [bdist_wheel]
 universal=1


### PR DESCRIPTION
This adds the basic requirements and makefile infrastructure for running mypy on baseplate.py. The metrics module is the first ~victim~ place to get annotated up. Sphinx will now pull in type annotations instead of having to do it manually in the docstring. I've also made mypy spit out an HTML report that looks like this:

![Screenshot from 2019-05-30 14-41-14](https://user-images.githubusercontent.com/338853/58666722-01298580-82e9-11e9-8035-02068ec29194.png)

which should help us track our progress on typing everything up.

Notes:

* We're targeting Python 3.6 so we can't use `from __future__ import annotations` so in places that need forward declarations of types, we just use strings. This feels double plus ungood.
* I've turned off all failed import warnings. Maybe this is too broad and I should explicitly turn off the ones we don't have? flake8/pylint will warn us of true typos though.
* None of the strictness settings are on yet as we don't have anywhere near full coverage. Hopefully that can go crazy later on.
* The `LoggingLogAdapter` change is because mypy doesn't like the import in try/except thing. :man_shrugging:   

:eyeglasses: @pacejackson @bradengroom @bsimpson63 