### PR TITLE
Add loid and scopes into AuthenticationToken property

### DIFF
--- a/baseplate/lib/edge_context.py
+++ b/baseplate/lib/edge_context.py
@@ -86,7 +86,7 @@ class AuthenticationToken:
         raise NotImplementedError
 
     @property
-    def loid_id(self) -> Optional[str]:
+    def loid(self) -> Optional[str]:
         raise NotImplementedError
 
     @property
@@ -119,7 +119,7 @@ class ValidatedAuthenticationToken(AuthenticationToken):
         return set(self.payload.get("scopes") or [])
 
     @property
-    def loid_id(self) -> Optional[str]:
+    def loid(self) -> Optional[str]:
         return (self.payload.get("loid") or {}).get("id")
 
     @property
@@ -149,7 +149,7 @@ class InvalidAuthenticationToken(AuthenticationToken):
         raise NoAuthenticationError
 
     @property
-    def loid_id(self) -> Optional[str]:
+    def loid(self) -> Optional[str]:
         raise NoAuthenticationError
 
     @property

--- a/baseplate/lib/edge_context.py
+++ b/baseplate/lib/edge_context.py
@@ -81,9 +81,21 @@ class AuthenticationToken:
     def oauth_client_type(self) -> Optional[str]:
         raise NotImplementedError
 
+    @property
+    def scopes(self) -> Set[str]:
+        raise NotImplementedError
+
+    @property
+    def loid_id(self) -> Optional[str]:
+        raise NotImplementedError
+
+    @property
+    def loid_created_ms(self) -> Optional[int]:
+        raise NotImplementedError
+
 
 class ValidatedAuthenticationToken(AuthenticationToken):
-    def __init__(self, payload: Dict[str, str]):
+    def __init__(self, payload: Dict[str, Any]):
         self.payload = payload
 
     @property
@@ -92,7 +104,7 @@ class ValidatedAuthenticationToken(AuthenticationToken):
 
     @cached_property
     def user_roles(self) -> Set[str]:  # type: ignore # pylint: disable=W0236
-        return set(self.payload.get("roles", []))
+        return set(self.payload.get("roles") or [])
 
     @property
     def oauth_client_id(self) -> Optional[str]:
@@ -101,6 +113,18 @@ class ValidatedAuthenticationToken(AuthenticationToken):
     @property
     def oauth_client_type(self) -> Optional[str]:
         return self.payload.get("client_type")
+
+    @property
+    def scopes(self) -> Set[str]:
+        return set(self.payload.get("scopes") or [])
+
+    @property
+    def loid_id(self) -> Optional[str]:
+        return (self.payload.get("loid") or {}).get("id")
+
+    @property
+    def loid_created_ms(self) -> Optional[int]:
+        return (self.payload.get("loid") or {}).get("created_ms")
 
 
 class InvalidAuthenticationToken(AuthenticationToken):
@@ -118,6 +142,18 @@ class InvalidAuthenticationToken(AuthenticationToken):
 
     @property
     def oauth_client_type(self) -> Optional[str]:
+        raise NoAuthenticationError
+
+    @property
+    def scopes(self) -> Set[str]:
+        raise NoAuthenticationError
+
+    @property
+    def loid_id(self) -> Optional[str]:
+        raise NoAuthenticationError
+
+    @property
+    def loid_created_ms(self) -> Optional[int]:
         raise NoAuthenticationError
 
 

--- a/baseplate/lib/edge_context.py
+++ b/baseplate/lib/edge_context.py
@@ -104,7 +104,7 @@ class ValidatedAuthenticationToken(AuthenticationToken):
 
     @cached_property
     def user_roles(self) -> Set[str]:  # type: ignore # pylint: disable=W0236
-        return set(self.payload.get("roles") or [])
+        return set(self.payload.get("roles", []))
 
     @property
     def oauth_client_id(self) -> Optional[str]:

