### PR TITLE
Simplify the request context laziness setup

### DIFF
--- a/tests/unit/events/publisher_tests.py
+++ b/tests/unit/events/publisher_tests.py
@@ -121,16 +121,6 @@ class PublisherTests(unittest.TestCase):
         )
 
     @mock.patch("time.sleep")
-    def test_publish_retry(self, mock_sleep):
-        self.session.post.side_effect = [requests.HTTPError(504), IOError, mock.Mock()]
-        events = b'[{"example": "value"}]'
-
-        self.publisher.publish(SerializedBatch(count=1, bytes=events))
-
-        self.assertEqual(mock_sleep.call_count, 2)
-        self.assertEqual(self.session.post.call_count, 3)
-
-    @mock.patch("time.sleep")
     def test_fail_on_client_error(self, mock_sleep):
         self.session.post.side_effect = [
             requests.HTTPError(400, response=mock.Mock(status_code=400))


### PR DESCRIPTION
The stuff I merged a couple of weeks ago (#304) has some problems with Pyramid integration. It looks like using `add_request_method(..., reify=True)` leads to a situation where the new request method gets a copy of the underlying Pyramid request object rather than the baseplate-provided wrapper. This means that those methods can't use any context attributes like `secrets` or whatever. This broke things when trying to upgrade GraphQL for canarying.

I poked around a bit and ended up realizing that what I built then was too complicated and instead of trying to wrap the object and do all the `__getattribute__` shenanigans we should go with the mixin approach @bradengroom pioneered in #253. The big difference from that PR remains that we're passing around the `context_config` dictionary rather than building a span observer for every attribute. This means we only copy the dictionary ref around on span creation rather than doing all the setup of lazy attributes so we keep the big perf win for span setup:

![Time per span by % of attributes accessed (25 attributes)](https://user-images.githubusercontent.com/338853/60919728-51cac180-a24b-11e9-97ce-cc7b51d81791.png)

But it also means that we're no longer doing any proxying of attributes except in local span situations. This means that accessing the ContextFactory-generated attributes after initial setup are very fast again:

![Time to read ContextFactory-generated attribute(1)](https://user-images.githubusercontent.com/338853/60919740-57c0a280-a24b-11e9-85ea-d4e204a52286.png)

and that accessing non-Baseplate stuff like `request.content_type` isn't penalized anymore:

![Time to read non-baseplate attribute (e g  pyramid request properties)](https://user-images.githubusercontent.com/338853/60919747-5b542980-a24b-11e9-849b-1fc333cb8633.png)
