### PR TITLE
Add avro producer and consumer to baseplate

### DIFF
--- a/baseplate/clients/kafka.py
+++ b/baseplate/clients/kafka.py
@@ -1,47 +1,48 @@
 import logging
+import time
 
 from typing import Any
 from typing import Dict
-from typing import Optional
+
+import confluent_kafka
 
 from confluent_kafka.avro import AvroProducer
+from confluent_kafka.avro import Producer
 
-from baseplate import _ExcInfo
 from baseplate import Span
-from baseplate import SpanObserver
 from baseplate.clients import ContextFactory
 from baseplate.lib import config
+
 
 logger = logging.getLogger(__name__)
 
 TOPIC_SUFFIX = "_avro"
+CHECK_INTERVAL_SECONDS = 0.001
 
 
 class AvroProducerContextFactory(ContextFactory):
     def __init__(self, bootstrap_servers: str, schema_registry: str, acks: int):
-        self.bootstrap_servers = bootstrap_servers
-        self.schema_registry = schema_registry
-        self.acks = acks
-
-    def make_object_for_context(self, name: str, span: Span) -> AvroProducer:
-        avro_producer = KafkaAvroProducer(
-            name,
-            span,
+        self.avro_producer = AvroProducer(
             {
-                "bootstrap.servers": self.bootstrap_servers,
-                "schema.registry.url": self.schema_registry,
-                "acks": self.acks,
-            },
+                "bootstrap.servers": bootstrap_servers,
+                "schema.registry.url": schema_registry,
+                "acks": acks,
+                # force sending 1 message at a time--don't wait for larger batches
+                "queue.buffering.max.ms": 0,
+                "max.in.flight": 1,
+            }
         )
-        span.register(AvroProducerSpanObserver(avro_producer))
-        return avro_producer
+
+    def make_object_for_context(self, name: str, span: Span) -> "KafkaAvroProducer":
+        return KafkaAvroProducer(name, span, self.avro_producer)
 
 
 class KafkaAvroProducer:
-    def __init__(self, name: str, span: Span, app_config: Dict[str, Any]):
+    def __init__(self, name: str, span: Span, avro_producer: AvroProducer):
         self.name = name
         self.span = span
-        self.avro_producer = AvroProducer(app_config)
+        self.avro_producer = avro_producer
+        self.initialized = False
 
     def produce(self, topic: str, schema_id: int, value: Dict[str, Any]) -> None:
         """Encode `value` using the `schema_id` and produce the message to Kafka.
@@ -53,31 +54,94 @@ class KafkaAvroProducer:
         :param value: object to serialize
 
         """
-        assert topic.endswith(TOPIC_SUFFIX)
+
+        if not topic.endswith(TOPIC_SUFFIX):
+            raise ValueError("Avro Producers must publish to topics ending with '_avro'")
+
+        if not self.initialized:
+            # make a metadata request, otherwise we'll have to do this on our
+            # first produce which can add up to 1s of extra latency
+            with self.span.make_child(f"{self.name}.avro_producer.list_topics"):
+                for _ in range(3):
+                    try:
+                        # list_topics() is a blocking call, so we have to use
+                        # a very short timeout and retry after a short sleep.
+                        self.avro_producer.list_topics(timeout=0.001)
+                        break
+                    except confluent_kafka.KafkaException:
+                        time.sleep(0.001)
+                else:
+                    logger.info("list_topics() failed after 3 attempts")
+
+            self.initialized = True
 
         serializer = self.avro_producer._serializer
 
-        with self.span.make_child(f"{self.name}.serializer.encode_record_with_schema_id"):
-            buffer = serializer.encode_record_with_schema_id(schema_id, value)
+        encode_trace_name = f"{self.name}.serializer.encode_record_with_schema_id"
+        encode_span = self.span.make_child(encode_trace_name)
 
-        with self.span.make_child(f"{self.name}.avro_producer.produce"):
-            super(AvroProducer, self.avro_producer).produce(topic=topic, value=buffer)  # type: ignore
+        with encode_span:
+            encoded = serializer.encode_record_with_schema_id(schema_id, value)
 
