### PR TITLE
Support thrift include statements, document integration

### DIFF
--- a/baseplate/integration/thrift/README.rst
+++ b/baseplate/integration/thrift/README.rst
@@ -11,7 +11,6 @@ So a file named ``foo/bar/baz.thrift``` is accessed as a python module named
 If the baz.thrift file already has a ``namespace py quux`` declaration. It will be
 accessed in python as ``foo.bar.quux``, not the thrift default of ``quux``.
 
-
 Install this behavior by including
 ``baseplate.integration.command.ThriftBuildPyCommand`` as the ``build_py`` command in
 your ``setup.py``.

--- a/baseplate/integration/thrift/README.rst
+++ b/baseplate/integration/thrift/README.rst
@@ -1,0 +1,17 @@
+Baseplate imposes some additional semantics on code defined in .thrift files.
+
+The namespace of the code defaults to (basename)_thrift instead of just the
+base name of the file. Note that this default only applies if there is no
+namespace declaration in the file. If one is present it will be respected, but
+forced to be relative to the directory the thrift file exists in, rather than
+being set to the root of the project.
+
+So a file named ``foo/bar/baz.thrift``` is accessed as a python module named
+``foo.bar.baz_thrift`` rather than the thrift standard of ``baz``.
+If the baz.thrift file already has a ``namespace py quux`` declaration. It will be
+accessed in python as ``foo.bar.quux``, not the thrift default of ``quux``.
+
+
+Install this behavior by including
+``baseplate.integration.command.ThriftBuildPyCommand`` as the ``build_py`` command in
+your ``setup.py``.

--- a/baseplate/integration/thrift/command.py
+++ b/baseplate/integration/thrift/command.py
@@ -9,6 +9,17 @@ import baseplate.thrift
 
 
 class BuildThriftCommand(Command):
+    """
+    Baseplate imposes some additional semantics on code defined in .thrift files.
+
+    The namespace of the code defaults to (basename)_thrift instead of just the
+    base name of the file.  The effective name space is also relative to the
+    package the .thrift file is in rather than the root of the project.
+
+    So a foo/bar/baz.thrift is accessed as a python module named
+    `foo.bar.baz_thrift` rather than the thrift standard of `baz`.
+    """
+
     description = "Generate Python code from Thrift IDL."
     user_options = [("build-base=", "b", "base directory for build library")]
 
@@ -18,6 +29,96 @@ class BuildThriftCommand(Command):
     def finalize_options(self):
         self.set_undefined_options("build", ("build_base", "build_base"))
 
+    def compile_thrift_file(self, temp_dir, thrift_file):
+        subprocess.check_call(
+            [
+                "thrift",
+                "-strict",
+                "-gen",
+                "py:slots",
+                "-out",
+                temp_dir,
+                "-I",
+                os.path.dirname(baseplate.thrift.__file__),
+                thrift_file,
+            ]
+        )
+
+    def namespace_declaration(self, line):
+        if line.startswith("namespace py") or line.startswith("namespace *"):
+            words = line.split()
+            if len(words) > 2:
+                return words[2]
+        return False
+
+    def copy_with_namespace(self, thrift_file, buildfile):
+        """
+        Patch or create the namespace declaration to include the path from the
+        source root to this file.  If it didn't already exist, the base name
+        will be set to (module name)_thrift, not the thrift default of (module
+        name).
+
+        Returns the python module name of the namespace.
+        """
+        with open(thrift_file, "rt") as fd, open(buildfile, "wt") as out:
+            # First, find any pre-existing namespace declaration
+            namespace = None
+            for line in fd:
+                ns = self.namespace_declaration(line)
+                if ns:
+                    namespace = ns
+                    break
+            if not namespace:
+                # No namespace declaration in the source. Set one up by
+                # using the module name plus _thrift to avoid conflicts
+                # with non thrift modules.
+                namespace = os.path.splitext(os.path.basename(thrift_file))[0]
+                namespace += "_thrift"
+
+            # Patch the namespace to reflect the full path from the source
+            # root to this file so the generated imports work.
+            namespace = os.path.dirname(thrift_file).replace("/", ".") + "." + namespace
+
+            fd.seek(0, 0)
+            for line in fd:
+                # Strip out any pre-existing namespace declarations so that our
+                # modified declaration is honored.
+                if self.namespace_declaration(line):
+                    out.write(f"namespace py {namespace}\n")
+                else:
+                    out.write(line)
+            out.flush()
+        return namespace
+
+    def build(self, thrift_file, build_dir, package_dir, python_namespace):
+        print(f"building {thrift_file} -> {python_namespace}")
+        # named 'module', unless there is a namespace declaration.
+        filename = os.path.basename(thrift_file)
+        package = python_namespace.replace(".", "/")
+        built_package = os.path.join(build_dir, package)
+
+        # move the built 'module' directory to a directory 'module_thrift'
+        # at the same path as the original 'module.thrift'. The rename to
+        # module_thrift is handled by copy_with_namespace because handling
+        # references to this code from other thrift files requires adjusting
+        # namespace declarations.
+        # output_package is interpreted relative to the input source, which is
+        # the current working directory.
+        output_package = package
+
+        self.copy_tree(built_package, output_package)
+
+    def find_thrift_files(self):
+        """
+        Returns: [(thrift file path, containing package root)]
+        """
+        thrift_packages = []
+        for package in self.distribution.packages:
+            package_dir = os.path.join(*package.split("."))
+            for thrift_file in glob.glob(os.path.join(package_dir, "*.thrift")):
+                thrift_packages.append((thrift_file, package_dir))
+        return thrift_packages
+
     def run(self):
         if self.dry_run:
             return
