### PR TITLE
Fix speed regression in thrift integration tests

### DIFF
--- a/tests/integration/thrift_tests.py
+++ b/tests/integration/thrift_tests.py
@@ -81,7 +81,9 @@ def serve_thrift(handler, server_span_observer=None):
     # bind a server socket on an available port
     server_bind_endpoint = config.Endpoint("127.0.0.1:0")
     listener = make_listener(server_bind_endpoint)
-    server = make_server({"max_concurrency": "100"}, listener, processor)
+    server = make_server(
+        {"max_concurrency": "100", "stop_timeout": "1 millisecond"}, listener, processor
+    )
 
     # figure out what port the server ended up on
     server_address = listener.getsockname()


### PR DESCRIPTION
This regressed in 86e9948ce3b041eb387ed494b53dd55692382e9d.

The test client pool leaves its connections open, so the test server
would wait around for the whole 10 second default stop timeout. By
setting a short timeout we can end the test much faster. The suite goes
from taking ~120 seconds to ~10 seconds (in CI the difference is ~6 minutes
 -> ~4.5 minutes because of the experiments)