### PR TITLE
Add incr_tag interface to spans for observer-generic counters

### DIFF
--- a/baseplate/__init__.py
+++ b/baseplate/__init__.py
@@ -54,6 +54,9 @@ class SpanObserver:
     def on_set_tag(self, key: str, value: Any) -> None:
         """Do something when a tag is set on the observed span."""
 
+    def on_incr_tag(self, key: str, delta: float) -> None:
+        """Do something when a tag value is incremented on the observed span."""
+
     def on_log(self, name: str, payload: Any) -> None:
         """Do something when a log entry is added to the span."""
 
@@ -553,6 +556,20 @@ class Span:
         """
         for observer in self.observers:
             observer.on_set_tag(key, value)
+
+    def incr_tag(self, key: str, delta: float = 1) -> None:
+        """Increment a tag value on the span.
+
+        This is useful to count instances of an event in your application. In
+        addition to showing up as a tag on the span, the value may also be
+        aggregated separately as an independent counter.
+
+        :param key: The name of the tag.
+        :param value: The amount to increment the value. Defaults to 1.
+
+        """
+        for observer in self.observers:
+            observer.on_incr_tag(key, delta)
 
     def log(self, name: str, payload: Optional[Any] = None) -> None:
         """Add a log entry to the span.

--- a/baseplate/observers/tracing.py
+++ b/baseplate/observers/tracing.py
@@ -221,7 +221,7 @@ class TraceSpanObserver(SpanObserver):
         self.elapsed = self.end - typing.cast(int, self.start)
 
         for key, value in self.counters.items():
-            self.binary_annotations.append(self._create_binary_annotation(key, value))
+            self.binary_annotations.append(self._create_binary_annotation(f"counter.{key}", value))
 
         self.recorder.send(self)
 

--- a/docs/api/baseplate/observers/statsd.rst
+++ b/docs/api/baseplate/observers/statsd.rst
@@ -50,6 +50,9 @@ has a name like ``{namespace}.clients.{context_name}.{method}`` and the counter
 ``{namespace}.clients.{context_name}.{method}.{success,failure}`` where
 ``context_name`` is the name of the client in the context configuration.
 
+Calls to :py:meth:`~baseplate.Span.incr_tag` will increment a counter like
+``{namespace}.{tag_name}`` by the amount specified.
+
 When using :program:`baseplate-serve`, various process-level runtime metrics
 will also be emitted. These are not tied to individual requests but instead
 give insight into how the whole application is functioning. See
@@ -64,3 +67,7 @@ When enabled, the metrics observer also adds a
 
    def my_handler(request):
        request.metrics.counter("foo").increment()
+
+To keep your application more generic, it's better to use local spans for
+custom local timers and :py:meth:`~baseplate.Span.incr_tag` for custom
+counters.

--- a/tests/unit/observers/metrics_tests.py
+++ b/tests/unit/observers/metrics_tests.py
@@ -39,7 +39,9 @@ class ServerSpanObserverTests(unittest.TestCase):
     def test_server_span_events(self):
         mock_batch = mock.Mock(spec=Batch)
         mock_timer = mock.Mock(spec=Timer)
+        mock_counter = mock.Mock(spec=Counter)
         mock_batch.timer.return_value = mock_timer
+        mock_batch.counter.return_value = mock_counter
 
         mock_server_span = mock.Mock(spec=ServerSpan)
         mock_server_span.name = "request_name"
@@ -48,6 +50,9 @@ class ServerSpanObserverTests(unittest.TestCase):
 
         observer.on_start()
         self.assertEqual(mock_timer.start.call_count, 1)
+
+        observer.on_incr_tag("test", delta=1)
+        self.assertEqual(mock_counter.increment.call_count, 1)
 
         mock_child_span = mock.Mock()
         mock_child_span.name = "example"
@@ -77,6 +82,10 @@ class ClientSpanObserverTests(unittest.TestCase):
         observer.on_start()
         self.assertEqual(mock_timer.start.call_count, 1)
 
+        observer.on_incr_tag("test", delta=1)
+        mock_counter.increment.assert_called()
+        mock_counter.reset_mock()
+
         observer.on_finish(exc_info=None)
         self.assertEqual(mock_timer.stop.call_count, 1)
         self.assertEqual(mock_counter.increment.call_count, 1)
@@ -90,8 +99,10 @@ class ClientSpanObserverTests(unittest.TestCase):
 class LocalSpanObserverTests(unittest.TestCase):
     def test_metrics(self):
         mock_timer = mock.Mock(spec=Timer)
+        mock_counter = mock.Mock(spec=Counter)
         mock_batch = mock.Mock(spec=Batch)
         mock_batch.timer.return_value = mock_timer
+        mock_batch.counter.return_value = mock_counter
 
         mock_local_span = mock.Mock(spec=LocalSpan)
         mock_local_span.name = "example"
@@ -103,6 +114,10 @@ class LocalSpanObserverTests(unittest.TestCase):
 
         observer.on_start()
         self.assertEqual(mock_timer.start.call_count, 1)
+
+        observer.on_incr_tag("test", delta=1)
+        mock_counter.increment.assert_called()
+        mock_counter.reset_mock()
 
         observer.on_finish(exc_info=None)
         self.assertEqual(mock_timer.stop.call_count, 1)

--- a/tests/unit/observers/tracing_tests.py
+++ b/tests/unit/observers/tracing_tests.py
@@ -233,7 +233,7 @@ class TraceSpanObserverTests(TraceTestBase):
         self.test_span_observer.on_incr_tag("test-key", 5)
         self.test_span_observer.on_finish(None)
         annotation = self.test_span_observer.binary_annotations[0]
-        self.assertEquals(annotation["key"], "test-key")
+        self.assertEquals(annotation["key"], "counter.test-key")
         self.assertEquals(annotation["value"], "8.0")
 
 

--- a/tests/unit/observers/tracing_tests.py
+++ b/tests/unit/observers/tracing_tests.py
@@ -226,6 +226,16 @@ class TraceSpanObserverTests(TraceTestBase):
         span_obj = self.test_span_observer._to_span_obj([], [])
         self.assertEqual(span_obj["parentId"], 0)
 
+    def test_incr_tag_adds_binary_annotation(self):
+        self.test_span_observer.binary_annotations = []
+        self.test_span_observer.on_start()
+        self.test_span_observer.on_incr_tag("test-key", 3)
+        self.test_span_observer.on_incr_tag("test-key", 5)
+        self.test_span_observer.on_finish(None)
+        annotation = self.test_span_observer.binary_annotations[0]
+        self.assertEquals(annotation["key"], "test-key")
+        self.assertEquals(annotation["value"], "8.0")
+
 
 class TraceServerSpanObserverTests(TraceTestBase):
     def setUp(self):


### PR DESCRIPTION
This is a generic interface on spans that allows you to "increment" a tag. The tracing observer just coalesces these into a final tag, while the metrics observer can now listen into these and send counters as well. The idea is that applications can use this interface and not tie themselves to a specific metrics implementation.

This makes it so that an application doing

```python
context.trace.incr_tag("foo")
```

is equivalent to

```python
context.trace.set_tag("counter.foo", "1")
context.metrics.counter("foo").increment()
```

but without the application ever having to know which observers are configured which gives us more flexibility to change observers in the future and keeps application code simpler.

Fixes #305 