@@ -25,45 +126,23 @@ class BuildThriftCommand(Command):
         temp_dir = os.path.join(self.build_base, "thrift")
         self.mkpath(temp_dir)
 
-        for package in self.distribution.packages:
-            package_dir = os.path.join(*package.split("."))
+        # Find all of the thrift files in this project.
+        thrift_packages = self.find_thrift_files()
 
-            for thriftfile in glob.glob(os.path.join(package_dir, "*.thrift")):
-                subprocess.check_call(
-                    [
-                        "thrift",
-                        "-strict",
-                        "-gen",
-                        "py:slots",
-                        "-out",
-                        temp_dir,
-                        "-I",
-                        os.path.dirname(baseplate.thrift.__file__),
-                        thriftfile,
-                    ]
-                )
+        # Copy them all to the clean temp dir, and patch their namespace
+        # declarations to match where we found them in the source.
+        buildfiles = []
+        for thrift_file, package_dir in thrift_packages:
+            build_file = os.path.join(temp_dir, thrift_file)
+            build_package = os.path.dirname(build_file)
+            if not os.path.exists(build_package):
+                os.makedirs(build_package)
+            py_namespace = self.copy_with_namespace(thrift_file, build_file)
+            buildfiles.append((thrift_file, build_file, package_dir, py_namespace))
 
-                module_name = os.path.splitext(os.path.basename(thriftfile))[0]
-                input_package = os.path.join(temp_dir, module_name)
-
-                generated_module = "_".join((module_name, "thrift"))
-                output_package = os.path.join(package_dir, generated_module)
-
-                self.copy_tree(input_package, output_package)
-
-                # rewrite "from thriftname" to "from package.thriftname_thrift"
-                full_package_name = "%s.%s" % (package, generated_module)
-                for remote in glob.glob(os.path.join(output_package, "*-remote")):
-                    with open(remote) as f:
-                        lines = f.readlines()
-
-                    with open(remote, "w") as f:
-                        for line in lines:
-                            prefix = "from " + module_name
-                            if line.startswith(prefix):
-                                f.write("from " + full_package_name + line[len(prefix) :])
-                            else:
-                                f.write(line)
+        # Then compile them all.
+        for thrift_file, build_file, package_dir, py_namespace in buildfiles:
+            self.build(build_file, temp_dir, package_dir, py_namespace)
 
 
 class ThriftBuildPyCommand(build_py):

--- a/baseplate/integration/thrift/command.py
+++ b/baseplate/integration/thrift/command.py
@@ -52,7 +52,8 @@ class BuildThriftCommand(Command):
         return False
 
     def copy_with_namespace(self, thrift_file, buildfile):
-        """
+        """Copy source to working directory, with adjusted namespace declarations.
+        
         Patch or create the namespace declaration to include the path from the
         source root to this file.  If it didn't already exist, the base name
         will be set to (module name)_thrift, not the thrift default of (module
@@ -93,7 +94,6 @@ class BuildThriftCommand(Command):
     def build(self, thrift_file, build_dir, package_dir, python_namespace):
         print(f"building {thrift_file} -> {python_namespace}")
         # named 'module', unless there is a namespace declaration.
-        filename = os.path.basename(thrift_file)
         package = python_namespace.replace(".", "/")
         built_package = os.path.join(build_dir, package)
 
@@ -109,9 +109,7 @@ class BuildThriftCommand(Command):
         self.copy_tree(built_package, output_package)
 
     def find_thrift_files(self):
-        """
-        Returns: [(thrift file path, containing package root)]
-        """
+        """Returns: [(thrift file path, package root path)]."""
         thrift_packages = []
         for package in self.distribution.packages:
             package_dir = os.path.join(*package.split("."))

--- a/tests/integration/thrift_modules/include_target.thrift
+++ b/tests/integration/thrift_modules/include_target.thrift
@@ -1,0 +1,2 @@
+struct IncludeTarget {
+}

--- a/tests/integration/thrift_modules/include_target_with_namespace.thrift
+++ b/tests/integration/thrift_modules/include_target_with_namespace.thrift
@@ -1,0 +1,4 @@
+namespace py include_target_namespace_custom
+
+struct IncludeTarget {
+}

--- a/tests/integration/thrift_modules/test_include.thrift
+++ b/tests/integration/thrift_modules/test_include.thrift
@@ -1,0 +1,5 @@
+include "include_target.thrift"
+
+struct TestInclude {
+  1: include_target.TestInclude,
+}

--- a/tests/integration/thrift_modules/test_include_local_namespace.thrift
+++ b/tests/integration/thrift_modules/test_include_local_namespace.thrift
@@ -1,0 +1,7 @@
+namespace py test_local_namespace
+
+include "include_target.thrift"
+
+struct TestInclude {
+  1: include_target.TestInclude,
+}

--- a/tests/integration/thrift_modules/test_include_remote_namespace.thrift
+++ b/tests/integration/thrift_modules/test_include_remote_namespace.thrift
@@ -1,0 +1,5 @@
+include "include_target_with_namespace.thrift"
+
+struct TestInclude {
+  1: include_target_with_namespace.TestInclude,
+}


### PR DESCRIPTION
The approach for handling thrift include statements is basically tell the thrift compiler to put the built code in the right place up front, rather than trying to fix up its output. 

So, the new build_thrift pass first patches all of the thrift files to have the correct namespace for including them python side, then builds them all, and finally copies the result out of the working directories back into the rest of the source.

This should make fully handling https://reddit.atlassian.net/browse/IO-2804 simpler.