### PR TITLE
baseplate: Add tracing debug tag populating for spans

### DIFF
--- a/baseplate/observers/tracing.py
+++ b/baseplate/observers/tracing.py
@@ -36,6 +36,8 @@ ANNOTATIONS = {
     "SERVER_RECEIVE": "sr",
     "LOCAL_COMPONENT": "lc",
     "COMPONENT": "component",
+    "DEBUG": "debug",
+    "ERROR": "error",
 }
 
 # Feature flags
@@ -187,7 +189,13 @@ class TraceSpanObserver(SpanObserver):
 
     def on_finish(self, exc_info):
         if exc_info:
-            self.on_set_tag("error", True)
+            self.on_set_tag(ANNOTATIONS["ERROR"], True)
+
+        # Set a debug annotation for downstream processing to
+        # utilize in span filtering.
+        if self.span.flags and (self.span.flags & FLAGS["DEBUG"]):
+            self.on_set_tag(ANNOTATIONS["DEBUG"], True)
+
         self.end = current_epoch_microseconds()
         self.elapsed = self.end - self.start
         self.record()


### PR DESCRIPTION
"Sampled" spans are ones that match a sampled request, which could be at the whim of any number of upstream sampling lotteries. We need a way to differentiate "debug" spans - spans that represent part or all of a request that we have designated specifically as "debug"-required.

Add differentiating between a sampled span and a debug span, and
update TraceObserver to determine whether a span is a debug span
using its flags.

Additionally, add a 'debug' binary annotation to debug spans
for trace storage systems to utilizing in filtering mechanisms.
