### PR TITLE
Allow backoff value to be set for filewatchers

### DIFF
--- a/baseplate/lib/experiments/__init__.py
+++ b/baseplate/lib/experiments/__init__.py
@@ -15,7 +15,6 @@ from baseplate.lib.events import DebugLogger
 from baseplate.lib.events import EventLogger
 from baseplate.lib.experiments.providers import parse_experiment
 from baseplate.lib.experiments.providers.base import Experiment
-from baseplate.lib.file_watcher import DEFAULT_FILEWATCHER_BACKOFF
 from baseplate.lib.file_watcher import FileWatcher
 from baseplate.lib.file_watcher import WatchedFileNotAvailableError
 
@@ -49,7 +48,7 @@ class ExperimentsContextFactory(ContextFactory):
         path: str,
         event_logger: Optional[EventLogger] = None,
         timeout: Optional[float] = None,
-        backoff: Optional[float] = DEFAULT_FILEWATCHER_BACKOFF,
+        backoff: Optional[float] = None,
     ):
         self._filewatcher = FileWatcher(path, json.load, timeout=timeout, backoff=backoff)
         self._event_logger = event_logger
@@ -310,6 +309,6 @@ def experiments_client_from_config(
     if options.backoff:
         backoff = options.backoff.total_seconds()
     else:
-        backoff = DEFAULT_FILEWATCHER_BACKOFF
+        backoff = None
 
     return ExperimentsContextFactory(options.path, event_logger, timeout=timeout, backoff=backoff)

--- a/baseplate/lib/experiments/__init__.py
+++ b/baseplate/lib/experiments/__init__.py
@@ -283,7 +283,7 @@ def experiments_client_from_config(
         settings for the experiments client.
     :param event_logger: The EventLogger to be used to log bucketing events.
     :param prefix: the prefix used to filter keys (defaults to "experiments.").
-    :param backoff: retry backoff time for experiments file watcher. Defaults to 
+    :param backoff: retry backoff time for experiments file watcher. Defaults to
         None, which is mapped to DEFAULT_FILEWATCHER_BACKOFF.
 
     """

--- a/baseplate/lib/experiments/__init__.py
+++ b/baseplate/lib/experiments/__init__.py
@@ -41,6 +41,8 @@ class ExperimentsContextFactory(ContextFactory):
     :param timeout: How long, in seconds, to block instantiation waiting
         for the watched experiments file to become available (defaults to not
         blocking).
+    :param backoff: retry backoff time for experiments file watcher. Defaults to
+        None, which is mapped to DEFAULT_FILEWATCHER_BACKOFF.
     """
 
     def __init__(

--- a/baseplate/lib/experiments/__init__.py
+++ b/baseplate/lib/experiments/__init__.py
@@ -283,6 +283,8 @@ def experiments_client_from_config(
         settings for the experiments client.
     :param event_logger: The EventLogger to be used to log bucketing events.
     :param prefix: the prefix used to filter keys (defaults to "experiments.").
+    :param backoff: retry backoff time for experiments file watcher. Defaults to 
+        None, which is mapped to DEFAULT_FILEWATCHER_BACKOFF.
 
     """
     assert prefix.endswith(".")

--- a/baseplate/lib/file_watcher.py
+++ b/baseplate/lib/file_watcher.py
@@ -91,6 +91,8 @@ class FileWatcher(Generic[T]):
     :param newline: Controls how universal newlines mode works
         (it only applies to text mode). It can be `None`, `""`, `"\\n"`, `"\\r"`,
         and `"\\r\\n"`.  This is not supported if `binary` is set to `True`.
+    :param backoff: retry backoff time for the file watcher. Defaults to 
+        None, which is mapped to DEFAULT_FILEWATCHER_BACKOFF.
 
     """
 

--- a/baseplate/lib/file_watcher.py
+++ b/baseplate/lib/file_watcher.py
@@ -47,6 +47,8 @@ from baseplate.lib.retry import RetryPolicy
 
 logger = logging.getLogger(__name__)
 
+DEFAULT_FILEWATCHER_BACKOFF = 0.01
+
 
 class _NOT_LOADED:
     pass
@@ -100,6 +102,7 @@ class FileWatcher(Generic[T]):
         binary: bool = False,
         encoding: Optional[str] = None,
         newline: Optional[str] = None,
+        backoff: Optional[float] = DEFAULT_FILEWATCHER_BACKOFF,
     ):
         if binary and encoding is not None:
             raise TypeError("'encoding' is not supported in binary mode.")
@@ -117,7 +120,7 @@ class FileWatcher(Generic[T]):
 
         if timeout is not None:
             last_error = None
-            for _ in RetryPolicy.new(budget=timeout, backoff=0.01):
+            for _ in RetryPolicy.new(budget=timeout, backoff=backoff):
                 if self._data is not _NOT_LOADED:
                     break
 

--- a/baseplate/lib/file_watcher.py
+++ b/baseplate/lib/file_watcher.py
@@ -91,7 +91,7 @@ class FileWatcher(Generic[T]):
     :param newline: Controls how universal newlines mode works
         (it only applies to text mode). It can be `None`, `""`, `"\\n"`, `"\\r"`,
         and `"\\r\\n"`.  This is not supported if `binary` is set to `True`.
-    :param backoff: retry backoff time for the file watcher. Defaults to 
+    :param backoff: retry backoff time for the file watcher. Defaults to
         None, which is mapped to DEFAULT_FILEWATCHER_BACKOFF.
 
     """

--- a/baseplate/lib/file_watcher.py
+++ b/baseplate/lib/file_watcher.py
@@ -102,7 +102,7 @@ class FileWatcher(Generic[T]):
         binary: bool = False,
         encoding: Optional[str] = None,
         newline: Optional[str] = None,
-        backoff: Optional[float] = DEFAULT_FILEWATCHER_BACKOFF,
+        backoff: Optional[float] = None,
     ):
         if binary and encoding is not None:
             raise TypeError("'encoding' is not supported in binary mode.")
@@ -117,6 +117,8 @@ class FileWatcher(Generic[T]):
         self._open_options = _OpenOptions(
             mode="rb" if binary else "r", encoding=encoding, newline=newline
         )
+
+        backoff = backoff or DEFAULT_FILEWATCHER_BACKOFF
 
         if timeout is not None:
             last_error = None

--- a/baseplate/lib/secrets.py
+++ b/baseplate/lib/secrets.py
@@ -326,6 +326,8 @@ def secrets_store_from_config(
         for the secrets data to become available (defaults to not blocking).
     :param prefix: Specifies the prefix used to filter keys. Defaults
         to "secrets."
+    :param backoff: retry backoff time for secrets file watcher. Defaults to
+        None, which is mapped to DEFAULT_FILEWATCHER_BACKOFF.
 
     """
     assert prefix.endswith(".")

--- a/baseplate/lib/secrets.py
+++ b/baseplate/lib/secrets.py
@@ -14,7 +14,6 @@ from baseplate import Span
 from baseplate.clients import ContextFactory
 from baseplate.lib import cached_property
 from baseplate.lib import config
-from baseplate.lib.file_watcher import DEFAULT_FILEWATCHER_BACKOFF
 from baseplate.lib.file_watcher import FileWatcher
 from baseplate.lib.file_watcher import WatchedFileNotAvailableError
 
@@ -128,12 +127,7 @@ class SecretsStore(ContextFactory):
 
     """
 
-    def __init__(
-        self,
-        path: str,
-        timeout: Optional[int] = None,
-        backoff: Optional[float] = DEFAULT_FILEWATCHER_BACKOFF,
-    ):
+    def __init__(self, path: str, timeout: Optional[int] = None, backoff: Optional[float] = None):
         self._filewatcher = FileWatcher(path, json.load, timeout=timeout, backoff=backoff)
 
     def _get_data(self) -> Any:
@@ -351,7 +345,7 @@ def secrets_store_from_config(
     if options.backoff:
         backoff = options.backoff.total_seconds()
     else:
-        backoff = DEFAULT_FILEWATCHER_BACKOFF
+        backoff = None
 
     # pylint: disable=maybe-no-member
     return SecretsStore(options.path, timeout=timeout, backoff=backoff)

--- a/tests/unit/lib/experiments/experiment_tests.py
+++ b/tests/unit/lib/experiments/experiment_tests.py
@@ -13,7 +13,6 @@ from baseplate.lib.experiments import EventType
 from baseplate.lib.experiments import Experiments
 from baseplate.lib.experiments import experiments_client_from_config
 from baseplate.lib.experiments import ExperimentsContextFactory
-from baseplate.lib.file_watcher import DEFAULT_FILEWATCHER_BACKOFF
 from baseplate.lib.file_watcher import FileWatcher
 from baseplate.lib.file_watcher import WatchedFileNotAvailableError
 
@@ -527,7 +526,7 @@ class ExperimentsClientFromConfigTests(unittest.TestCase):
         )
         self.assertIsInstance(experiments, ExperimentsContextFactory)
         file_watcher_mock.assert_called_once_with(
-            "/tmp/test", json.load, timeout=None, backoff=DEFAULT_FILEWATCHER_BACKOFF
+            "/tmp/test", json.load, timeout=None, backoff=None
         )
 
     def test_timeout(self, file_watcher_mock):
@@ -537,7 +536,7 @@ class ExperimentsClientFromConfigTests(unittest.TestCase):
         )
         self.assertIsInstance(experiments, ExperimentsContextFactory)
         file_watcher_mock.assert_called_once_with(
-            "/tmp/test", json.load, timeout=60.0, backoff=DEFAULT_FILEWATCHER_BACKOFF
+            "/tmp/test", json.load, timeout=60.0, backoff=None
         )
 
     def test_prefix(self, file_watcher_mock):
@@ -549,5 +548,5 @@ class ExperimentsClientFromConfigTests(unittest.TestCase):
         )
         self.assertIsInstance(experiments, ExperimentsContextFactory)
         file_watcher_mock.assert_called_once_with(
-            "/tmp/test", json.load, timeout=60.0, backoff=DEFAULT_FILEWATCHER_BACKOFF
+            "/tmp/test", json.load, timeout=60.0, backoff=None
         )

--- a/tests/unit/lib/experiments/experiment_tests.py
+++ b/tests/unit/lib/experiments/experiment_tests.py
@@ -13,6 +13,7 @@ from baseplate.lib.experiments import EventType
 from baseplate.lib.experiments import Experiments
 from baseplate.lib.experiments import experiments_client_from_config
 from baseplate.lib.experiments import ExperimentsContextFactory
+from baseplate.lib.file_watcher import DEFAULT_FILEWATCHER_BACKOFF
 from baseplate.lib.file_watcher import FileWatcher
 from baseplate.lib.file_watcher import WatchedFileNotAvailableError
 
@@ -525,7 +526,9 @@ class ExperimentsClientFromConfigTests(unittest.TestCase):
             {"experiments.path": "/tmp/test"}, event_logger
         )
         self.assertIsInstance(experiments, ExperimentsContextFactory)
-        file_watcher_mock.assert_called_once_with("/tmp/test", json.load, timeout=None)
+        file_watcher_mock.assert_called_once_with(
+            "/tmp/test", json.load, timeout=None, backoff=DEFAULT_FILEWATCHER_BACKOFF
+        )
 
     def test_timeout(self, file_watcher_mock):
         event_logger = mock.Mock(spec=DebugLogger)
@@ -533,7 +536,9 @@ class ExperimentsClientFromConfigTests(unittest.TestCase):
             {"experiments.path": "/tmp/test", "experiments.timeout": "60 seconds"}, event_logger
         )
         self.assertIsInstance(experiments, ExperimentsContextFactory)
-        file_watcher_mock.assert_called_once_with("/tmp/test", json.load, timeout=60.0)
+        file_watcher_mock.assert_called_once_with(
+            "/tmp/test", json.load, timeout=60.0, backoff=DEFAULT_FILEWATCHER_BACKOFF
+        )
 
     def test_prefix(self, file_watcher_mock):
         event_logger = mock.Mock(spec=DebugLogger)
@@ -543,4 +548,6 @@ class ExperimentsClientFromConfigTests(unittest.TestCase):
             prefix="r2_experiments.",
         )
         self.assertIsInstance(experiments, ExperimentsContextFactory)
-        file_watcher_mock.assert_called_once_with("/tmp/test", json.load, timeout=60.0)
+        file_watcher_mock.assert_called_once_with(
+            "/tmp/test", json.load, timeout=60.0, backoff=DEFAULT_FILEWATCHER_BACKOFF
+        )


### PR DESCRIPTION
Reduce spam in graphql logs caused by excessive retries from secrets and experiments filewatchers.
