### PR TITLE
Make the connection pool stats configurable

### DIFF
--- a/baseplate/server/runtime_monitor.py
+++ b/baseplate/server/runtime_monitor.py
@@ -172,6 +172,7 @@ def start(server_config, application, pool):
             "monitoring": {
                 "blocked_hub": config.Optional(config.Timespan, default=None),
                 "concurrency": config.Optional(config.Boolean, default=True),
+                "connection_pool": config.Optional(config.Boolean, default=False),
                 "gc": {
                     "stats": config.Optional(config.Boolean, default=True),
                     "timing": config.Optional(config.Boolean, default=False),
@@ -181,10 +182,13 @@ def start(server_config, application, pool):
         },
     )
 
-    reporters = [_BaseplateReporter(baseplate.get_runtime_metric_reporters())]
+    reporters = []
 
     if cfg.monitoring.concurrency:
         reporters.append(_ConcurrencyReporter(pool))
+
+    if cfg.monitoring.connection_pool:
+        reporters.append(_BaseplateReporter(baseplate.get_runtime_metric_reporters()))
 
     if cfg.monitoring.blocked_hub is not None:
         try:

--- a/docs/cli/serve.rst
+++ b/docs/cli/serve.rst
@@ -185,6 +185,12 @@ The following reporters are available:
    :py:class:`~baseplate.metrics.Gauge` with the current number of in-flight
    requests being processed concurrently.
 
+``monitoring.connection_pool``
+   Enabled if ``true``, disabled if ``false``. Defaults to disabled.
+
+   This will track the usage of connection pools for various clients in the
+   application. The metrics generated will depend on which clients are used.
+
 ``monitoring.gc.stats``
    Enabled if ``true``, disabled if ``false``. Defaults to enabled.
 


### PR DESCRIPTION
I relented and made this configurable so we can opt services in when Telegraf's ready.