### PR TITLE
Add 'component' annotation to traces

### DIFF
--- a/baseplate/diagnostics/tracing/__init__.py
+++ b/baseplate/diagnostics/tracing/__init__.py
@@ -30,6 +30,7 @@ ANNOTATIONS = {
     "SERVER_SEND": "ss",
     "SERVER_RECEIVE": "sr",
     "LOCAL_COMPONENT": "lc",
+    "COMPONENT": "component",
 }
 
 # Feature flags
@@ -172,6 +173,7 @@ class TraceSpanObserver(SpanObserver):
         self.end = None
         self.elapsed = None
         self.binary_annotations = []
+        self.on_set_tag(ANNOTATIONS['COMPONENT'], 'baseplate')
         super(TraceSpanObserver, self).__init__()
 
     def on_start(self):

--- a/baseplate/diagnostics/tracing/__init__.py
+++ b/baseplate/diagnostics/tracing/__init__.py
@@ -173,7 +173,7 @@ class TraceSpanObserver(SpanObserver):
         self.end = None
         self.elapsed = None
         self.binary_annotations = []
-        self.on_set_tag(ANNOTATIONS['COMPONENT'], 'baseplate')
+        self.on_set_tag(ANNOTATIONS["COMPONENT"], "baseplate")
         super(TraceSpanObserver, self).__init__()
 
     def on_start(self):

--- a/tests/unit/diagnostics/tracing_tests.py
+++ b/tests/unit/diagnostics/tracing_tests.py
@@ -126,7 +126,7 @@ class TraceSpanObserverTests(TraceTestBase):
     def test_component_set_on_initialization(self):
         component_set = False
         for annotation in self.test_span_observer.binary_annotations:
-            if annotation['key'] == ANNOTATIONS['COMPONENT'] and annotation['value'] == 'baseplate':
+            if annotation["key"] == ANNOTATIONS["COMPONENT"] and annotation["value"] == "baseplate":
                 component_set = True
                 break
         self.assertTrue(component_set)
@@ -284,15 +284,17 @@ class TraceLocalSpanObserverTests(TraceTestBase):
         self.assertListEqual(
             local_trace_observer.binary_annotations,
             [
-                {'key': ANNOTATIONS['COMPONENT'],
-                 'value': 'baseplate',
-                 'endpoint': {'ipv4': 'test-host', 'serviceName': 'test-service'},
+                {
+                    "key": ANNOTATIONS["COMPONENT"],
+                    "value": "baseplate",
+                    "endpoint": {"ipv4": "test-host", "serviceName": "test-service"},
                 },
-                {'key': ANNOTATIONS['LOCAL_COMPONENT'],
-                 'value': 'test-component',
-                 'endpoint': {'ipv4': 'test-host', 'serviceName': 'test-service'},
+                {
+                    "key": ANNOTATIONS["LOCAL_COMPONENT"],
+                    "value": "test-component",
+                    "endpoint": {"ipv4": "test-host", "serviceName": "test-service"},
                 },
-            ]
+            ],
         )
 
     def test_serialize(self):
@@ -306,9 +308,9 @@ class TraceLocalSpanObserverTests(TraceTestBase):
         self.assertEqual(serialized_span["name"], self.span.name)
         annotations = serialized_span["binaryAnnotations"]
         for annotation in annotations:
-            self.assertTrue('key' in annotation)
-            self.assertTrue('value' in annotation)
-            self.assertTrue('endpoint' in annotation)
+            self.assertTrue("key" in annotation)
+            self.assertTrue("value" in annotation)
+            self.assertTrue("endpoint" in annotation)
 
 
 class NullRecorderTests(TraceTestBase):


### PR DESCRIPTION
The 'component' annotation is a standard across
tracing implementations that designates the software
package, framework, or library that generates a given span.
Adding this annotation to Baseplate will make it easier
to see Baseplate-generated spans in a trace.