+        producer_trace_name = f"{self.name}.avro_producer.produce"
+        producer_span = self.span.make_child(producer_trace_name)
 
-class AvroProducerSpanObserver(SpanObserver):
-    """Automatically flush to kafka at the end of each request."""
+        # Producer.produce() is asynchronous so we have to jump through some
+        # hoops to get the result here at the call site.
+        delivery_result: Dict[str, Any] = dict(complete=False, error=None, message=None)
 
-    def __init__(self, kafka_avro_producer: KafkaAvroProducer):
-        self.avro_producer = kafka_avro_producer.avro_producer
+        def on_delivery(err: confluent_kafka.KafkaError, msg: confluent_kafka.Message) -> None:
+            delivery_result["error"] = err
+            delivery_result["message"] = msg
+            delivery_result["complete"] = True
 
-    def on_finish(self, exc_info: Optional[_ExcInfo]) -> None:
-        self.avro_producer.flush()
+        with producer_span:
+            # call the base class Producer.produce() method so we can do our own
+            # interactions with schema registry to avoid a bug where the schema
+            # can be re-registered.
+            Producer.produce(
+                self.avro_producer, topic=topic, value=encoded, on_delivery=on_delivery
+            )
+
+            self.avro_producer.flush(timeout=0)
+            while not delivery_result["complete"]:
+                # we can't use timeouts on the kafka consumer methods
+                # because they call out to C code that ends up blocking
+                # the event loop. gevent will successfully yield control
+                # on this sleep call though.
+                # see https://tech.wayfair.com/2018/07/blocking-io-in-gunicorn-gevent-workers/
+                logger.debug(  # pylint: disable=logging-too-many-args
+                    "waiting %s for pending message to flush", CHECK_INTERVAL_SECONDS
+                )
+                time.sleep(CHECK_INTERVAL_SECONDS)
+                self.avro_producer.flush(timeout=0)
+
+        if delivery_result["error"]:
+            error = delivery_result["error"]
+            raise ValueError(f"KafkaError: {error.str()}")
+
+        message = delivery_result["message"]
+
+        if not message:
+            raise ValueError("Unexpected message delivery failure")
+
+        logger.debug(  # pylint: disable=logging-too-many-args
+            "message delivered (topic: %s, partition: %s, offset: %s)",
+            message.topic(),
+            message.partition(),
+            message.offset(),
+        )
 
 
 def avro_producer_from_config(
-    app_config: config.RawConfig, prefix: str = "application_kafka."
+    app_config: config.RawConfig, prefix: str
 ) -> AvroProducerContextFactory:
