### PR TITLE
Metrics error handling and bugfix

### DIFF
--- a/baseplate/metrics.py
+++ b/baseplate/metrics.py
@@ -215,7 +215,7 @@ class Batch(BaseClient):
 
     def flush(self) -> None:
         """Immediately send the batched metrics."""
-        counters = self.counters
+        counters, self.counters = self.counters, {}
         for counter in counters.values():
             counter.flush()
 

--- a/tests/unit/metrics_tests.py
+++ b/tests/unit/metrics_tests.py
@@ -67,17 +67,13 @@ class BufferedTransportTests(unittest.TestCase):
         self.assertEqual(mocket.sendall.call_count, 1)
         self.assertEqual(mocket.sendall.call_args, mock.call(b"a\nb\nc"))
 
-    @mock.patch("socket.socket")
-    def test_buffered_exception_is_caught(self, mock_make_socket):
-        mocket = mock_make_socket.return_value
-        mocket.sendall.side_effect = mock.Mock(side_effect=socket.error("Test"))
+    def test_buffered_exception_is_caught(self):
         raw_transport = metrics.RawTransport(EXAMPLE_ENDPOINT)
         transport = metrics.BufferedTransport(raw_transport)
-        for i in range(10000):
-            transport.send(b"a")
+        transport.send(b"x" * 65536)
 
-        self.assertEqual(mocket.sendall.call_count, 0)
-        transport.flush()
+        with self.assertRaises(metrics.MessageTooBigTransportError):
+            transport.flush()
 
 
 class BaseClientTests(unittest.TestCase):

--- a/tests/unit/metrics_tests.py
+++ b/tests/unit/metrics_tests.py
@@ -177,6 +177,14 @@ class BatchTests(unittest.TestCase):
             batch_counter.increment()
         self.assertTrue(batch_counter.flush.called)
 
+    def test_counters_cleared_after_flush(self):
+        self.batch.counter("some_counter").increment()
+        self.batch.flush()
+        self.mock_buffer.send.assert_called()
+        self.mock_buffer.reset_mock()
+        self.batch.flush()
+        self.mock_buffer.send.assert_not_called()
+
     def tearDown(self):
         self.patcher.stop()
 


### PR DESCRIPTION
The first commit tries to clarify error messaging around metrics batches. I was watching the thing service logs yesterday and noticed a fair number of the "batch too big" warnings were actually for other stuff like "connection refused". I think this also makes the error handling a bit cleaner. The new messaging looks like:

```
Metrics batch of 370109 bytes is too large to send, flush more often or reduce amount done in this request. Top counters: example_service.busy_counter=2345, example_service.normal_counter=37
```

or 

```
Failed to send metrics batch: [Errno 111] Connection refused
```

The second commit fixes an error encountered by the data team in the event collectors.