### PR TITLE
Set a 'maxsize' on the internal work queue in BaseKombuConsumer

### DIFF
--- a/baseplate/queue_consumer.py
+++ b/baseplate/queue_consumer.py
@@ -106,7 +106,7 @@ class BaseKombuConsumer:
         :param list queues: List of :py:class:`kombu.queue.Queue` objects.
         :param int queue_size: (Optional) The maximum number of messages to cache
             in the internal `queue.Queue` worker queue.  Defaults to 100.  For
-            an infinite size (not reccomended), use `queue_size=0`.
+            an infinite size (not recommended), use `queue_size=0`.
 
         """
         work_queue = queue.Queue(maxsize=queue_size)

--- a/baseplate/queue_consumer.py
+++ b/baseplate/queue_consumer.py
@@ -99,14 +99,17 @@ class BaseKombuConsumer:
         self.worker_thread = worker_thread
 
     @classmethod
-    def new(cls, connection, queues):
+    def new(cls, connection, queues, queue_size=100):
         """Create and initialize a consumer.
 
         :param kombu.Exchange exchange:
         :param list queues: List of :py:class:`kombu.queue.Queue` objects.
+        :param int queue_size: (Optional) The maximum number of messages to cache
+            in the internal `queue.Queue` worker queue.  Defaults to 100.  For
+            an infinite size (not reccomended), use `queue_size=0`.
 
         """
-        work_queue = queue.Queue()
+        work_queue = queue.Queue(maxsize=queue_size)
         worker = _ConsumerWorker(connection, queues, work_queue)
         worker_thread = Thread(target=worker.run)
         worker_thread.name = "consumer message pump"

--- a/tests/unit/queue_consumer_tests.py
+++ b/tests/unit/queue_consumer_tests.py
@@ -52,3 +52,17 @@ class BaseKombuConsumerTests(unittest.TestCase):
             ]
         )
         self.assertEqual(worker.get_message.call_count, 4)
+
+    # Mock out threading.Thread so we don't actually start up phantom worker threads.
+    @mock.patch("baseplate.queue_consumer.Thread")
+    def test_queue_size(self, _):
+        consumer = queue_consumer.BaseKombuConsumer.new(mock.Mock(), mock.Mock(), queue_size=10)
+        self.assertEqual(consumer.worker.work_queue.maxsize, 10)
+
+    # Mock out threading.Thread so we don't actually start up phantom worker threads.
+    @mock.patch("baseplate.queue_consumer.Thread")
+    def test_default_queue_size_gt_zero(self, _):
+        # We don't really care to test the exact default queue size, just that
+        # it is greater than zero (which is infinite/unbounded).
+        consumer = queue_consumer.BaseKombuConsumer.new(mock.Mock(), mock.Mock())
+        self.assertGreater(consumer.worker.work_queue.maxsize, 0)


### PR DESCRIPTION
Currently we are using the default value which is unbounded.  In certain cases, this can lead to the _ConsumerWorker rapidly filling the work queue until the application runs out of memory and crashes.

👓 @spladug @bsimpson63 