-    """Make an avro producer context factory from a configuration dictionary."""
+    """Make an avro producer context factory from a configuration dictionary.
+
+    :param app_config: The raw configuration information.
+    :param prefix: The name of the kafka cluster to publish messages to.
+
+    """
     assert prefix.endswith(".")
 
     parser = config.SpecParser(

--- a/baseplate/frameworks/queue_consumer/kafka.py
+++ b/baseplate/frameworks/queue_consumer/kafka.py
@@ -15,7 +15,7 @@ from typing import Union
 
 import confluent_kafka
 
-from confluent_kafka.avro import AvroConsumer  # pylint: disable=unused-import
+from confluent_kafka.avro import AvroConsumer  # noqa pylint: disable=unused-import
 from gevent.server import StreamServer
 
 from baseplate import Baseplate

--- a/baseplate/frameworks/queue_consumer/kafka.py
+++ b/baseplate/frameworks/queue_consumer/kafka.py
@@ -11,6 +11,7 @@ from typing import List
 from typing import Optional
 from typing import Sequence
 from typing import TYPE_CHECKING
+from typing import Union
 
 import confluent_kafka
 
@@ -167,6 +168,67 @@ class KafkaMessageHandler(MessageHandler):
             raise
 
 
+def validate_group_id(name: str, group_id: str) -> None:
+    service_name, _, group_name = group_id.partition(".")
+    assert service_name and group_name, "group_id must start with 'SERVICENAME.'"
+    assert name == f"kafka_consumer.{group_name}"
+
+
+def make_kafka_consumer(
+    bootstrap_servers: str,
+    group_id: str,
+    topics: Sequence[str],
+    schema_registry: Optional[str] = None,
+) -> Union[confluent_kafka.Consumer, confluent_kafka.avro.AvroConsumer]:
+    consumer_config = {
+        "bootstrap.servers": bootstrap_servers,
+        "group.id": group_id,
+        # reset the offset to the latest offset when no stored offset exists.
+        # this means that when a new consumer group is created it will only
+        # process new messages.
+        "auto.offset.reset": "latest",
+    }
+
+    if schema_registry:
+        consumer_config["schema.registry.url"] = schema_registry
+        consumer = confluent_kafka.avro.AvroConsumer(consumer_config)
+    else:
+        consumer = confluent_kafka.Consumer(consumer_config)
+
+    try:
+        # we can allow a blocking timeout here because there is only one
+        # consumer for the entire server
+        metadata = consumer.list_topics(timeout=10)
+    except confluent_kafka.KafkaException:
+        logger.error("failed getting metadata from %s, exiting.", bootstrap_servers)
+        raise
+
+    all_topics = set(metadata.topics.keys())
+    for topic in topics:
+        assert (
+            topic in all_topics
+        ), f"topic '{topic}' does not exist. maybe it's misspelled or on a different kafka cluster?"
+
+    # pylint: disable=unused-argument
+    def log_assign(
+        consumer: Union[confluent_kafka.Consumer, confluent_kafka.avro.AvroConsumer],
+        partitions: List[confluent_kafka.TopicPartition],
+    ) -> None:
+        for topic_partition in partitions:
+            logger.info("assigned %s/%s", topic_partition.topic, topic_partition.partition)
+
+    # pylint: disable=unused-argument
+    def log_revoke(
+        consumer: Union[confluent_kafka.Consumer, confluent_kafka.avro.AvroConsumer],
+        partitions: List[confluent_kafka.TopicPartition],
+    ) -> None:
+        for topic_partition in partitions:
+            logger.info("revoked %s/%s", topic_partition.topic, topic_partition.partition)
+
+    consumer.subscribe(topics, on_assign=log_assign, on_revoke=log_revoke)
+    return consumer
+
+
 class _BaseKafkaQueueConsumerFactory(QueueConsumerFactory):
     def __init__(
         self,
@@ -212,8 +274,9 @@ class _BaseKafkaQueueConsumerFactory(QueueConsumerFactory):
         topics: Sequence[str],
         handler_fn: Handler,
         kafka_consume_batch_size: int = 1,
-        message_unpack_fn: KafkaMessageDeserializer = json.loads,
+        message_unpack_fn: Optional[KafkaMessageDeserializer] = None,
         health_check_fn: Optional[HealthcheckCallback] = None,
+        schema_registry: Optional[str] = None,
     ) -> "_BaseKafkaQueueConsumerFactory":
         """Return a new `_BaseKafkaQueueConsumerFactory`.
 
@@ -235,17 +298,22 @@ class _BaseKafkaQueueConsumerFactory(QueueConsumerFactory):
         :param kafka_consume_batch_size: The number of messages the `KafkaConsumerWorker`
             reads from Kafka in each batch. Defaults to 1.
         :param message_unpack_fn: A function that takes one argument, the `bytes` message body
-            and returns the message in the format the handler expects. Defaults to `json.loads`.
+            and returns the message in the format the handler expects. If no input is provided,
+            a function is automatically picked one based on whether a schema_registry was provided or not.
         :param health_check_fn: A `baseplate.server.queue_consumer.HealthcheckCallback`
             function that can be used to customize your health check.
+        :param schema_registry: Schema Registry where the schemas of the Avro messages are stored
 
         """
 
-        service_name, _, group_name = group_id.partition(".")
-        assert service_name and group_name, "group_id must start with 'SERVICENAME.'"
-        assert name == f"kafka_consumer.{group_name}"
+        validate_group_id(name, group_id)
+        consumer = make_kafka_consumer(bootstrap_servers, group_id, topics, schema_registry)
 
-        consumer = cls.make_kafka_consumer(bootstrap_servers, group_id, topics)
+        if message_unpack_fn is None:
+            if schema_registry:
+                message_unpack_fn = consumer._serializer.decode_message
+            else:
+                message_unpack_fn = json.loads
 
         return cls(
             name=name,
@@ -260,52 +328,6 @@ class _BaseKafkaQueueConsumerFactory(QueueConsumerFactory):
     @classmethod
     def _consumer_config(cls) -> Dict[str, Any]:
         raise NotImplementedError
-
-    @classmethod
-    def make_kafka_consumer(
-        cls, bootstrap_servers: str, group_id: str, topics: Sequence[str]
-    ) -> confluent_kafka.Consumer:
-        consumer_config = {
-            "bootstrap.servers": bootstrap_servers,
-            "group.id": group_id,
-            # reset the offset to the latest offset when no stored offset exists.
-            # this means that when a new consumer group is created it will only
-            # process new messages.
-            "auto.offset.reset": "latest",
-        }
-        consumer_config.update(cls._consumer_config())
-        consumer = confluent_kafka.Consumer(consumer_config)
-
-        try:
-            # we can allow a blocking timeout here because there is only one
-            # consumer for the entire server
-            metadata = consumer.list_topics(timeout=10)
-        except confluent_kafka.KafkaException:
-            logger.error("failed getting metadata from %s, exiting.", bootstrap_servers)
-            raise
-
-        all_topics = set(metadata.topics.keys())
-        for topic in topics:
-            assert (
-                topic in all_topics
-            ), f"topic '{topic}' does not exist. maybe it's misspelled or on a different kafka cluster?"
-
-        # pylint: disable=unused-argument
-        def log_assign(
-            consumer: confluent_kafka.Consumer, partitions: List[confluent_kafka.TopicPartition]
-        ) -> None:
-            for topic_partition in partitions:
-                logger.info("assigned %s/%s", topic_partition.topic, topic_partition.partition)
-
-        # pylint: disable=unused-argument
-        def log_revoke(
-            consumer: confluent_kafka.Consumer, partitions: List[confluent_kafka.TopicPartition]
-        ) -> None:
-            for topic_partition in partitions:
-                logger.info("revoked %s/%s", topic_partition.topic, topic_partition.partition)
-
-        consumer.subscribe(topics, on_assign=log_assign, on_revoke=log_revoke)
-        return consumer
 
     def build_pump_worker(self, work_queue: WorkQueue) -> KafkaConsumerWorker:
         return KafkaConsumerWorker(

--- a/baseplate/frameworks/queue_producer/avro_kafka.py
+++ b/baseplate/frameworks/queue_producer/avro_kafka.py
@@ -1,0 +1,97 @@
+import logging
+
+from typing import Any
+from typing import Dict
+from typing import Optional
+
+from confluent_kafka.avro import AvroProducer
+
+from baseplate import _ExcInfo
+from baseplate import Span
+from baseplate import SpanObserver
+from baseplate.clients import ContextFactory
+from baseplate.lib import config
+
+logger = logging.getLogger(__name__)
+
+
+class AvroProducerContextFactory(ContextFactory):
+    def __init__(self, bootstrap_servers: str, schema_registry: str, acks: int):
+        self.bootstrap_servers = bootstrap_servers
+        self.schema_registry = schema_registry
+        self.acks = acks
+
+    def make_object_for_context(self, name: str, span: Span) -> AvroProducer:
+        avro_producer = KafkaAvroProducer(
+            name,
+            span,
+            {
+                "bootstrap.servers": self.bootstrap_servers,
+                "schema.registry.url": self.schema_registry,
+                "acks": self.acks,
+            },
+        )
+        span.register(AvroProducerSpanObserver(avro_producer))
+        return avro_producer
+
+
+class KafkaAvroProducer:
+    def __init__(self, name: str, span: Span, app_config: Dict[str, Any]):
+        self.name = name
+        self.span = span
+        self.avro_producer = AvroProducer(app_config)
+
+    def produce(self, topic: str, schema_id: int, value: Dict[str, Any]) -> None:
+        """Encode `value` using the `schema_id` and produce the message to Kafka.
+
+        :param topic: topic name
+        :param schema_id: schema id associated with the schema that `value` conforms to. It will
+                          be used to look up the schema from Schema Registry. This prevents callers
+                          from using unregistered schemas
+       :param value: object to serialize
+
+        """
+        serializer = self.avro_producer._serializer
+
+        encode_trace_name = "{}.{}".format(self.name, "serializer.encode_record_with_schema_id")
+        encode_span = self.span.make_child(encode_trace_name)
+
+        with encode_span:
+            buffer = serializer.encode_record_with_schema_id(schema_id, value)
+
+        producer_trace_name = "{}.{}".format(self.name, "avro_producer.produce")
+        producer_span = self.span.make_child(producer_trace_name)
+
+        producer = super(AvroProducer, self.avro_producer)  # pylint: disable=bad-super-call;
+        with producer_span:
+            producer.produce(topic=topic, value=buffer)  # type: ignore
+
+
+class AvroProducerSpanObserver(SpanObserver):
+    """Automatically flush to kafka at the end of each request."""
+
+    def __init__(self, kafka_avro_producer: KafkaAvroProducer):
+        self.avro_producer = kafka_avro_producer.avro_producer
+
+    def on_finish(self, exc_info: Optional[_ExcInfo]) -> None:
+        self.avro_producer.flush()
+
+
+def avro_producer_from_config(
+    app_config: config.RawConfig, prefix: str = "application_kafka."
+) -> AvroProducerContextFactory:
+    """Make an avro producer context factory from a configuration dictionary."""
+    assert prefix.endswith(".")
+
+    parser = config.SpecParser(
+        {
+            "bootstrap_servers": config.String,
+            "schema_registry": config.String,
+            "acks": config.Integer,
+        }
+    )
+    options = parser.parse(prefix[:-1], app_config)
+
+    return AvroProducerContextFactory(
+        options.bootstrap_servers, options.schema_registry, options.acks
+    )

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -14,7 +14,7 @@ cassandra-driver==3.17.0
 certifi==2019.3.9
 cffi==1.11.5
 chardet==3.0.4
-confluent-kafka==1.1
+confluent-kafka==1.3
 coverage==4.5.2
 cqlmapper==0.1.0
 cryptography==2.4.2

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -8,6 +8,7 @@ asn1crypto==0.24.0
 astroid==2.3.3
 atomicwrites==1.3.0
 attrs==18.2.0
+avro_python3==1.9.1
 beautifulsoup4==4.6.3
 cassandra-driver==3.17.0
 certifi==2019.3.9

--- a/tests/unit/clients/kafka_tests.py
+++ b/tests/unit/clients/kafka_tests.py
@@ -14,6 +14,7 @@ from baseplate.lib.config import ConfigurationError
 from ... import does_not_raise
 
 
+@mock.patch.object(AvroProducerContextFactory, "initialize")
 @pytest.mark.parametrize(
     "_app_config,kwargs,expectation,expected",
     [
@@ -36,17 +37,10 @@ from ... import does_not_raise
         (
             {
                 "application_kafka.bootstrap_servers": "127.0.0.1:9092",
-                "application_kafka.schema.registry.url": "http://127.0.0.1:8081",
-            },
-            {},
-            pytest.raises(ConfigurationError),
-            {},
-        ),
-        (
-            {
-                "application_kafka.bootstrap_servers": "127.0.0.1:9092",
                 "application_kafka.schema_registry": "http://127.0.0.1:8081",
                 "application_kafka.acks": "-1",
+                "application_kafka.threadpool_size": "1",
+                "application_kafka.prefetch_schema_ids": "1",
             },
             {},
             does_not_raise(),
@@ -54,7 +48,7 @@ from ... import does_not_raise
         ),
     ],
 )
-def test_avro_producer_from_config(_app_config, kwargs, expectation, expected):
+def test_avro_producer_from_config(initailize_fn, _app_config, kwargs, expectation, expected):
     with expectation:
         connection = avro_producer_from_config(_app_config, prefix="application_kafka.", **kwargs)
     for attr, value in expected.items():
@@ -111,7 +105,10 @@ APP_CONFIG = {
 
 
 class TestAvroProducerContextFactory:
-    def test_avro_producer_from_config(self, bootstrap_servers, schema_registry, acks):
+    @mock.patch.object(AvroProducerContextFactory, "initialize")
+    def test_avro_producer_from_config(
+        self, intialize_fn, bootstrap_servers, schema_registry, acks
+    ):
         factory = avro_producer_from_config(APP_CONFIG, prefix="application_kafka.")
         assert isinstance(factory, AvroProducerContextFactory)
         assert isinstance(factory.avro_producer, AvroProducer)
@@ -120,20 +117,23 @@ class TestAvroProducerContextFactory:
         with pytest.raises(AssertionError):
             avro_producer_from_config(APP_CONFIG, prefix="app")
 
+    @mock.patch.object(AvroProducerContextFactory, "initialize")
     def test_avro_producer_context_factory_init(
-        self, name, span, bootstrap_servers, schema_registry, acks
+        self, intialize_fn, name, span, bootstrap_servers, schema_registry, acks
     ):
         factory = AvroProducerContextFactory(bootstrap_servers, schema_registry, acks)
         kafka_avro_producer = factory.make_object_for_context(name, span)
         assert kafka_avro_producer.name == name
         assert kafka_avro_producer.span == span
-        assert kafka_avro_producer.initialized is False
+        intialize_fn.assert_called_once_with(factory.threadpool, [])
         assert isinstance(kafka_avro_producer, KafkaAvroProducer)
         assert isinstance(kafka_avro_producer.avro_producer, AvroProducer)
+        assert isinstance(factory.last_initialized_at, float)
 
+    @mock.patch.object(AvroProducerContextFactory, "initialize")
     @mock.patch.object(KafkaAvroProducer, "produce")
     def test_kafka_avro_producer_produce(
-        self, name, span, bootstrap_servers, schema_registry, acks
+        self, produce_fn, initialize_fn, name, span, bootstrap_servers, schema_registry, acks
     ):
         factory = AvroProducerContextFactory(bootstrap_servers, schema_registry, acks)
         _kafka_avro_producer = factory.make_object_for_context(name, span)
@@ -144,8 +144,9 @@ class TestAvroProducerContextFactory:
             topic="topic_1_avro", schema_id=1, value={"endpoint_timestamp": 1500079}
         )
 
+    @mock.patch.object(AvroProducerContextFactory, "initialize")
     def test_kafka_avro_producer_produce_bad_topic(
-        self, name, span, bootstrap_servers, schema_registry, acks
+        self, initialize_fn, name, span, bootstrap_servers, schema_registry, acks
     ):
 
         factory = AvroProducerContextFactory(bootstrap_servers, schema_registry, acks)
@@ -155,11 +156,13 @@ class TestAvroProducerContextFactory:
                 topic="topic_1", schema_id=1, value={"endpoint_timestamp": 1500079}
             )
 
+    @mock.patch.object(AvroProducerContextFactory, "initialize")
     @mock.patch("baseplate.clients.kafka.Producer")
-    def test_producer_produce(self, mock_producer, topic, schema_id, schema_value, name, span):
+    def test_producer_produce(
+        self, mock_producer, initialize_fn, topic, schema_id, schema_value, name, span
+    ):
         _avro_producer = mock.Mock()
         kafka_avro_producer = KafkaAvroProducer(name, span, _avro_producer)
-        assert kafka_avro_producer.initialized is False
 
         mock_producer.produce.side_effect = ValueError
         with pytest.raises(ValueError):
@@ -168,14 +171,4 @@ class TestAvroProducerContextFactory:
 
         kafka_avro_producer.avro_producer._serializer.encode_record_with_schema_id.assert_called_once_with(
             schema_id, schema_value
-        )
-        kafka_avro_producer.avro_producer.list_topics.assert_called_once()
-        assert kafka_avro_producer.initialized is True
-        span.make_child.assert_has_calls(
-            [
-                mock.call(f"{kafka_avro_producer.name}.avro_producer.list_topics"),
-                mock.call(f"{kafka_avro_producer.name}.serializer.encode_record_with_schema_id"),
-                mock.call(f"{kafka_avro_producer.name}.avro_producer.produce"),
-            ],
-            any_order=True,
         )

--- a/tests/unit/clients/kafka_tests.py
+++ b/tests/unit/clients/kafka_tests.py
@@ -1,0 +1,181 @@
+from unittest import mock
+
+import pytest
+
+from confluent_kafka.avro import AvroProducer  # noqa pylint: disable=unused-import
+from confluent_kafka.avro import Producer  # noqa pylint: disable=unused-import
+
+from baseplate import ServerSpan
+from baseplate.clients.kafka import avro_producer_from_config
+from baseplate.clients.kafka import AvroProducerContextFactory
+from baseplate.clients.kafka import KafkaAvroProducer
+from baseplate.lib.config import ConfigurationError
+
+from ... import does_not_raise
+
+
+@pytest.mark.parametrize(
+    "_app_config,kwargs,expectation,expected",
+    [
+        ({}, {}, pytest.raises(ConfigurationError), {}),
+        (
+            {"application_kafka.bootstrap_servers": "127.0.0.1:9092"},
+            {},
+            pytest.raises(ConfigurationError),
+            {},
+        ),
+        (
+            {
+                "application_kafka.bootstrap_servers": "127.0.0.1:9092",
+                "application_kafka.schema.registry.url": "http://127.0.0.1:8081",
+            },
+            {},
+            pytest.raises(ConfigurationError),
+            {},
+        ),
+        (
+            {
+                "application_kafka.bootstrap_servers": "127.0.0.1:9092",
+                "application_kafka.schema.registry.url": "http://127.0.0.1:8081",
+            },
+            {},
+            pytest.raises(ConfigurationError),
+            {},
+        ),
+        (
+            {
+                "application_kafka.bootstrap_servers": "127.0.0.1:9092",
+                "application_kafka.schema_registry": "http://127.0.0.1:8081",
+                "application_kafka.acks": "-1",
+            },
+            {},
+            does_not_raise(),
+            {},
+        ),
+    ],
+)
+def test_avro_producer_from_config(_app_config, kwargs, expectation, expected):
+    with expectation:
+        connection = avro_producer_from_config(_app_config, prefix="application_kafka.", **kwargs)
+    for attr, value in expected.items():
+        assert getattr(connection, attr) == value
+
+
+@pytest.fixture
+def span():
+    sp = mock.MagicMock(spec=ServerSpan)
+    sp.make_child().__enter__.return_value = mock.MagicMock()
+    return sp
+
+
+@pytest.fixture
+def name():
+    return "test_producer_avro"
+
+
+@pytest.fixture
+def bootstrap_servers():
+    return "127.0.0.1:9092"
+
+
+@pytest.fixture
+def schema_registry():
+    return "http://127.0.0.1:8081"
+
+
+@pytest.fixture
+def acks():
+    return "-1"
+
+
+@pytest.fixture
+def topic():
+    return "topic_1_avro"
+
+
+@pytest.fixture
+def schema_id():
+    return 1
+
+
+@pytest.fixture
+def schema_value():
+    return {"endpoint_timestamp": 1500079}
+
+
+APP_CONFIG = {
+    "application_kafka.bootstrap_servers": "127.0.0.1:9092",
+    "application_kafka.schema_registry": "http://127.0.0.1:8081",
+    "application_kafka.acks": "-1",
+}
+
+
+class TestAvroProducerContextFactory:
+    def test_avro_producer_from_config(self, bootstrap_servers, schema_registry, acks):
+        factory = avro_producer_from_config(APP_CONFIG, prefix="application_kafka.")
+        assert isinstance(factory, AvroProducerContextFactory)
+        assert isinstance(factory.avro_producer, AvroProducer)
+
+    def test_avro_producer_from_config_bad_prefix(self, bootstrap_servers, schema_registry, acks):
+        with pytest.raises(AssertionError):
+            avro_producer_from_config(APP_CONFIG, prefix="app")
+
+    def test_avro_producer_context_factory_init(
+        self, name, span, bootstrap_servers, schema_registry, acks
+    ):
+        factory = AvroProducerContextFactory(bootstrap_servers, schema_registry, acks)
+        kafka_avro_producer = factory.make_object_for_context(name, span)
+        assert kafka_avro_producer.name == name
+        assert kafka_avro_producer.span == span
+        assert kafka_avro_producer.initialized is False
+        assert isinstance(kafka_avro_producer, KafkaAvroProducer)
+        assert isinstance(kafka_avro_producer.avro_producer, AvroProducer)
+
+    @mock.patch.object(KafkaAvroProducer, "produce")
+    def test_kafka_avro_producer_produce(
+        self, name, span, bootstrap_servers, schema_registry, acks
+    ):
+        factory = AvroProducerContextFactory(bootstrap_servers, schema_registry, acks)
+        _kafka_avro_producer = factory.make_object_for_context(name, span)
+        _kafka_avro_producer.produce(
+            topic="topic_1_avro", schema_id=1, value={"endpoint_timestamp": 1500079}
+        )
+        _kafka_avro_producer.produce.assert_called_once_with(
+            topic="topic_1_avro", schema_id=1, value={"endpoint_timestamp": 1500079}
+        )
+
+    def test_kafka_avro_producer_produce_bad_topic(
+        self, name, span, bootstrap_servers, schema_registry, acks
+    ):
+
+        factory = AvroProducerContextFactory(bootstrap_servers, schema_registry, acks)
+        _kafka_avro_producer = factory.make_object_for_context(name, span)
+        with pytest.raises(ValueError):
+            _kafka_avro_producer.produce(
+                topic="topic_1", schema_id=1, value={"endpoint_timestamp": 1500079}
+            )
+
+    @mock.patch("baseplate.clients.kafka.Producer")
+    def test_producer_produce(self, mock_producer, topic, schema_id, schema_value, name, span):
+        _avro_producer = mock.Mock()
+        kafka_avro_producer = KafkaAvroProducer(name, span, _avro_producer)
+        assert kafka_avro_producer.initialized is False
+
+        mock_producer.produce.side_effect = ValueError
+        with pytest.raises(ValueError):
+            kafka_avro_producer.produce(topic, schema_id, schema_value)
+        mock_producer.produce.assert_called_once()
+
+        kafka_avro_producer.avro_producer._serializer.encode_record_with_schema_id.assert_called_once_with(
+            schema_id, schema_value
+        )
+        kafka_avro_producer.avro_producer.list_topics.assert_called_once()
+        assert kafka_avro_producer.initialized is True
+        span.make_child.assert_has_calls(
+            [
+                mock.call(f"{kafka_avro_producer.name}.avro_producer.list_topics"),
+                mock.call(f"{kafka_avro_producer.name}.serializer.encode_record_with_schema_id"),
+                mock.call(f"{kafka_avro_producer.name}.avro_producer.produce"),
+            ],
+            any_order=True,
+        )

--- a/tests/unit/frameworks/queue_consumer/kafka_tests.py
+++ b/tests/unit/frameworks/queue_consumer/kafka_tests.py
@@ -397,7 +397,9 @@ class TestFastConsumerFactory:
         )
         kafka_consumer.return_value = mock_consumer
 
-        _consumer = FastConsumerFactory.make_kafka_consumer(bootstrap_servers, group_id, topics)
+        _consumer = FastConsumerFactory.new(
+            name, baseplate, bootstrap_servers, group_id, topics, mock.Mock()
+        ).consumer
 
         assert _consumer == mock_consumer
 
@@ -429,7 +431,9 @@ class TestFastConsumerFactory:
         kafka_consumer.return_value = mock_consumer
 
         with pytest.raises(AssertionError):
-            FastConsumerFactory.make_kafka_consumer(bootstrap_servers, group_id, ["topic_4"])
+            FastConsumerFactory.new(
+                name, baseplate, bootstrap_servers, group_id, ["topic_4"], mock.Mock()
+            )
 
         kafka_consumer.assert_called_once_with(
             {


### PR DESCRIPTION
This moves the avro consumer and producer code into baseplate service for access to all services. Matches code live in Thing Service now.