### PR TITLE
Fix infinite loop in Raven setup when using relative paths

### DIFF
--- a/baseplate/observers/sentry.py
+++ b/baseplate/observers/sentry.py
@@ -76,7 +76,8 @@ def error_reporter_from_config(raw_config: config.RawConfig, module_name: str) -
     )
 
     application_module = sys.modules[module_name]
-    directory = os.path.dirname(application_module.__file__)
+    module_path = os.path.abspath(application_module.__file__)
+    directory = os.path.dirname(module_path)
     release = None
     while directory != "/":
         try:


### PR DESCRIPTION
When running a script that uses error_reporter_from_config() from a
directory that does not have any git repository, the revision resolution
would infinite loop. This grabs the absolute path to the code before
traversing the tree so that we can truly find out the revision or give
up.

Fixes #177