### PR TITLE
Fix redis client parameter munging and make test stricter

### DIFF
--- a/baseplate/clients/redis.py
+++ b/baseplate/clients/redis.py
@@ -118,7 +118,7 @@ class MonitoredRedisConnection(redis.StrictRedis):
         trace_name = f"{self.context_name}.{command}"
 
         with self.server_span.make_child(trace_name):
-            return super().execute_command(command, *args, **kwargs)
+            return super().execute_command(command, *args[1:], **kwargs)
 
     # pylint: disable=arguments-differ
     def pipeline(  # type: ignore

--- a/tests/integration/redis_tests.py
+++ b/tests/integration/redis_tests.py
@@ -33,7 +33,9 @@ class RedisIntegrationTests(unittest.TestCase):
 
     def test_simple_command(self):
         with self.server_span:
-            self.context.redis.ping()
+            result = self.context.redis.ping()
+
+        self.assertTrue(result)
 
         server_span_observer = self.baseplate_observer.get_only_child()
         span_observer = server_span_observer.get_only_child()


### PR DESCRIPTION
This regressed in 1aa93077e24041478b7c38d41c4c65a734bc8e76.