### PR TITLE
Collect connection pool statistics periodically

### DIFF
--- a/baseplate/context/__init__.py
+++ b/baseplate/context/__init__.py
@@ -32,6 +32,9 @@ class ContextFactory:
 
     """
 
+    def report_runtime_metrics(self, batch):
+        """Report runtime metrics to the stats sytem."""
+
     def make_object_for_context(self, name, span):
         """Return an object that can be added to the context object."""
         raise NotImplementedError

--- a/baseplate/context/sqlalchemy.py
+++ b/baseplate/context/sqlalchemy.py
@@ -86,9 +86,9 @@ class SQLAlchemyEngineContextFactory(ContextFactory):
             return
 
         batch.gauge("size").replace(pool.size())
-        batch.gauge("checkedin").replace(pool.checkedin())
+        batch.gauge("open_and_available").replace(pool.checkedin())
+        batch.gauge("in_use").replace(pool.checkedout())
         batch.gauge("overflow").replace(max(pool.overflow(), 0))
-        batch.gauge("checkedout").replace(pool.checkedout())
 
     def make_object_for_context(self, name, span):
         engine = self.engine.execution_options(context_name=name, server_span=span)

--- a/baseplate/context/sqlalchemy.py
+++ b/baseplate/context/sqlalchemy.py
@@ -85,10 +85,10 @@ class SQLAlchemyEngineContextFactory(ContextFactory):
         if not isinstance(pool, QueuePool):
             return
 
-        batch.gauge("size").replace(pool.size())
-        batch.gauge("open_and_available").replace(pool.checkedin())
-        batch.gauge("in_use").replace(pool.checkedout())
-        batch.gauge("overflow").replace(max(pool.overflow(), 0))
+        batch.gauge("pool.size").replace(pool.size())
+        batch.gauge("pool.open_and_available").replace(pool.checkedin())
+        batch.gauge("pool.in_use").replace(pool.checkedout())
+        batch.gauge("pool.overflow").replace(max(pool.overflow(), 0))
 
     def make_object_for_context(self, name, span):
         engine = self.engine.execution_options(context_name=name, server_span=span)

--- a/baseplate/context/thrift.py
+++ b/baseplate/context/thrift.py
@@ -48,6 +48,13 @@ class ThriftContextFactory(ContextFactory):
             },
         )
 
+    def report_runtime_metrics(self, batch):
+        batch.gauge("size").replace(self.pool.size)
+        batch.gauge("checkedout").replace(self.pool.checkedout)
+        # it's hard to report "checkedin" currently because we can't
+        # distinguish easily between available connection slots that aren't
+        # instantiated and ones that have actual open connections.
+
     def make_object_for_context(self, name, span):
         return self.proxy_cls(self.client_cls, self.pool, span, name)
 

--- a/baseplate/context/thrift.py
+++ b/baseplate/context/thrift.py
@@ -49,8 +49,8 @@ class ThriftContextFactory(ContextFactory):
         )
 
     def report_runtime_metrics(self, batch):
-        batch.gauge("size").replace(self.pool.size)
-        batch.gauge("in_use").replace(self.pool.checkedout)
+        batch.gauge("pool.size").replace(self.pool.size)
+        batch.gauge("pool.in_use").replace(self.pool.checkedout)
         # it's hard to report "open_and_available" currently because we can't
         # distinguish easily between available connection slots that aren't
         # instantiated and ones that have actual open connections.

--- a/baseplate/context/thrift.py
+++ b/baseplate/context/thrift.py
@@ -50,8 +50,8 @@ class ThriftContextFactory(ContextFactory):
 
     def report_runtime_metrics(self, batch):
         batch.gauge("size").replace(self.pool.size)
-        batch.gauge("checkedout").replace(self.pool.checkedout)
-        # it's hard to report "checkedin" currently because we can't
+        batch.gauge("in_use").replace(self.pool.checkedout)
+        # it's hard to report "open_and_available" currently because we can't
         # distinguish easily between available connection slots that aren't
         # instantiated and ones that have actual open connections.
 

--- a/baseplate/core.py
+++ b/baseplate/core.py
@@ -611,6 +611,7 @@ class Baseplate:
     def __init__(self):
         self.observers = []
         self._metrics_client = None
+        self._reporters = {}
 
     def register(self, observer):
         """Register an observer.
@@ -710,6 +711,7 @@ class Baseplate:
         # pylint: disable=cyclic-import
         from baseplate.context import ContextObserver
 
+        self._reporters[name] = context_factory.report_runtime_metrics
         self.register(ContextObserver(name, context_factory))
 
     def make_server_span(self, context, name, trace_info=None):

