### PR TITLE
Trace publisher heartbeat

### DIFF
--- a/baseplate/diagnostics/tracing/publisher.py
+++ b/baseplate/diagnostics/tracing/publisher.py
@@ -156,9 +156,12 @@ def publish_traces():
     while True:
         current_ts = int(round(time.time() * 1000))
         if (current_ts - last_heartbeat_ts) >= HEARTBEAT_INTERVAL:
-            logger.info("Trace publisher running")
-            metrics_client.counter("trace_publisher.heartbeat")
+            logger.info("Trace publisher running. %d messages queued", trace_queue.current_messages)
+            metrics_client.counter("trace_publisher.heartbeat").increment()
+            msg_gauge = metrics_client.gauge("trace_publisher.queue.number_of_messages")
+            msg_gauge.replace(trace_queue.current_messages)
             last_heartbeat_ts = current_ts
+
         try:
             message = trace_queue.get(timeout=.2)
         except TimedOutError:

--- a/baseplate/diagnostics/tracing/publisher.py
+++ b/baseplate/diagnostics/tracing/publisher.py
@@ -117,7 +117,7 @@ def publish_traces():
     if args.debug:
         level = logging.DEBUG
     else:
-        level = logging.WARNING
+        level = logging.INFO
     logging.basicConfig(level=level)
 
     config_parser = configparser.RawConfigParser()

--- a/baseplate/diagnostics/tracing/publisher.py
+++ b/baseplate/diagnostics/tracing/publisher.py
@@ -153,6 +153,9 @@ def publish_traces():
         except TimedOutError:
             message = None
 
+        # batcher.add should be called even if mesage is None. Inside of the
+        # add method, the age of the batch is checked. The batch is published
+        # if it is older than MAX_BATCH_AGE.
         try:
             batcher.add(message)
         except BatchFull:

--- a/baseplate/message_queue.py
+++ b/baseplate/message_queue.py
@@ -122,6 +122,11 @@ class MessageQueue:
         """
         self.queue.close()
 
+    @property
+    def current_messages(self):
+        """Get the current number of messages in the queue."""
+        return self.queue.current_messages
+
 
 def queue_tool():
     import argparse

--- a/tests/integration/message_queue_tests.py
+++ b/tests/integration/message_queue_tests.py
@@ -73,6 +73,16 @@ class TestMessageQueueCreation(unittest.TestCase):
             with self.assertRaises(TimedOutError):
                 mq.put(b"2", timeout=0)
 
+    def test_current_messages(self):
+        message_queue = MessageQueue(self.qname, max_messages=2, max_message_size=1)
+        with contextlib.closing(message_queue) as mq:
+            mq.put(b"1", timeout=0)
+            self.assertEqual(mq.current_messages, 1)
+            mq.put(b"2", timeout=0)
+            self.assertEqual(mq.current_messages, 2)
+            mq.get()
+            self.assertEqual(mq.current_messages, 1)
+
     def tearDown(self):
         try:
             queue = posix_ipc.MessageQueue(self.qname)


### PR DESCRIPTION
Currently, the logs for the trace publisher are silent if nothing is going wrong. All emitted metrics are also tied to the ZipkinPublisher class. This means that if no traces are being published, no metrics are emitted.

These changes will make the logs slightly noisier by bumping to default level to ``INFO``. A metric and log line will also be emitted every 15 seconds so allow the monitoring and alerting to be established around the main loop and not the publisher.