### PR TITLE
Return List[bytes] in the queue_consumer healthchecker

### DIFF
--- a/baseplate/server/queue_consumer.py
+++ b/baseplate/server/queue_consumer.py
@@ -43,9 +43,9 @@ def make_simple_healthchecker(
 
         if ok:
             start_response("200 OK", [("Content-Type", "text/plain")])
-            return ["all good, boss"]
+            return [b"all good, boss"]
         start_response("503 UNAVAILABLE", [("Content-Type", "text/plain")])
-        return ["he's dead jim"]
+        return [b"he's dead jim"]
 
     return WSGIServer(listener=listener, application=healthcheck)
 

--- a/baseplate/server/queue_consumer.py
+++ b/baseplate/server/queue_consumer.py
@@ -36,7 +36,7 @@ HealthcheckCallback = Callable[[WSGIEnvironment], bool]
 def make_simple_healthchecker(
     listener: socket.socket, callback: Optional[HealthcheckCallback] = None
 ) -> WSGIServer:
-    def healthcheck(environ: WSGIEnvironment, start_response: "StartResponse") -> List[str]:
+    def healthcheck(environ: WSGIEnvironment, start_response: "StartResponse") -> List[bytes]:
         ok = True
         if callback:
             ok = callback(environ)


### PR DESCRIPTION
Note, this didn't actually cause the healthchecker to fail, just spam your logs with errors, since the actual request still returns a 200:

```
vagrant@reddit:~/src/super-secret-reddit-service (super-secret-reddit-service)$ curl -v localhost:9400/health
*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 9400 (#0)
> GET /health HTTP/1.1
> Host: localhost:9400
> User-Agent: curl/7.58.0
> Accept: */*
> 
< HTTP/1.1 200 OK
< Content-Type: text/plain
< Date: Mon, 28 Oct 2019 22:46:58 GMT
< Content-Length: 14
< 
* transfer closed with 14 bytes remaining to read
* stopped the pause stream!
* Closing connection 0
curl: (18) transfer closed with 14 bytes remaining to read
```