--- a/baseplate/thrift_pool.py
+++ b/baseplate/thrift_pool.py
@@ -136,6 +136,7 @@ class ThriftConnectionPool:
         self.timeout = timeout
         self.protocol_factory = protocol_factory
 
+        self.size = size
         self.pool = queue.LifoQueue()
         for _ in range(size):
             self.pool.put(None)
@@ -228,3 +229,7 @@ class ThriftConnectionPool:
             raise
         finally:
             self._release(prot)
+
+    @property
+    def checkedout(self):
+        return self.size - self.pool.qsize()

--- a/docs/baseplate/context/sqlalchemy.rst
+++ b/docs/baseplate/context/sqlalchemy.rst
@@ -8,10 +8,37 @@ Configuration Parsing
 
 .. autofunction:: baseplate.context.sqlalchemy.engine_from_config
 
-
 Classes
 -------
 
 .. autoclass:: baseplate.context.sqlalchemy.SQLAlchemyEngineContextFactory
 
 .. autoclass:: baseplate.context.sqlalchemy.SQLAlchemySessionContextFactory
+
+Runtime Metrics
+---------------
+
+In addition to request-level metrics reported through spans, this wrapper
+reports connection pool statistics periodically via the :ref:`runtime-metrics`
+system.  All metrics are prefixed as follows:
+
+   {namespace}.runtime.{hostname}.PID{pid}.clients.{name}
+
+where ``namespace`` is the application's namespace, ``hostname`` and ``pid``
+come from the operating system, and ``name`` is the name given to
+:py:meth:`~baseplate.core.Baseplate.add_to_context` when registering this
+context factory.
+
+The following metrics are reported:
+
+``pool.size``
+   The size limit for the connection pool.
+``pool.open_and_available``
+   How many connections have been established but are sitting available for use
+   in the connection pool.
+``pool.in_use``
+   How many connections have been established and are currently checked out and
+   being used.
+``pool.overflow``
+   How many connections beyond the pool size are currently being used. See
+   :py:class:`sqlalchemy.pool.QueuePool` for more information.

--- a/docs/baseplate/context/thrift.rst
+++ b/docs/baseplate/context/thrift.rst
@@ -4,3 +4,25 @@
 .. automodule:: baseplate.context.thrift
 
 .. autoclass:: baseplate.context.thrift.ThriftContextFactory
+
+Runtime Metrics
+---------------
+
+In addition to request-level metrics reported through spans, this wrapper
+reports connection pool statistics periodically via the :ref:`runtime-metrics`
+system.  All metrics are prefixed as follows:
+
+   {namespace}.runtime.{hostname}.PID{pid}.clients.{name}
+
+where ``namespace`` is the application's namespace, ``hostname`` and ``pid``
+come from the operating system, and ``name`` is the name given to
+:py:meth:`~baseplate.core.Baseplate.add_to_context` when registering this
+context factory.
+
+The following metrics are reported:
+
+``pool.size``
+   The size limit for the connection pool.
+``pool.in_use``
+   How many connections have been established and are currently checked out and
+   being used.

--- a/docs/cli/serve.rst
+++ b/docs/cli/serve.rst
@@ -138,6 +138,8 @@ Note that Einhorn will exit if you send it a ``SIGUSR1``. You can instead open u
    > signal SIGUSR1
    Successfully sent USR1s to 4 processes: [...]
 
+.. _runtime-metrics:
+
 Process-level metrics
 ---------------------
 


### PR DESCRIPTION
This adds a new ability to ContextFactory objects that hooks them into
the server runtime metrics system and asks them to periodically produce
metrics.

The SQLAlchemy and Thrift context clients are now instrumented to
periodically report their connection pool statistics to give more
insight into what's going on in there.

For some simple context clients like this:

```python
baseplate.add_to_context(
    "downstream", ThriftContextFactory(thrift_pool, BaseplateService.Client))
baseplate.add_to_context("db", SQLAlchemyEngineContextFactory(engine))
```

The following metrics might be sent:

```
example_server.runtime.hostname.PID13814.clients.downstream.size:10|g
example_server.runtime.hostname.PID13814.clients.downstream.checkedout:0|g
example_server.runtime.hostname.PID13814.clients.db.size:5|g
example_server.runtime.hostname.PID13814.clients.db.checkedin:0|g
example_server.runtime.hostname.PID13814.clients.db.overflow:0|g
example_server.runtime.hostname.PID13814.clients.db.checkedout:0|g
```

This starts to fix #150.