### PR TITLE
tracing: Turn all exception logging in tracing module to warning

### DIFF
--- a/baseplate/observers/tracing.py
+++ b/baseplate/observers/tracing.py
@@ -131,7 +131,7 @@ class TraceBaseplateObserver(BaseplateObserver):
         try:
             self.hostname = socket.gethostbyname(socket.gethostname())
         except socket.gaierror as e:
-            logger.error("Hostname could not be resolved, error=%s", e)
+            logger.warning("Hostname could not be resolved, error=%s", e)
             self.hostname = "undefined"
 
     @classmethod
@@ -372,7 +372,7 @@ class BaseBatchRecorder:
         try:
             self.span_queue.put_nowait(span)
         except Exception as e:
-            self.logger.error("Failed adding span to recording queue: %s", e)
+            self.logger.warning("Failed adding span to recording queue: %s", e)
 
 
 class LoggingRecorder(BaseBatchRecorder):
@@ -441,7 +441,7 @@ class RemoteRecorder(BaseBatchRecorder):
                 timeout=1,
             )
         except RequestException as e:
-            self.logger.error("Error flushing spans: %s", e)
+            self.logger.warning("Error flushing spans: %s", e)
 
 
 class TraceTooLargeError(Exception):
@@ -475,7 +475,7 @@ class SidecarRecorder:
         # request/response path and should finish cleanly.
         serialized_str = json.dumps(span._serialize())
         if len(serialized_str) > MAX_SIDECAR_MESSAGE_SIZE:
-            logger.error(
+            logger.warning(
                 "Trace too big. Traces published to %s are not allowed to be larger "
                 "than %d bytes. Received trace is %d bytes. This can be caused by "
                 "an excess amount of tags or a large amount of child spans.",
@@ -486,7 +486,9 @@ class SidecarRecorder:
         try:
             self.queue.put(serialized_str, timeout=0)
         except TimedOutError:
-            logger.error("Trace queue %s is full. Is trace sidecar healthy?", self.queue.queue.name)
+            logger.warning(
+                "Trace queue %s is full. Is trace sidecar healthy?", self.queue.queue.name
+            )
 
 
 def tracing_client_from_config(


### PR DESCRIPTION
Tracing instrumentation is not application-critical. This changes
exception and error logging in the module to 'warning' so non-critical
instrumentation issues do not spam application logs.