### PR TITLE
Rework runtime metrics reporting of concurrency

### DIFF
--- a/baseplate/server/runtime_monitor.py
+++ b/baseplate/server/runtime_monitor.py
@@ -11,12 +11,18 @@ from typing import Dict
 from typing import List
 from typing import NoReturn
 from typing import Optional
+from typing import Set
 
 import gevent.events
 
 from gevent.pool import Pool
 
+from baseplate import _ExcInfo
 from baseplate import Baseplate
+from baseplate import BaseplateObserver
+from baseplate import RequestContext
+from baseplate import ServerSpan
+from baseplate import ServerSpanObserver
 from baseplate.lib import config
 from baseplate.lib import metrics
 
@@ -32,12 +38,36 @@ class _Reporter:
         raise NotImplementedError
 
 
-class _ConcurrencyReporter(_Reporter):
+class _OpenConnectionsReporter(_Reporter):
     def __init__(self, pool: Pool):
         self.pool = pool
 
     def report(self, batch: metrics.Batch) -> None:
-        batch.gauge("active_requests").replace(len(self.pool.greenlets))
+        batch.gauge("open_connections").replace(len(self.pool.greenlets))
+
+
+class _ActiveRequestsObserver(BaseplateObserver, _Reporter):
+    def __init__(self) -> None:
+        self.live_requests: Set[int] = set()
+
+    def on_server_span_created(self, context: RequestContext, server_span: ServerSpan) -> None:
+        observer = _ActiveRequestsServerSpanObserver(self, server_span.trace_id)
+        server_span.register(observer)
+
+    def report(self, batch: metrics.Batch) -> None:
+        batch.gauge("active_requests").replace(len(self.live_requests))
+
+
+class _ActiveRequestsServerSpanObserver(ServerSpanObserver):
+    def __init__(self, reporter: _ActiveRequestsObserver, trace_id: int):
+        self.reporter = reporter
+        self.trace_id = trace_id
+
+    def on_start(self) -> None:
+        self.reporter.live_requests.add(self.trace_id)
+
+    def on_finish(self, exc_info: Optional[_ExcInfo]) -> None:
+        self.reporter.live_requests.remove(self.trace_id)
 
 
 class _BlockedGeventHubReporter(_Reporter):
@@ -198,7 +228,10 @@ def start(server_config: Dict[str, str], application: Any, pool: Pool) -> None:
     reporters: List[_Reporter] = []
 
     if cfg.monitoring.concurrency:
-        reporters.append(_ConcurrencyReporter(pool))
+        reporters.append(_OpenConnectionsReporter(pool))
+        observer = _ActiveRequestsObserver()
+        reporters.append(observer)
+        baseplate.register(observer)
 
     if cfg.monitoring.connection_pool:
         reporters.append(_BaseplateReporter(baseplate.get_runtime_metric_reporters()))

--- a/docs/cli/serve.rst
+++ b/docs/cli/serve.rst
@@ -35,15 +35,17 @@ comes with two servers built in:
 ``baseplate.server.wsgi``
    A Gevent WSGI server.
 
-Both take two optional configuration values as well:
+Both take two configuration values as well:
 
 ``max_concurrency``
-   The maximum number of simultaneous clients the server will handle. Unlimited
-   by default.
+   The maximum number of simultaneous clients the server will handle. Note that
+   this is how many connections will be accepted, but some of those connections
+   may be idle at any given time.
 
 ``stop_timeout``
-   How long, in seconds, to wait for active connections to finish up gracefully
-   when shutting down. By default, the server will shut down immediately.
+   (Optional) How long, in seconds, to wait for active connections to finish up
+   gracefully when shutting down. By default, the server will shut down
+   immediately.
 
 The WSGI server takes an additional optional parameter:
 
@@ -184,9 +186,10 @@ The following reporters are available:
    This will track the number of in-flight requests being processed
    concurrently by this server process.
 
-   At each report interval, this will update a
-   :py:class:`~baseplate.lib.metrics.Gauge` with the current number of
-   in-flight requests being processed concurrently.
+   At each report interval, this will update two
+   :py:class:`~baseplate.lib.metrics.Gauge` metrics with the current number of
+   open connections (``open_connections``) and current number of in-flight
+   requests being processed concurrently (``active_requests``).
 
 ``monitoring.connection_pool``
    Enabled if ``true``, disabled if ``false``. Defaults to disabled.


### PR DESCRIPTION
The previous number incorrectly conflated the number of open connections
with the number of in-flight requests. An idle connection has very
little impact on the server, but in-flight requests contend for CPU
time.

Example output:

```
example_server.runtime.reddit.PID2505.open_connections:5|g
example_server.runtime.reddit.PID2505.active_requests:2|g
```

This is a redefinition of the existing `active_requests` gauge. I didn't think it made sense to keep the old one just for backwards compatibility since it was a confusing name. Would it be better to come up with a third name and leave the old one blank instead?

Fixes #353 

:eyeglasses: @pacejackson @bsimpson63 