### PR TITLE
support pool_recycle in engine_from_config

### DIFF
--- a/baseplate/clients/sqlalchemy.py
+++ b/baseplate/clients/sqlalchemy.py
@@ -45,11 +45,17 @@ def engine_from_config(
         credentials from ``secrets`` as a :py:class:`~baseplate.lib.secrets.CredentialSecret`.
         If this is supplied, any credentials given in ``url`` we be replaced by
         these.
+    * ``pool_recycle`` (optional): this setting causes the pool to recycle connections after
+        the given number of seconds has passed. It defaults to -1, or no timeout.
 
     """
     assert prefix.endswith(".")
     parser = config.SpecParser(
-        {"url": config.String, "credentials_secret": config.Optional(config.String)}
+        {
+            "url": config.String,
+            "credentials_secret": config.Optional(config.String),
+            "pool_recycle": config.Optional(config.String),
+        }
     )
     options = parser.parse(prefix[:-1], app_config)
     url = make_url(options.url)
@@ -61,7 +67,10 @@ def engine_from_config(
         url.username = credentials.username
         url.password = credentials.password
 
-    return create_engine(url, **kwargs)
+    if options.pool_recycle:
+        return create_engine(url, pool_recycle=int(options.pool_recycle), **kwargs)
+    else:
+        return create_engine(url, **kwargs)
 
 
 class SQLAlchemySession(config.Parser):

--- a/baseplate/clients/sqlalchemy.py
+++ b/baseplate/clients/sqlalchemy.py
@@ -60,7 +60,7 @@ def engine_from_config(
     options = parser.parse(prefix[:-1], app_config)
     url = make_url(options.url)
 
-    if options.pool_recycle:
+    if options.pool_recycle is not None:
         kwargs.setdefault("pool_recycle", options.pool_recycle)
 
     if options.credentials_secret:

--- a/baseplate/clients/sqlalchemy.py
+++ b/baseplate/clients/sqlalchemy.py
@@ -54,7 +54,7 @@ def engine_from_config(
         {
             "url": config.String,
             "credentials_secret": config.Optional(config.String),
-            "pool_recycle": config.Optional(config.String),
+            "pool_recycle": config.Optional(config.Integer),
         }
     )
     options = parser.parse(prefix[:-1], app_config)

--- a/baseplate/clients/sqlalchemy.py
+++ b/baseplate/clients/sqlalchemy.py
@@ -60,6 +60,9 @@ def engine_from_config(
     options = parser.parse(prefix[:-1], app_config)
     url = make_url(options.url)
 
+    if options.pool_recycle:
+        kwargs.setdefault("pool_recycle", options.pool_recycle)
+
     if options.credentials_secret:
         if not secrets:
             raise TypeError("'secrets' is required if 'credentials_secret' is set")
@@ -67,10 +70,7 @@ def engine_from_config(
         url.username = credentials.username
         url.password = credentials.password
 
-    if options.pool_recycle:
-        return create_engine(url, pool_recycle=int(options.pool_recycle), **kwargs)
-    else:
-        return create_engine(url, **kwargs)
+    return create_engine(url, **kwargs)
 
 
 class SQLAlchemySession(config.Parser):

--- a/tests/unit/clients/sqlalchemy_tests.py
+++ b/tests/unit/clients/sqlalchemy_tests.py
@@ -39,7 +39,7 @@ class EngineFromConfigTests(unittest.TestCase):
             {
                 "database.url": "postgresql://fizz:buzz@localhost:9000/db",
                 "database.credentials_secret": "secret/sql/account",
-                "database.pool_recycle": 60,
+                "database.pool_recycle": "60",
             },
             self.secrets,
         )

--- a/tests/unit/clients/sqlalchemy_tests.py
+++ b/tests/unit/clients/sqlalchemy_tests.py
@@ -39,6 +39,7 @@ class EngineFromConfigTests(unittest.TestCase):
             {
                 "database.url": "postgresql://fizz:buzz@localhost:9000/db",
                 "database.credentials_secret": "secret/sql/account",
+                "database.pool_recycle": 60,
             },
             self.secrets,
         )
@@ -50,7 +51,8 @@ class EngineFromConfigTests(unittest.TestCase):
                 host="localhost",
                 port="9000",
                 database="db",
-            )
+            ),
+            pool_recycle=60,
         )
 
     @mock.patch("baseplate.clients.sqlalchemy.create_engine")


### PR DESCRIPTION
As part of thing->k8s migration, we noticed that baseplate does not support pool_recycle while creating the db engine.

Added the support for pool_recycle in https://github.snooguts.net/reddit/reddit-service-thing/commit/cc0bbdea642023f5dfc3c6798974596ab5f72f88

We wanted to push the changes to baseplate as well so other services that use pool_recycle do not run into a similar issue when moving to k8s.

👓 @bsimpson63 @spladug 