### PR TITLE
Performance fixes

### DIFF
--- a/baseplate/lib/crypto.py
+++ b/baseplate/lib/crypto.py
@@ -155,15 +155,15 @@ def validate_signature(secret: VersionedSecret, message: str, signature: bytes) 
     except (struct.error, KeyError, binascii.Error, TypeError, ValueError):
         raise UnreadableSignatureError
 
+    if time.time() > expiration:
+        raise ExpiredSignatureError(expiration)
+
     for secret_value in secret.all_versions:
         digest = _compute_digest(secret_value, header, message)
         if hmac.compare_digest(digest, signature_digest):
             break
     else:
         raise IncorrectSignatureError
-
-    if time.time() > expiration:
-        raise ExpiredSignatureError(expiration)
 
     return SignatureInfo(version, expiration)
 

--- a/baseplate/lib/edge_context.py
+++ b/baseplate/lib/edge_context.py
@@ -48,7 +48,7 @@ class AuthenticationTokenValidator:
                 decoded = jwt.decode(token, public_key, algorithms="RS256")
                 return ValidatedAuthenticationToken(decoded)
             except jwt.ExpiredSignatureError:
-                pass
+                return InvalidAuthenticationToken()
             except jwt.DecodeError:
                 pass
 


### PR DESCRIPTION
Return error early at 2 places to improve performances:

1. In edge context, when the error is jwt.ExpiredSignatureError there's
   no point of trying the next version of public key.

2. In message signature verification, if the expiration timestamp is
   already in the past there's no point of calculating the digest and do
   the comparison.