### PR TITLE
queue_consumer: Add Kafka implementation

### DIFF
--- a/baseplate/frameworks/queue_consumer/kafka.py
+++ b/baseplate/frameworks/queue_consumer/kafka.py
@@ -1,0 +1,505 @@
+import json
+import logging
+import queue
+import socket
+import time
+
+from typing import Any
+from typing import Callable
+from typing import Dict
+from typing import List
+from typing import Optional
+from typing import Sequence
+from typing import TYPE_CHECKING
+
+import confluent_kafka
+
+from gevent.server import StreamServer
+
+from baseplate import Baseplate
+from baseplate import RequestContext
+from baseplate.server.queue_consumer import HealthcheckCallback
+from baseplate.server.queue_consumer import make_simple_healthchecker
+from baseplate.server.queue_consumer import MessageHandler
+from baseplate.server.queue_consumer import PumpWorker
+from baseplate.server.queue_consumer import QueueConsumerFactory
+
+
+if TYPE_CHECKING:
+    WorkQueue = queue.Queue[confluent_kafka.Message]  # pylint: disable=unsubscriptable-object
+else:
+    WorkQueue = queue.Queue
+
+
+logger = logging.getLogger(__name__)
+
+
+KafkaMessageDeserializer = Callable[[bytes], Any]
+Handler = Callable[[RequestContext, Any, confluent_kafka.Message], None]
+
+
+class KafkaConsumerWorker(PumpWorker):
+    """Reads messages from the Kafka consumer and pumps them into the internal work_queue."""
+
+    def __init__(
+        self,
+        baseplate: Baseplate,
+        name: str,
+        consumer: confluent_kafka.Consumer,
+        work_queue: WorkQueue,
+        batch_size: int = 1,
+    ):
+        self.baseplate = baseplate
+        self.name = name
+        self.consumer = consumer
+        self.work_queue = work_queue
+        self.batch_size = batch_size
+
+        self.started = False
+        self.stopped = False
+
+    def run(self) -> None:
+        logger.debug("Starting KafkaConsumerWorker.")
+        self.started = True
+        while not self.stopped:
+            context = self.baseplate.make_context_object()
+            with self.baseplate.make_server_span(context, f"{self.name}.pump") as span:
+                with span.make_child("kafka.consume"):
+                    messages = self.consumer.consume(num_messages=self.batch_size, timeout=0)
+
+                if not messages:
+                    logger.debug("waited 1s and received no messages, waiting again")
+                    # we can't use timeouts on the kafka consumer methods
+                    # because they call out to C code that ends up blocking
+                    # the event loop. gevent will successfully yield control
+                    # on this sleep call though.
+                    # see https://tech.wayfair.com/2018/07/blocking-io-in-gunicorn-gevent-workers/
+                    time.sleep(1)
+                    continue
+
+                with span.make_child("kafka.work_queue_put"):
+                    for message in messages:
+                        self.work_queue.put(message)
+
+    def stop(self) -> None:
+        # stop consuming, but leave the consumer instance intact. if we
+        # close the consumer before the message handler is done it won't be able
+        # to commit offsets
+        logger.debug("Stopping KafkaConsumerWorker.")
+        self.stopped = True
+
+
+class KafkaMessageHandler(MessageHandler):
+    """Reads messages from the internal work_queue and processes them."""
+
+    def __init__(
+        self,
+        baseplate: Baseplate,
+        name: str,
+        handler_fn: Handler,
+        message_unpack_fn: KafkaMessageDeserializer,
+        on_success_fn: Optional[Handler] = None,
+    ):
+        self.baseplate = baseplate
+        self.name = name
+        self.handler_fn = handler_fn
+        self.message_unpack_fn = message_unpack_fn
+        self.on_success_fn = on_success_fn
+
+    def handle(self, message: confluent_kafka.Message) -> None:
+        context = self.baseplate.make_context_object()
+        try:
+            # We place the call to ``baseplate.make_server_span`` inside the
+            # try/except block because we still want Baseplate to see and
+            # handle the error (publish it to error reporting)
+            with self.baseplate.make_server_span(context, f"{self.name}.handler") as span:
+                error = message.error()
+                if error:
+                    # this isn't a real message, but is an error from Kafka
+                    raise ValueError(f"KafkaError: {error.str()}")
+
+                topic = message.topic()
+                offset = message.offset()
+                partition = message.partition()
+
+                span.set_tag("kind", "consumer")
+                span.set_tag("kafka.topic", topic)
+                span.set_tag("kafka.key", message.key())
+                span.set_tag("kafka.partition", partition)
+                span.set_tag("kafka.offset", offset)
+                span.set_tag("kafka.timestamp", message.timestamp())
+
+                blob: bytes = message.value()
+
+                try:
+                    data = self.message_unpack_fn(blob)
+                except Exception:
+                    logger.error("skipping invalid message")
+                    context.trace.incr_tag(f"{self.name}.{topic}.invalid_message")
+                    return
+
+                try:
+                    ingest_timestamp_ms = data["endpoint_timestamp"]
+                    now_ms = int(time.time() * 1000)
+                    message_latency = (now_ms - ingest_timestamp_ms) / 1000
+                except KeyError:
+                    # we can't guarantee that all publishers populate this field
+                    # v2 events publishers (event collectors) do, but future
+                    # kafka publishers may not
+                    message_latency = None
+
+                self.handler_fn(context, data, message)
+
+                if self.on_success_fn:
+                    self.on_success_fn(context, data, message)
+
+                if message_latency is not None:
+                    context.metrics.timer(f"{self.name}.{topic}.latency").send(message_latency)
+
+                context.metrics.gauge(f"{self.name}.{topic}.offset.{partition}").replace(offset)
+        except Exception:
+            # let this exception crash the server so we'll stop processing messages
+            # and won't commit offsets. when the server restarts it will get
+            # this message again and try to process it.
+            logger.exception(
+                "Unhandled error while trying to process a message, terminating the server"
+            )
+            raise
+
+
+class _BaseKafkaQueueConsumerFactory(QueueConsumerFactory):
+    def __init__(
+        self,
+        name: str,
+        baseplate: Baseplate,
+        consumer: confluent_kafka.Consumer,
+        handler_fn: Handler,
+        kafka_consume_batch_size: int = 1,
+        message_unpack_fn: KafkaMessageDeserializer = json.loads,
+        health_check_fn: Optional[HealthcheckCallback] = None,
+    ):
+        """`_BaseKafkaQueueConsumerFactory` constructor.
+
+        :param name: A name for your consumer process. Must look like "kafka_consumer.{group_name}"
+        :param baseplate: The Baseplate set up for your consumer.
+        :param consumer: An instance of :py:class:`~confluent_kafka.Consumer`.
+        :param handler_fn: A `baseplate.frameworks.queue_consumer.kafka.Handler`
+            function that will process an individual message.
+        :param kafka_consume_batch_size: The number of messages the `KafkaConsumerWorker`
+            reads from Kafka in each batch. Defaults to 1.
+        :param message_unpack_fn: A function that takes one argument, the `bytes` message body
+            and returns the message in the format the handler expects. Defaults to `json.loads`.
+        :param health_check_fn: A `baseplate.server.queue_consumer.HealthcheckCallback`
+            function that can be used to customize your health check.
+
+        """
+
+        self.name = name
+        self.baseplate = baseplate
+        self.consumer = consumer
+        self.handler_fn = handler_fn
+        self.kafka_consume_batch_size = kafka_consume_batch_size
+        self.message_unpack_fn = message_unpack_fn
+        self.health_check_fn = health_check_fn
+
+    @classmethod
+    def new(
+        cls,
+        name: str,
+        baseplate: Baseplate,
+        bootstrap_servers: str,
+        group_id: str,
+        topics: Sequence[str],
+        handler_fn: Handler,
+        kafka_consume_batch_size: int = 1,
+        message_unpack_fn: KafkaMessageDeserializer = json.loads,
+        health_check_fn: Optional[HealthcheckCallback] = None,
+    ) -> "_BaseKafkaQueueConsumerFactory":
+        """Return a new `_BaseKafkaQueueConsumerFactory`.
+
+        This method will create the :py:class:`~confluent_kafka.Consumer` for you and is
+        appropriate to use in most cases where you just need a basic consumer
+        with sensible defaults.
+
+        This method will also enforce naming standards for the Kafka consumer group
+        and the baseplate server span.
+
+        :param name: A name for your consumer process. Must look like "kafka_consumer.{group_name}"
+        :param baseplate: The Baseplate set up for your consumer.
+        :param bootstrap_servers: A comma delimited string of kafka brokers.
+        :param group_id: The kafka consumer group id. Must look like "{service_name}.{group_name}"
+            to help prevent collisions between services.
+        :param topics: An iterable of kafka topics to consume from.
+        :param handler_fn: A `baseplate.frameworks.queue_consumer.kafka.Handler`
+            function that will process an individual message.
+        :param kafka_consume_batch_size: The number of messages the `KafkaConsumerWorker`
+            reads from Kafka in each batch. Defaults to 1.
+        :param message_unpack_fn: A function that takes one argument, the `bytes` message body
+            and returns the message in the format the handler expects. Defaults to `json.loads`.
+        :param health_check_fn: A `baseplate.server.queue_consumer.HealthcheckCallback`
+            function that can be used to customize your health check.
+
+        """
+
+        service_name, _, group_name = group_id.partition(".")
+        assert service_name and group_name, "group_id must start with 'SERVICENAME.'"
+        assert name == f"kafka_consumer.{group_name}"
+
+        consumer = cls.make_kafka_consumer(bootstrap_servers, group_id, topics)
+
+        return cls(
+            name=name,
+            baseplate=baseplate,
+            consumer=consumer,
+            handler_fn=handler_fn,
+            kafka_consume_batch_size=kafka_consume_batch_size,
+            message_unpack_fn=message_unpack_fn,
+            health_check_fn=health_check_fn,
+        )
+
+    @classmethod
+    def _consumer_config(cls) -> Dict[str, Any]:
+        raise NotImplementedError
+
+    @classmethod
+    def make_kafka_consumer(
+        cls, bootstrap_servers: str, group_id: str, topics: Sequence[str]
+    ) -> confluent_kafka.Consumer:
+        consumer_config = {
+            "bootstrap.servers": bootstrap_servers,
+            "group.id": group_id,
+            # reset the offset to the latest offset when no stored offset exists.
+            # this means that when a new consumer group is created it will only
+            # process new messages.
+            "auto.offset.reset": "latest",
+        }
+        consumer_config.update(cls._consumer_config())
+        consumer = confluent_kafka.Consumer(consumer_config)
+
+        try:
+            # we can allow a blocking timeout here because there is only one
+            # consumer for the entire server
+            metadata = consumer.list_topics(timeout=10)
+        except confluent_kafka.KafkaException:
+            logger.error("failed getting metadata from %s, exiting.", bootstrap_servers)
+            raise
+
+        all_topics = set(metadata.topics.keys())
+        for topic in topics:
+            assert (
+                topic in all_topics
+            ), f"topic '{topic}' does not exist. maybe it's misspelled or on a different kafka cluster?"
+
+        # pylint: disable=unused-argument
+        def log_assign(
+            consumer: confluent_kafka.Consumer, partitions: List[confluent_kafka.TopicPartition]
+        ) -> None:
+            for topic_partition in partitions:
+                logger.info("assigned %s/%s", topic_partition.topic, topic_partition.partition)
+
+        # pylint: disable=unused-argument
+        def log_revoke(
+            consumer: confluent_kafka.Consumer, partitions: List[confluent_kafka.TopicPartition]
+        ) -> None:
+            for topic_partition in partitions:
+                logger.info("revoked %s/%s", topic_partition.topic, topic_partition.partition)
+
+        consumer.subscribe(topics, on_assign=log_assign, on_revoke=log_revoke)
+        return consumer
+
+    def build_pump_worker(self, work_queue: WorkQueue) -> KafkaConsumerWorker:
+        return KafkaConsumerWorker(
+            baseplate=self.baseplate,
+            name=self.name,
+            consumer=self.consumer,
+            work_queue=work_queue,
+            batch_size=self.kafka_consume_batch_size,
+        )
+
+    def build_message_handler(self) -> KafkaMessageHandler:
+        return KafkaMessageHandler(
+            self.baseplate, self.name, self.handler_fn, self.message_unpack_fn
+        )
+
+    def build_health_checker(self, listener: socket.socket) -> StreamServer:
+        return make_simple_healthchecker(listener, callback=self.health_check_fn)
+
+
+class InOrderConsumerFactory(_BaseKafkaQueueConsumerFactory):
+    """Factory for running a :py:class:`~baseplate.server.queue_consumer.QueueConsumerServer` using Kafka.
+
+    The `InOrderConsumerFactory` attempts to achieve in order, exactly once
+    message processing.
+
+    This will run a single `KafkaConsumerWorker` that reads messages from Kafka and
+    puts them into an internal work queue. Then it will run a single `KafkaMessageHandler`
+    that reads messages from the internal work queue, processes them with the
+    `handler_fn`, and then commits each message's offset to Kafka.
+
+    This one-at-a-time, in-order processing ensures that when a failure happens
+    during processing we don't commit its offset (or the offset of any later
+    messages) and that when the server restarts it will receive the failed
+    message and attempt to process it again. Additionally, because each
+    message's offset is committed immediately after processing we should
+    never process a message more than once.
+
+    For most cases where you just need a basic consumer with sensible defaults
+    you can use `InOrderConsumerFactory.new`.
+
+    If you need more control, you can create the :py:class:`~confluent_kafka.Consumer`
+    yourself and use the constructor directly.
+
+    """
+
+    # we need to ensure that only a single message handler worker exists (max_concurrency = 1)
+    # otherwise we could have out of order processing and mess up committing offsets to kafka!
+    message_handler_count = 0
+
+    @classmethod
+    def _consumer_config(cls) -> Dict[str, Any]:
+        return {
+            # The consumer sends periodic heartbeats on a separate thread to
+            # indicate its liveness to the broker. If no heartbeats are received by
+            # the broker for a group member within the session timeout (because the
+            # consumer and heartbeat thread have died), the broker
+            # will remove the consumer from the group and trigger a rebalance.
+            "heartbeat.interval.ms": 3000,
+            "session.timeout.ms": 10000,
+            # Maximum allowed time between calls to consume messages. If this
+            # interval is exceeded the consumer is considered failed and the group
+            # will rebalance in order to reassign the partitions to another consumer
+            # group member.
+            # Note: It is recommended to set enable.auto.offset.store=false for
+            # long-time processing applications and then explicitly store offsets
+            # after message processing, to make sure offsets are not auto-committed
+            # prior to processing has finished.
+            "max.poll.interval.ms": 300000,
+            # disable offset autocommit, we'll manually commit.
+            "enable.auto.commit": "false",
+        }
+
+    def build_message_handler(self) -> KafkaMessageHandler:
+        assert self.message_handler_count == 0, "Can only run 1 message handler!"
+
+        self.message_handler_count += 1
+
+        # pylint: disable=unused-argument
+        def commit_offset(
+            context: RequestContext, data: Any, message: confluent_kafka.Message
+        ) -> None:
+            logger.debug(
+                "committing topic %s partition %s offset %s",
+                message.topic(),
+                message.partition(),
+                message.offset(),
+            )
+            with context.trace.make_child("kafka.commit"):
+                self.consumer.commit(message=message, asynchronous=False)
+
+        return KafkaMessageHandler(
+            self.baseplate,
+            self.name,
+            self.handler_fn,
+            self.message_unpack_fn,
+            # commit offset after each successful message handle()
+            on_success_fn=commit_offset,
+        )
+
+
+class FastConsumerFactory(_BaseKafkaQueueConsumerFactory):
+    """Factory for running a :py:class:`~baseplate.server.queue_consumer.QueueConsumerServer` using Kafka.
+
+    The `FastConsumerFactory` prioritizes high throughput over exactly once
+    message processing.
+
+    This will run a single `KafkaConsumerWorker` that reads messages from Kafka and
+    puts them into an internal work queue. Then it will run multiple `KafkaMessageHandler`s
+    that read messages from the internal work queue, processes them with the
+    `handler_fn`. The number of `KafkaMessageHandler` processes is controlled
+    by the `max_concurrency` parameter in the `~baseplate.server.queue_consumer.QueueConsumerServer`
+    configuration. Kafka partition offsets are automatically committed by the
+    `confluent_kafka.Consumer` every 5 seconds, so any message that has been
+    read by the `KafkaConsumerWorker` could be committed, regardless of whether
+    it has been processed.
+
+    This server should be able to achieve very high message processing throughput
+    due to the multiple `KafkaMessageHandler` processes and less frequent, background
+    partition offset commits. This does come at a price though: messages may be
+    processed out of order, not at all, or multiple times. This is appropriate
+    when processing throughput is important and it's acceptable to skip messages
+    or process messages more than once (maybe there is ratelimiting in the
+    handler or somewhere downstream).
+
+    Messages processed out of order:
+    Messages are added to the internal work queue in order, but one worker may
+    finish processing a "later" message before another worker finishes
+    processing an "earlier" message.
+
+    Messages never processed:
+    If the server crashes it may not have processed some messages that have already
+    had their offsets automatically committed. When the server restarts it won't
+    read those messages.
+
+    Messages processed more than once:
+    If the server crashes it may have processed some messages but not yet
+    committed their offsets. When the server restarts it will reprocess those
+    messages.
+
+    For most cases where you just need a basic consumer with sensible defaults
+    you can use `FastConsumerFactory.new`.
+
+    If you need more control, you can create the :py:class:`~confluent_kafka.Consumer`
+    yourself and use the constructor directly.
+
+    """
+
+    # pylint: disable=unused-argument
+    @staticmethod
+    def _commit_callback(
+        err: confluent_kafka.KafkaError, topic_partition_list: List[confluent_kafka.TopicPartition]
+    ) -> None:
+        # called after automatic commits
+        for topic_partition in topic_partition_list:
+            topic = topic_partition.topic
+            partition = topic_partition.partition
+            offset = topic_partition.offset
+
+            if topic_partition.error:
+                logger.error(
+                    "commit error topic %s partition %s offset %s", topic, partition, offset
+                )
+            elif offset == confluent_kafka.OFFSET_INVALID:
+                # we receive offsets for all partitions. an offset value of
+                # OFFSET_INVALID means that no offset was committed.
+                pass
+            else:
+                logger.debug(
+                    "commit success topic %s partition %s offset %s", topic, partition, offset
+                )
+
+    @classmethod
+    def _consumer_config(cls) -> Dict[str, Any]:
+        return {
+            # The consumer sends periodic heartbeats on a separate thread to
+            # indicate its liveness to the broker. If no heartbeats are received by
+            # the broker for a group member within the session timeout (because the
+            # consumer and heartbeat thread have died), the broker
+            # will remove the consumer from the group and trigger a rebalance.
+            "heartbeat.interval.ms": 3000,
+            "session.timeout.ms": 10000,
+            # Maximum allowed time between calls to consume messages. If this
+            # interval is exceeded the consumer is considered failed and the group
+            # will rebalance in order to reassign the partitions to another consumer
+            # group member.
+            # Note: It is recommended to set enable.auto.offset.store=false for
+            # long-time processing applications and then explicitly store offsets
+            # after message processing, to make sure offsets are not auto-committed
+            # prior to processing has finished.
+            "max.poll.interval.ms": 300000,
+            # autocommit offsets every 5 seconds
+            "enable.auto.commit": "true",
+            "auto.commit.interval.ms": 5000,
+            "enable.auto.offset.store": "true",
+            # register a commit callback so that we'll log commits
+            "on_commit": cls._commit_callback,
+        }

