### PR TITLE
Trigger graceful shutdown of server on SIGUSR2

### DIFF
--- a/baseplate/server/__init__.py
+++ b/baseplate/server/__init__.py
@@ -181,8 +181,11 @@ def register_signal_handlers():
     def _handle_shutdown_signal(_signo, _frame):
         shutdown_event.set()
 
+    # shutdown is signalled with SIGUSR2 under einhorn and SIGTERM in k8s
     signal.signal(signal.SIGUSR2, _handle_shutdown_signal)
     signal.siginterrupt(signal.SIGUSR2, False)
+    signal.signal(signal.SIGTERM, _handle_shutdown_signal)
+    signal.siginterrupt(signal.SIGTERM, False)
     return shutdown_event
 
 

--- a/baseplate/server/__init__.py
+++ b/baseplate/server/__init__.py
@@ -14,6 +14,7 @@ import logging.config
 import signal
 import socket
 import sys
+import threading
 import traceback
 import warnings
 
@@ -162,7 +163,7 @@ def make_app(app_config):
 
 
 def register_signal_handlers():
-    def _handle_debug_signal(_, frame):
+    def _handle_debug_signal(_signo, frame):
         if not frame:
             logger.warning("Received SIGUSR1, but no frame found.")
             return
@@ -175,10 +176,19 @@ def register_signal_handlers():
     signal.signal(signal.SIGUSR1, _handle_debug_signal)
     signal.siginterrupt(signal.SIGUSR1, False)
 
+    shutdown_event = threading.Event()
+
+    def _handle_shutdown_signal(_signo, _frame):
+        shutdown_event.set()
+
+    signal.signal(signal.SIGUSR2, _handle_shutdown_signal)
+    signal.siginterrupt(signal.SIGUSR2, False)
+    return shutdown_event
+
 
 def load_app_and_run_server():
     """Parse arguments, read configuration, and start the server."""
-    register_signal_handlers()
+    shutdown_event = register_signal_handlers()
 
     args = parse_args(sys.argv[1:])
     config = read_config(args.config_file, args.server_name, args.app_name)
@@ -195,8 +205,11 @@ def load_app_and_run_server():
         reloader.start_reload_watcher(extra_files=[args.config_file.name])
 
     logger.info("Listening on %s", listener.getsockname())
-
-    server.serve_forever()
+    server.start()
+    try:
+        shutdown_event.wait()
+    finally:
+        server.stop()
 
 
 def load_and_run_script():


### PR DESCRIPTION
This signal is sent by Einhorn to indicate a shutdown. By listening to
it, we can ask the server to gracefully shut down and properly wait for
existing requests to finish up. This should hopefully help a bit with deploy-related
request failures. 

I have no idea why I didn't do this in the first place. I clearly knew SIGUSR2 was reserved for this purpose. :cry: 

:eyeglasses: @bsimpson63 @pacejackson 