### PR TITLE
Default to 10 second wait for graceful server shutdown

### DIFF
--- a/baseplate/server/thrift.py
+++ b/baseplate/server/thrift.py
@@ -59,7 +59,7 @@ def make_server(server_config: Dict[str, str], listener: socket.socket, app: Any
         server_config,
         {
             "max_concurrency": config.Integer,
-            "stop_timeout": config.Optional(config.Integer, default=0),
+            "stop_timeout": config.Optional(config.Integer, default=10),
         },
     )
 

--- a/baseplate/server/wsgi.py
+++ b/baseplate/server/wsgi.py
@@ -1,3 +1,4 @@
+import datetime
 import logging
 import socket
 
@@ -25,7 +26,9 @@ def make_server(server_config: Dict[str, str], listener: socket.socket, app: Any
         {
             "handler": config.Optional(config.String, default=None),
             "max_concurrency": config.Integer,
-            "stop_timeout": config.Optional(config.Integer, default=10),
+            "stop_timeout": config.Optional(
+                config.TimespanWithLegacyFallback, default=datetime.timedelta(seconds=10)
+            ),
         },
     )
 
@@ -44,7 +47,7 @@ def make_server(server_config: Dict[str, str], listener: socket.socket, app: Any
         error_log=LoggingLogAdapter(logger, level=logging.ERROR),
         **kwargs,
     )
-    server.stop_timeout = cfg.stop_timeout
+    server.stop_timeout = cfg.stop_timeout.total_seconds()
 
     runtime_monitor.start(server_config, app, pool)
     return server

--- a/baseplate/server/wsgi.py
+++ b/baseplate/server/wsgi.py
@@ -25,7 +25,7 @@ def make_server(server_config: Dict[str, str], listener: socket.socket, app: Any
         {
             "handler": config.Optional(config.String, default=None),
             "max_concurrency": config.Integer,
-            "stop_timeout": config.Optional(config.Integer, default=0),
+            "stop_timeout": config.Optional(config.Integer, default=10),
         },
     )
 


### PR DESCRIPTION
The default was previously 0. I thought that meant wait forever, but
instead it meant die immediately. After fixing graceful shutdown, this
meant we'd still be hard-killing in flight requests but now we'd also be
getting the GreenletExit errors from it. This default of 10 seconds is
meant to give some time for long-running requests while not holding up
shutdown too long.