--- a/docs/api/baseplate/frameworks/queue_consumer/index.rst
+++ b/docs/api/baseplate/frameworks/queue_consumer/index.rst
@@ -6,5 +6,6 @@
 .. toctree::
    :titlesonly:
 
+   baseplate.frameworks.queue_consumer.kafka: Kafka Queue Consumer <kafka>
    baseplate.frameworks.queue_consumer.kombu: Kombu Queue Consumer <kombu>
    baseplate.frameworks.queue_consumer.deprecated: Deprecated Kombu Queue Consumer <deprecated>

--- a/docs/api/baseplate/frameworks/queue_consumer/kafka.rst
+++ b/docs/api/baseplate/frameworks/queue_consumer/kafka.rst
@@ -1,0 +1,53 @@
+``baseplate.frameworks.queue_consumer.kafka``
+=============================================
+
+This module provides a :py:class:`~baseplate.server.queue_consumer.QueueConsumerFactory`
+that allows you to run a :py:class:`~baseplate.server.queue_consumer.QueueConsumerServer`
+that integrates Baseplate's facilities with Kafka.
+
+An abbreviated example of it in use::
+
+    import confluent_kafka
+    from baseplate import RequestContext
+    from typing import Any
+    from typing import Dict
+
+    def process_links(
+        context: RequestContext,
+        data: Dict[str, Any],
+        message: confluent_kafka.Message,
+    ):
+        print(f"processing {data}")
+
+    def make_consumer_factory(app_config):
+        baseplate = Baseplate()
+        return InOrderConsumerFactory.new(
+            name="kafka_consumer.link_consumer_v0",
+            baseplate=baseplate,
+            bootstrap_servers="127.0.0.1:9092",
+            group_id="service.link_consumer",
+            topics=["new_links", "edited_links"],
+            handler_fn=process_links,
+        )
+
+
+This will create a Kafka consumer group named ``'service.link_consumer'`` that
+consumes from the topics ``'new_links'`` and ``'edited_links'``. Messages read
+from those topics will be fed to ``process_links``.
+
+.. automodule:: baseplate.frameworks.queue_consumer.kafka
+
+
+Factory
+-------
+
+.. autoclass:: InOrderConsumerFactory
+
+   .. automethod:: new
+   .. automethod:: __init__
+
+
+.. autoclass:: FastConsumerFactory
+
+   .. automethod:: new
+   .. automethod:: __init__

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -13,6 +13,7 @@ cassandra-driver==3.17.0
 certifi==2019.3.9
 cffi==1.11.5
 chardet==3.0.4
