### PR TITLE
Allow custom callback from the secrets fetcher

### DIFF
--- a/baseplate/sidecars/secrets_fetcher.py
+++ b/baseplate/sidecars/secrets_fetcher.py
@@ -344,7 +344,7 @@ def trigger_callback(
     callback: Optional[str], secrets_file: str, last_proc: Optional[subprocess.Popen] = None
 ) -> Optional[subprocess.Popen]:
     if callback:
-        if last_proc is not None and last_proc.poll() is None:
+        if last_proc and last_proc.poll() is None:
             logger.info("Previous callback process is still running. Skipping")
         else:
             return subprocess.Popen([callback, secrets_file])


### PR DESCRIPTION
Allows applications to defined a callback to run after the secret fetcher lays down its file.

test_config.ini
```
[secret-fetcher]
vault.url = http://127.0.0.1:8200
vault.role = my-server-role

output.path = secrets.json
output.owner = vagrant
output.group = vagrant
output.mode = 0400


secrets =
	secret/data/dbuser,
	secret/data/dbpass

callback = scripts/my-transformer
```

scripts/my-transformer
```
#!/usr/bin/python

import json
import sys

secrets_file = sys.argv[1]

with open(secrets_file) as f:
    secrets = json.load(f)

with open('secrets.properties', 'w') as f:
    f.write("DB_USER=" + secrets['secrets']['secret/data/dbuser']['data']['value'] + "\n")
    f.write("DB_PASS=" + secrets['secrets']['secret/data/dbpass']['data']['value'] + "\n")
```

Running:
```
$ python -m baseplate.sidecars.secrets_fetcher test_config.ini --once
2019-12-05 17:18:09,737:INFO:Running secret fetcher once
2019-12-05 17:18:09,738:INFO:Fetching secrets.
2019-12-05 17:18:09,744:INFO:Secrets fetched.
```

secrets.properties
```
DB_USER=reddit
DB_PASS=password
```