### PR TITLE
Add py.typed file to indicate we support type checking

### DIFF
--- a/baseplate/py.typed
+++ b/baseplate/py.typed
@@ -1,0 +1,1 @@
+# https://www.python.org/dev/peps/pep-0561/#packaging-type-information

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,10 @@ setup(
     ],
     # the thrift compiler must be able to find baseplate.thrift to build
     # services which extend BaseplateService.
-    package_data={"baseplate.thrift": ["*.thrift"]},
+    package_data={
+        "baseplate": ["py.typed"],
+        "baseplate.thrift": ["*.thrift"],
+    },
     zip_safe=False,
     entry_points={
         "distutils.commands": [


### PR DESCRIPTION
This is just a good citizenship thing. Apparently required per PEP-0561.

https://www.python.org/dev/peps/pep-0561/#packaging-type-information