+confluent-kafka==1.1
 coverage==4.5.2
 cqlmapper==0.1.0
 cryptography==2.4.2

--- a/tests/unit/frameworks/queue_consumer/kafka_tests.py
+++ b/tests/unit/frameworks/queue_consumer/kafka_tests.py
@@ -1,0 +1,578 @@
+import socket
+
+from queue import Queue
+from unittest import mock
+
+import confluent_kafka
+import pytest
+
+from gevent.server import StreamServer
+
+from baseplate import Baseplate
+from baseplate import RequestContext
+from baseplate import ServerSpan
+from baseplate.frameworks.queue_consumer.kafka import FastConsumerFactory
+from baseplate.frameworks.queue_consumer.kafka import InOrderConsumerFactory
+from baseplate.frameworks.queue_consumer.kafka import KafkaConsumerWorker
+from baseplate.frameworks.queue_consumer.kafka import KafkaMessageHandler
+from baseplate.lib import metrics
+
+
+@pytest.fixture
+def context():
+    context = mock.Mock(spec=RequestContext)
+    context.metrics = mock.Mock(spec=metrics.Client)
+    return context
+
+
+@pytest.fixture
+def span():
+    sp = mock.MagicMock(spec=ServerSpan)
+    sp.make_child().__enter__.return_value = mock.MagicMock()
+    return sp
+
+
+@pytest.fixture
+def baseplate(context, span):
+    bp = mock.MagicMock(spec=Baseplate)
+    bp._metrics_client = None
+    bp.make_server_span().__enter__.return_value = span
+    bp.make_context_object.return_value = context
+    # Reset the mock calls since setting up the span actually triggers a "call"
+    # to bp.make_server_span
+    bp.reset_mock()
+    return bp
+
+
+@pytest.fixture
+def name():
+    return "kafka_consumer.test_group"
+
+
+class TestKafkaMessageHandler:
+    @pytest.fixture
+    def message(self):
+        msg = mock.Mock(spec=confluent_kafka.Message)
+        msg.topic.return_value = "topic_1"
+        msg.key.return_value = "key_1"
+        msg.partition.return_value = 3
+        msg.offset.return_value = 33
+        msg.timestamp.return_value = 123456
+        msg.value.return_value = b"message-payload"
+        msg.error.return_value = None
+        return msg
+
+    @mock.patch("baseplate.frameworks.queue_consumer.kafka.time")
+    def test_handle(self, time, context, span, baseplate, name, message):
+        time.time.return_value = 2.0
+
+        handler_fn = mock.Mock()
+        message_unpack_fn = mock.Mock(
+            return_value={"endpoint_timestamp": 1000.0, "body": "some text"}
+        )
+        on_success_fn = mock.Mock()
+
+        mock_timer = mock.Mock()
+        context.metrics.timer.return_value = mock_timer
+
+        mock_gauge = mock.Mock()
+        context.metrics.gauge.return_value = mock_gauge
+
+        handler = KafkaMessageHandler(baseplate, name, handler_fn, message_unpack_fn, on_success_fn)
+        handler.handle(message)
+        baseplate.make_context_object.assert_called_once()
+        baseplate.make_server_span.assert_called_once_with(context, f"{name}.handler")
+        baseplate.make_server_span().__enter__.assert_called_once()
+        span.set_tag.assert_has_calls(
+            [
+                mock.call("kind", "consumer"),
+                mock.call("kafka.topic", "topic_1"),
+                mock.call("kafka.key", "key_1"),
+                mock.call("kafka.partition", 3),
+                mock.call("kafka.offset", 33),
+                mock.call("kafka.timestamp", 123456),
+            ],
+            any_order=True,
+        )
+        message_unpack_fn.assert_called_once_with(b"message-payload")
+        handler_fn.assert_called_once_with(
+            context, {"endpoint_timestamp": 1000.0, "body": "some text"}, message
+        )
+        on_success_fn.assert_called_once_with(
+            context, {"endpoint_timestamp": 1000.0, "body": "some text"}, message
+        )
+
+        context.metrics.timer.assert_called_once_with(f"{name}.topic_1.latency")
+        mock_timer.send.assert_called_once_with(1.0)
+
+        context.metrics.gauge.assert_called_once_with(f"{name}.topic_1.offset.3")
+        mock_gauge.replace.assert_called_once_with(33)
+
+    def test_handle_no_endpoint_timestamp(self, context, span, baseplate, name, message):
+        handler_fn = mock.Mock()
+        message_unpack_fn = mock.Mock(return_value={"body": "some text"})
+        on_success_fn = mock.Mock()
+
+        mock_gauge = mock.Mock()
+        context.metrics.gauge.return_value = mock_gauge
+
+        handler = KafkaMessageHandler(baseplate, name, handler_fn, message_unpack_fn, on_success_fn)
+        handler.handle(message)
+        baseplate.make_context_object.assert_called_once()
+        baseplate.make_server_span.assert_called_once_with(context, f"{name}.handler")
+        baseplate.make_server_span().__enter__.assert_called_once()
+        span.set_tag.assert_has_calls(
+            [
+                mock.call("kind", "consumer"),
+                mock.call("kafka.topic", "topic_1"),
+                mock.call("kafka.key", "key_1"),
+                mock.call("kafka.partition", 3),
+                mock.call("kafka.offset", 33),
+                mock.call("kafka.timestamp", 123456),
+            ],
+            any_order=True,
+        )
+        message_unpack_fn.assert_called_once_with(b"message-payload")
+        handler_fn.assert_called_once_with(context, {"body": "some text"}, message)
+        on_success_fn.assert_called_once_with(context, {"body": "some text"}, message)
+
+        context.metrics.timer.assert_not_called()
+
+        context.metrics.gauge.assert_called_once_with(f"{name}.topic_1.offset.3")
+        mock_gauge.replace.assert_called_once_with(33)
+
+    def test_handle_kafka_error(self, context, span, baseplate, name, message):
+        handler_fn = mock.Mock()
+        message_unpack_fn = mock.Mock()
+        on_success_fn = mock.Mock()
+
+        # we can't actually create an instance of KafkaError, so use a mock
+        error_mock = mock.Mock()
+        error_mock.str.return_value = "kafka error"
+        message.error.return_value = error_mock
+
+        handler = KafkaMessageHandler(baseplate, name, handler_fn, message_unpack_fn, on_success_fn)
+
+        with pytest.raises(ValueError):
+            handler.handle(message)
+
+        baseplate.make_context_object.assert_called_once()
+        baseplate.make_server_span.assert_called_once_with(context, f"{name}.handler")
+        baseplate.make_server_span().__enter__.assert_called_once()
+        span.set_tag.assert_not_called()
+        message_unpack_fn.assert_not_called()
+        handler_fn.assert_not_called()
+        on_success_fn.assert_not_called()
+        context.metrics.timer.assert_not_called()
+        context.metrics.gauge.assert_not_called()
+
+    def test_handle_unpack_error(self, context, span, baseplate, name, message):
+        handler_fn = mock.Mock()
+        message_unpack_fn = mock.Mock(side_effect=ValueError("something bad happened"))
+        on_success_fn = mock.Mock()
+
+        context.trace = span
+
+        handler = KafkaMessageHandler(baseplate, name, handler_fn, message_unpack_fn, on_success_fn)
+        handler.handle(message)
+        baseplate.make_context_object.assert_called_once()
+        baseplate.make_server_span.assert_called_once_with(context, f"{name}.handler")
+        baseplate.make_server_span().__enter__.assert_called_once()
+        span.set_tag.assert_has_calls(
+            [
+                mock.call("kind", "consumer"),
+                mock.call("kafka.topic", "topic_1"),
+                mock.call("kafka.key", "key_1"),
+                mock.call("kafka.partition", 3),
+                mock.call("kafka.offset", 33),
+                mock.call("kafka.timestamp", 123456),
+            ],
+            any_order=True,
+        )
+        span.incr_tag.assert_called_once_with(f"{name}.topic_1.invalid_message")
+        message_unpack_fn.assert_called_once_with(b"message-payload")
+        handler_fn.assert_not_called()
+        on_success_fn.assert_not_called()
+        context.metrics.timer.assert_not_called()
+        context.metrics.gauge.assert_not_called()
+
+    def test_handle_handler_error(self, context, span, baseplate, name, message):
+        handler_fn = mock.Mock(side_effect=ValueError("something went wrong"))
+        message_unpack_fn = mock.Mock(
+            return_value={"endpoint_timestamp": 1000.0, "body": "some text"}
+        )
+        on_success_fn = mock.Mock()
+
+        handler = KafkaMessageHandler(baseplate, name, handler_fn, message_unpack_fn, on_success_fn)
+
+        with pytest.raises(ValueError):
+            handler.handle(message)
+
+        baseplate.make_context_object.assert_called_once()
+        baseplate.make_server_span.assert_called_once_with(context, f"{name}.handler")
+        baseplate.make_server_span().__enter__.assert_called_once()
+        span.set_tag.assert_has_calls(
+            [
+                mock.call("kind", "consumer"),
+                mock.call("kafka.topic", "topic_1"),
+                mock.call("kafka.key", "key_1"),
+                mock.call("kafka.partition", 3),
+                mock.call("kafka.offset", 33),
+                mock.call("kafka.timestamp", 123456),
+            ],
+            any_order=True,
+        )
+        message_unpack_fn.assert_called_once_with(b"message-payload")
+        handler_fn.assert_called_once_with(
+            context, {"endpoint_timestamp": 1000.0, "body": "some text"}, message
+        )
+        on_success_fn.assert_not_called()
+        context.metrics.timer.assert_not_called()
+        context.metrics.gauge.assert_not_called()
+
+
+@pytest.fixture
+def bootstrap_servers():
+    return "127.0.0.1:9092"
+
+
+@pytest.fixture
+def group_id():
+    return "test_service.test_group"
+
+
+@pytest.fixture
+def topics():
+    return ["topic_1"]
+
+
+class TestInOrderConsumerFactory:
+    @mock.patch("confluent_kafka.Consumer")
+    def test_make_kafka_consumer(
+        self, kafka_consumer, name, baseplate, bootstrap_servers, group_id, topics
+    ):
+        mock_consumer = mock.Mock()
+        mock_consumer.list_topics.return_value = mock.Mock(
+            topics={"topic_1": mock.Mock(), "topic_2": mock.Mock(), "topic_3": mock.Mock()}
+        )
+        kafka_consumer.return_value = mock_consumer
+
+        _consumer = InOrderConsumerFactory.make_kafka_consumer(bootstrap_servers, group_id, topics)
+
+        assert _consumer == mock_consumer
+
+        kafka_consumer.assert_called_once_with(
+            {
+                "bootstrap.servers": bootstrap_servers,
+                "group.id": group_id,
+                "auto.offset.reset": "latest",
+                "heartbeat.interval.ms": 3000,
+                "session.timeout.ms": 10000,
+                "max.poll.interval.ms": 300000,
+                "enable.auto.commit": "false",
+            }
+        )
+        mock_consumer.subscribe.assert_called_once()
+        assert mock_consumer.subscribe.call_args_list[0][0][0] == topics
+
+    @mock.patch("confluent_kafka.Consumer")
+    def test_make_kafka_consumer_unknown_topic(
+        self, kafka_consumer, name, baseplate, bootstrap_servers, group_id, topics
+    ):
+        mock_consumer = mock.Mock()
+        mock_consumer.list_topics.return_value = mock.Mock(
+            topics={"topic_1": mock.Mock(), "topic_2": mock.Mock(), "topic_3": mock.Mock()}
+        )
+        kafka_consumer.return_value = mock_consumer
+
+        with pytest.raises(AssertionError):
+            InOrderConsumerFactory.make_kafka_consumer(bootstrap_servers, group_id, ["topic_4"])
+
+        kafka_consumer.assert_called_once_with(
+            {
+                "bootstrap.servers": bootstrap_servers,
+                "group.id": group_id,
+                "auto.offset.reset": "latest",
+                "heartbeat.interval.ms": 3000,
+                "session.timeout.ms": 10000,
+                "max.poll.interval.ms": 300000,
+                "enable.auto.commit": "false",
+            }
+        )
+        mock_consumer.subscribe.assert_not_called()
+
+    @mock.patch("confluent_kafka.Consumer")
+    def test_init(self, kafka_consumer, name, baseplate, bootstrap_servers, group_id, topics):
+        mock_consumer = mock.Mock()
+        mock_consumer.list_topics.return_value = mock.Mock(
+            topics={"topic_1": mock.Mock(), "topic_2": mock.Mock(), "topic_3": mock.Mock()}
+        )
+        kafka_consumer.return_value = mock_consumer
+
+        handler_fn = mock.Mock()
+        message_unpack_fn = mock.Mock()
+        health_check_fn = mock.Mock()
+        factory = InOrderConsumerFactory.new(
+            name=name,
+            baseplate=baseplate,
+            bootstrap_servers=bootstrap_servers,
+            group_id=group_id,
+            topics=topics,
+            handler_fn=handler_fn,
+            message_unpack_fn=message_unpack_fn,
+            health_check_fn=health_check_fn,
+        )
+        assert factory.name == name
+        assert factory.baseplate == baseplate
+        assert factory.handler_fn == handler_fn
+        assert factory.message_unpack_fn == message_unpack_fn
+        assert factory.health_check_fn == health_check_fn
+        assert factory.consumer == mock_consumer
+
+    @pytest.fixture
+    def make_queue_consumer_factory(self, name, baseplate, bootstrap_servers, group_id, topics):
+        @mock.patch("confluent_kafka.Consumer")
+        def _make_queue_consumer_factory(kafka_consumer, health_check_fn=None):
+            mock_consumer = mock.Mock()
+            mock_consumer.list_topics.return_value = mock.Mock(
+                topics={"topic_1": mock.Mock(), "topic_2": mock.Mock(), "topic_3": mock.Mock()}
+            )
+            kafka_consumer.return_value = mock_consumer
+
+            return InOrderConsumerFactory.new(
+                name=name,
+                baseplate=baseplate,
+                bootstrap_servers=bootstrap_servers,
+                group_id=group_id,
+                topics=topics,
+                handler_fn=lambda ctx, data, msg: True,
+                message_unpack_fn=lambda b: {},
+                health_check_fn=health_check_fn,
+            )
+
+        return _make_queue_consumer_factory
+
+    def test_build_pump_worker(self, make_queue_consumer_factory):
+        factory = make_queue_consumer_factory()
+        work_queue = Queue(maxsize=10)
+        pump = factory.build_pump_worker(work_queue)
+        assert isinstance(pump, KafkaConsumerWorker)
+        assert pump.consumer == factory.consumer
+        assert pump.work_queue == work_queue
+
+    def test_build_message_handler(self, make_queue_consumer_factory):
+        factory = make_queue_consumer_factory()
+        handler = factory.build_message_handler()
+        assert isinstance(handler, KafkaMessageHandler)
+        assert handler.baseplate == factory.baseplate
+        assert handler.name == factory.name
+        assert handler.handler_fn == factory.handler_fn
+        assert handler.message_unpack_fn == factory.message_unpack_fn
+        assert handler.on_success_fn.__name__ == "commit_offset"
+
+    def test_build_multiple_message_handlers(self, make_queue_consumer_factory):
+        factory = make_queue_consumer_factory()
+
+        factory.build_message_handler()
+
+        with pytest.raises(AssertionError):
+            factory.build_message_handler()
+
+    @pytest.mark.parametrize("health_check_fn", [None, lambda req: True])
+    def test_build_health_checker(self, health_check_fn, make_queue_consumer_factory):
+        factory = make_queue_consumer_factory(health_check_fn=health_check_fn)
+        listener = mock.Mock(spec=socket.socket)
+        health_checker = factory.build_health_checker(listener)
+        assert isinstance(health_checker, StreamServer)
+
+
+class TestFastConsumerFactory:
+    @mock.patch("confluent_kafka.Consumer")
+    def test_make_kafka_consumer(
+        self, kafka_consumer, name, baseplate, bootstrap_servers, group_id, topics
+    ):
+        mock_consumer = mock.Mock()
+        mock_consumer.list_topics.return_value = mock.Mock(
+            topics={"topic_1": mock.Mock(), "topic_2": mock.Mock(), "topic_3": mock.Mock()}
+        )
+        kafka_consumer.return_value = mock_consumer
+
+        _consumer = FastConsumerFactory.make_kafka_consumer(bootstrap_servers, group_id, topics)
+
+        assert _consumer == mock_consumer
+
+        kafka_consumer.assert_called_once_with(
+            {
+                "bootstrap.servers": bootstrap_servers,
+                "group.id": group_id,
+                "auto.offset.reset": "latest",
+                "heartbeat.interval.ms": 3000,
+                "session.timeout.ms": 10000,
+                "max.poll.interval.ms": 300000,
+                "enable.auto.commit": "true",
+                "auto.commit.interval.ms": 5000,
+                "enable.auto.offset.store": "true",
+                "on_commit": FastConsumerFactory._commit_callback,
+            }
+        )
+        mock_consumer.subscribe.assert_called_once()
+        assert mock_consumer.subscribe.call_args_list[0][0][0] == topics
+
+    @mock.patch("confluent_kafka.Consumer")
+    def test_make_kafka_consumer_unknown_topic(
+        self, kafka_consumer, name, baseplate, bootstrap_servers, group_id, topics
+    ):
+        mock_consumer = mock.Mock()
+        mock_consumer.list_topics.return_value = mock.Mock(
+            topics={"topic_1": mock.Mock(), "topic_2": mock.Mock(), "topic_3": mock.Mock()}
+        )
+        kafka_consumer.return_value = mock_consumer
+
+        with pytest.raises(AssertionError):
+            FastConsumerFactory.make_kafka_consumer(bootstrap_servers, group_id, ["topic_4"])
+
+        kafka_consumer.assert_called_once_with(
+            {
+                "bootstrap.servers": bootstrap_servers,
+                "group.id": group_id,
+                "auto.offset.reset": "latest",
+                "heartbeat.interval.ms": 3000,
+                "session.timeout.ms": 10000,
+                "max.poll.interval.ms": 300000,
+                "enable.auto.commit": "true",
+                "auto.commit.interval.ms": 5000,
+                "enable.auto.offset.store": "true",
+                "on_commit": FastConsumerFactory._commit_callback,
+            }
+        )
+        mock_consumer.subscribe.assert_not_called()
+
+    @mock.patch("confluent_kafka.Consumer")
+    def test_init(self, kafka_consumer, name, baseplate, bootstrap_servers, group_id, topics):
+        mock_consumer = mock.Mock()
+        mock_consumer.list_topics.return_value = mock.Mock(
+            topics={"topic_1": mock.Mock(), "topic_2": mock.Mock(), "topic_3": mock.Mock()}
+        )
+        kafka_consumer.return_value = mock_consumer
+
+        handler_fn = mock.Mock()
+        message_unpack_fn = mock.Mock()
+        health_check_fn = mock.Mock()
+        factory = FastConsumerFactory.new(
+            name=name,
+            baseplate=baseplate,
+            bootstrap_servers=bootstrap_servers,
+            group_id=group_id,
+            topics=topics,
+            handler_fn=handler_fn,
+            message_unpack_fn=message_unpack_fn,
+            health_check_fn=health_check_fn,
+        )
+        assert factory.name == name
+        assert factory.baseplate == baseplate
+        assert factory.handler_fn == handler_fn
+        assert factory.message_unpack_fn == message_unpack_fn
+        assert factory.health_check_fn == health_check_fn
+        assert factory.consumer == mock_consumer
+
+    @pytest.fixture
+    def make_queue_consumer_factory(self, name, baseplate, bootstrap_servers, group_id, topics):
+        @mock.patch("confluent_kafka.Consumer")
+        def _make_queue_consumer_factory(kafka_consumer, health_check_fn=None):
+            mock_consumer = mock.Mock()
+            mock_consumer.list_topics.return_value = mock.Mock(
+                topics={"topic_1": mock.Mock(), "topic_2": mock.Mock(), "topic_3": mock.Mock()}
+            )
+            kafka_consumer.return_value = mock_consumer
+
+            return FastConsumerFactory.new(
+                name=name,
+                baseplate=baseplate,
+                bootstrap_servers=bootstrap_servers,
+                group_id=group_id,
+                topics=topics,
+                handler_fn=lambda ctx, data, msg: True,
+                message_unpack_fn=lambda b: {},
+                health_check_fn=health_check_fn,
+            )
+
+        return _make_queue_consumer_factory
+
+    def test_build_pump_worker(self, make_queue_consumer_factory):
+        factory = make_queue_consumer_factory()
+        work_queue = Queue(maxsize=10)
+        pump = factory.build_pump_worker(work_queue)
+        assert isinstance(pump, KafkaConsumerWorker)
+        assert pump.consumer == factory.consumer
+        assert pump.work_queue == work_queue
+
+    def test_build_message_handler(self, make_queue_consumer_factory):
+        factory = make_queue_consumer_factory()
+        handler = factory.build_message_handler()
+        assert isinstance(handler, KafkaMessageHandler)
+        assert handler.baseplate == factory.baseplate
+        assert handler.name == factory.name
+        assert handler.handler_fn == factory.handler_fn
+        assert handler.message_unpack_fn == factory.message_unpack_fn
+        assert handler.on_success_fn is None
+
+    @pytest.mark.parametrize("health_check_fn", [None, lambda req: True])
+    def test_build_health_checker(self, health_check_fn, make_queue_consumer_factory):
+        factory = make_queue_consumer_factory(health_check_fn=health_check_fn)
+        listener = mock.Mock(spec=socket.socket)
+        health_checker = factory.build_health_checker(listener)
+        assert isinstance(health_checker, StreamServer)
+
+
+class TestKafkaConsumerWorker:
+    @pytest.fixture
+    def consumer_worker(self, baseplate, name):
+        mock_consumer = mock.Mock()
+        mock_queue = mock.Mock(spec=Queue)
+        return KafkaConsumerWorker(baseplate, name, mock_consumer, mock_queue)
+
+    def test_initial_state(self, consumer_worker):
+        assert consumer_worker.started is False
+        assert consumer_worker.stopped is False
+
+    @mock.patch("baseplate.frameworks.queue_consumer.kafka.time")
+    def test_run(self, time, span, baseplate, name, consumer_worker):
+        msg1 = mock.Mock()
+        msg2 = mock.Mock()
+        msg3 = mock.Mock()
+        consumer_worker.consumer.consume.side_effect = [(), (msg1,), (msg2,), (msg3,)]
+
+        with mock.patch.object(
+            KafkaConsumerWorker, "stopped", create=True, new_callable=mock.PropertyMock
+        ) as stopped_value:
+            stopped_value.side_effect = [False, False, False, True]
+            consumer_worker.run()
+
+        baseplate.make_context_object.mock_calls == [mock.call(), mock.call(), mock.call()]
+        baseplate.make_server_span.mock_calls == [
+            mock.call(context, f"{name}.pump"),
+            mock.call(context, f"{name}.pump"),
+            mock.call(context, f"{name}.pump"),
+        ]
+        span.make_child.mock_calls == [
+            mock.call("kafka.consume"),
+            mock.call("kafka.work_queue_put"),
+            mock.call("kafka.consume"),
+            mock.call("kafka.work_queue_put"),
+            mock.call("kafka.consume"),
+            mock.call("kafka.work_queue_put"),
+        ]
+
+        assert consumer_worker.started is True
+        assert consumer_worker.consumer.consume.mock_calls == [
+            mock.call(num_messages=1, timeout=0),
+            mock.call(num_messages=1, timeout=0),
+            mock.call(num_messages=1, timeout=0),
+        ]
+
+        time.sleep.assert_called_once_with(1)
+        assert consumer_worker.work_queue.put.mock_calls == [mock.call(msg1), mock.call(msg2)]
+
+    def test_stop(self, consumer_worker):
+        consumer_worker.stop()
+        assert consumer_worker.stopped is True


### PR DESCRIPTION
This lets us run a `QueueConsumerServer` against Kafka instead of kombu/RabbitMQ.

This code is very similar to what has been running in Thing service and Channels service. I'll update the code running in Thing service to match this exactly before merging this baseplate PR.