--- a/tests/unit/lib/edge_context_tests.py
+++ b/tests/unit/lib/edge_context_tests.py
@@ -22,7 +22,7 @@ class AuthenticationTokenTests(unittest.TestCase):
         self.assertEqual(token.oauth_client_id, "client_id")
         self.assertEqual(token.oauth_client_type, "type_a")
         self.assertEqual(token.scopes, {"scope_a"})
-        self.assertEqual(token.loid_id, "t2_user")
+        self.assertEqual(token.loid, "t2_user")
         self.assertEqual(token.loid_created_ms, 1574458470)
 
     def test_validated_authentication_token_none(self):
@@ -41,7 +41,7 @@ class AuthenticationTokenTests(unittest.TestCase):
         self.assertEqual(token.oauth_client_id, None)
         self.assertEqual(token.oauth_client_type, None)
         self.assertEqual(token.scopes, set())
-        self.assertEqual(token.loid_id, None)
+        self.assertEqual(token.loid, None)
         self.assertEqual(token.loid_created_ms, None)
 
     def test_invalidated_authentication_token(self):

--- a/tests/unit/lib/edge_context_tests.py
+++ b/tests/unit/lib/edge_context_tests.py
@@ -30,7 +30,6 @@ class AuthenticationTokenTests(unittest.TestCase):
             "sub": "t2_user",
             "exp": 1574458470,
             "client_id": None,
-            "roles": None,
             "client_type": None,
             "scopes": None,
             "loid": None,

--- a/tests/unit/lib/edge_context_tests.py
+++ b/tests/unit/lib/edge_context_tests.py
@@ -1,0 +1,53 @@
+import unittest
+
+from baseplate.lib.edge_context import InvalidAuthenticationToken
+from baseplate.lib.edge_context import NoAuthenticationError
+from baseplate.lib.edge_context import ValidatedAuthenticationToken
+
+
+class AuthenticationTokenTests(unittest.TestCase):
+    def test_validated_authentication_token(self):
+        payload = {
+            "sub": "t2_user",
+            "exp": 1574458470,
+            "client_id": "client_id",
+            "roles": ["role_a"],
+            "client_type": "type_a",
+            "scopes": ["scope_a"],
+            "loid": {"id": "t2_user", "created_ms": 1574458470},
+        }
+        token = ValidatedAuthenticationToken(payload)
+        self.assertEqual(token.subject, "t2_user")
+        self.assertEqual(token.user_roles, {"role_a"})
+        self.assertEqual(token.oauth_client_id, "client_id")
+        self.assertEqual(token.oauth_client_type, "type_a")
+        self.assertEqual(token.scopes, {"scope_a"})
+        self.assertEqual(token.loid_id, "t2_user")
+        self.assertEqual(token.loid_created_ms, 1574458470)
+
+    def test_validated_authentication_token_none(self):
+        payload = {
+            "sub": "t2_user",
+            "exp": 1574458470,
+            "client_id": None,
+            "roles": None,
+            "client_type": None,
+            "scopes": None,
+            "loid": None,
+        }
+        token = ValidatedAuthenticationToken(payload)
+        self.assertEqual(token.subject, "t2_user")
+        self.assertEqual(token.user_roles, set())
+        self.assertEqual(token.oauth_client_id, None)
+        self.assertEqual(token.oauth_client_type, None)
+        self.assertEqual(token.scopes, set())
+        self.assertEqual(token.loid_id, None)
+        self.assertEqual(token.loid_created_ms, None)
+
+    def test_invalidated_authentication_token(self):
+        token = InvalidAuthenticationToken()
+        for attr in dir(token):
+            if attr.startswith("__"):
+                continue
+            with self.assertRaises(NoAuthenticationError):
+                getattr(token, attr)


### PR DESCRIPTION
## Description
In authentication service 
2 fields was added into authentication token payload 
1: Scopes(deployed) 
2: Loid(field exists): we are logging more information in this field (PR)

So in order to access those fields easier by other services, add those fields into `property` instead of hiding in the `payload`

@pacejackson @bsimpson63 