### PR TITLE
Fix ServerTimeout exemption on raven<6.1

### DIFF
--- a/baseplate/observers/sentry.py
+++ b/baseplate/observers/sentry.py
@@ -102,7 +102,7 @@ def error_reporter_from_config(raw_config: config.RawConfig, module_name: str) -
         processors=cfg.sentry.processors,
     )
 
-    client.ignore_exceptions.add(ServerTimeout)
+    client.ignore_exceptions.add("ServerTimeout")
     return client
 
 


### PR DESCRIPTION
Support for non-string values was only added in 6.1. Some of our
services are still using older versions.

https://github.com/getsentry/raven-python/blob/master/CHANGELOG.md#610-2017-05-25