### PR TITLE
Fix thrift build import rename growing forever on rebuild

### DIFF
--- a/baseplate/frameworks/thrift/command.py
+++ b/baseplate/frameworks/thrift/command.py
@@ -61,9 +61,10 @@ class BuildThriftCommand(Command):
                         for line in lines:
                             prefix = "from " + module_name
                             if line.startswith(prefix):
-                                f.write("from " + full_package_name + line[len(prefix) :])
-                            else:
-                                f.write(line)
+                                if not line.startswith("from " + full_package_name):
+                                    f.write("from " + full_package_name + line[len(prefix) :])
+                                    continue
+                            f.write(line)
 
 
 class ThriftBuildPyCommand(build_py):


### PR DESCRIPTION
The transform was not idempotent when the thriftfile was the same name
as the root module. Staying firmly in hack territory, we just check if
the line we want to transform already has the full path we desire.

(I opted to stay away from f-strings for this patch so that it can be backported to 0.30 more easily)

Fixes #354 