### PR TITLE
Set socket options in server individually

### DIFF
--- a/baseplate/server/__init__.py
+++ b/baseplate/server/__init__.py
@@ -142,14 +142,14 @@ def make_listener(endpoint: EndpointConfiguration) -> socket.socket:
     flags = fcntl.fcntl(sock.fileno(), fcntl.F_GETFD)
     fcntl.fcntl(sock.fileno(), fcntl.F_SETFD, flags | fcntl.FD_CLOEXEC)
 
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+
     # on linux, SO_REUSEPORT is supported for IPv4 and IPv6 but not other
     # families. we prefer it when available because it more evenly spreads load
     # among multiple processes sharing a port. (though it does have some
     # downsides, specifically regarding behaviour during restarts)
-    socket_options = socket.SO_REUSEADDR
     if endpoint.family in (socket.AF_INET, socket.AF_INET6):
-        socket_options |= socket.SO_REUSEPORT
-    sock.setsockopt(socket.SOL_SOCKET, socket_options, 1)
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
 
     sock.bind(endpoint.address)
     sock.listen(128)


### PR DESCRIPTION
On macOS it appears that ORing together SO_REUSEADDR and SO_REUSEPORT
and flagging them on together isn't allowed. Doing them individually
like this _is_ allowed and works on both macOS and Linux so we'll just
do that.

Getting basic Mac support is nice for the tutorial and quick development. It's not our general target through.

Fixes #346.