### PR TITLE
Rename baseplate-tshell to baseplate-shell

### DIFF
--- a/baseplate/server/__init__.py
+++ b/baseplate/server/__init__.py
@@ -87,7 +87,7 @@ class Configuration(NamedTuple):
     server: Optional[Dict[str, str]]
     app: Dict[str, str]
     has_logging_options: bool
-    tshell: Optional[Dict[str, str]]
+    shell: Optional[Dict[str, str]]
 
 
 def read_config(config_file: TextIO, server_name: Optional[str], app_name: str) -> Configuration:
@@ -100,11 +100,13 @@ def read_config(config_file: TextIO, server_name: Optional[str], app_name: str) 
     server_config = dict(parser.items("server:" + server_name)) if server_name else None
     app_config = dict(parser.items("app:" + app_name))
     has_logging_config = parser.has_section("loggers")
-    tshell_config = None
-    if parser.has_section("tshell"):
-        tshell_config = dict(parser.items("tshell"))
+    shell_config = None
+    if parser.has_section("shell"):
+        shell_config = dict(parser.items("shell"))
+    elif parser.has_section("tshell"):
+        shell_config = dict(parser.items("tshell"))
 
-    return Configuration(filename, server_config, app_config, has_logging_config, tshell_config)
+    return Configuration(filename, server_config, app_config, has_logging_config, shell_config)
 
 
 def configure_logging(config: Configuration, debug: bool) -> None:
@@ -313,7 +315,7 @@ def _fn_accepts_additional_args(script_fn: Callable[..., Any], fn_args: Sequence
     return allows_additional_args
 
 
-def load_and_run_tshell() -> None:
+def load_and_run_shell() -> None:
     """Launch a shell for a thrift service."""
 
     sys.path.append(os.getcwd())
@@ -355,8 +357,8 @@ def load_and_run_tshell() -> None:
     span = baseplate.make_server_span(context, "shell")
     env["context"] = span.context
 
-    if config.tshell and "setup" in config.tshell:
-        setup = _load_factory(config.tshell["setup"])
+    if config.shell and "setup" in config.shell:
+        setup = _load_factory(config.shell["setup"])
         setup(env, env_banner)
 
     # generate banner text

--- a/bin/baseplate-shell
+++ b/bin/baseplate-shell
@@ -11,7 +11,4 @@ patch_all()
 
 from baseplate.server import load_and_run_shell
 
-print("baseplate-tshell has been renamed to baseplate-shell. Please use that in the future!")
-print()
-
 load_and_run_shell()

--- a/docs/cli/index.rst
+++ b/docs/cli/index.rst
@@ -7,8 +7,4 @@ CLI Tools
    baseplate-healthcheck: Check if your service is alive <healthcheck>
    baseplate-serve: The application server <serve>
    baseplate-script: Run backend scripts <script>
-   baseplate-tshell: Begin an interactive shell for a Thrift service <tshell>
-
-HTTP services can use Pyramid's pshell_ in order to get an interactive shell.
-
-.. _pshell: https://docs.pylonsproject.org/projects/pyramid/en/latest/pscripts/pshell.html
+   baseplate-shell: Begin an interactive shell for a service <shell>

--- a/docs/cli/shell.rst
+++ b/docs/cli/shell.rst
@@ -1,13 +1,11 @@
-``baseplate-tshell``
+``baseplate-shell``
 ====================
 
-This command allows you to run an interactive Python shell for a Thrift service
+This command allows you to run an interactive Python shell for Baseplate.py services
 with the application configuration and context loaded. The command is
-``baseplate-tshell``.
+``baseplate-shell``.
 
-HTTP services can use Pyramid's pshell_ in order to get an interactive shell.
-
-.. _pshell: https://docs.pylonsproject.org/projects/pyramid/en/latest/pscripts/pshell.html
+This shell can be used for any kind of Baseplate.py service: Thrift, HTTP, etc.
 
 Command Line
 ------------
@@ -19,7 +17,8 @@ default. This can be overridden with the ``--app-name`` option.
 
 By default, the shell will have variables containing the application and the
 context exposed. Additional variables can be exposed by providing a ``setup``
-function in the ``tshell`` section of the configuration file.
+function in the ``shell`` (or ``tshell`` for backwards compatibility) section
+of the configuration file.
 
 Example
 -------
@@ -31,14 +30,14 @@ Given a configuration file, ``example.ini``:
    [app:main]
    factory = baseplate.server.thrift
 
-   [tshell]
-   setup = my_service:tshell_setup
+   [shell]
+   setup = my_service:shell_setup
 
 and a small setup function, ``my_service.py``:
 
 .. code-block:: python
 
-   def tshell_setup(env, env_banner):
+   def shell_setup(env, env_banner):
        from my_service import models
        env['models'] = models
        env_banner['models'] = 'Models module'
@@ -47,7 +46,7 @@ You can begin a shell with the models module exposed:
 
 .. code-block:: console
 
-   $ tshell example.ini
+   $ baseplate-shell example.ini
    Baseplate Interactive Shell
    Python 2.7.6 (default, Nov 23 2017, 15:49:48)
    [GCC 4.8.4]

--- a/setup.py
+++ b/setup.py
@@ -32,8 +32,9 @@ setup(
         "zookeeper": ["kazoo>=2.5.0"],
     },
     scripts=[
-        "bin/baseplate-serve",
         "bin/baseplate-script",
+        "bin/baseplate-serve",
+        "bin/baseplate-shell",
         "bin/baseplate-tshell",
         "bin/baseplate-healthcheck",
     ],


### PR DESCRIPTION
It turns out that since Apache Thrift, we're standardized on how the
application object works so we can use this shell for both kinds of
services. Not only is this simpler to think about, but it also means
we're not using different configuration parsing for Pyramid shells which
fixes #367.

:eyeglasses: @bradengroom @pacejackson 