### PR TITLE
Convert boolean span tags to strings

### DIFF
--- a/baseplate/observers/tracing.py
+++ b/baseplate/observers/tracing.py
@@ -258,7 +258,7 @@ class TraceSpanObserver(SpanObserver):
         endpoint_info = self._endpoint_info()
 
         # Annotation values must be str type.
-        if isinstance(bool):
+        if isinstance(annotation_value, bool):
             # only "lower" bool values so we aren't affecting any other types
             annotation_value = str(annotation_value).lower()
         elif not isinstance(annotation_value, str):

--- a/baseplate/observers/tracing.py
+++ b/baseplate/observers/tracing.py
@@ -257,9 +257,9 @@ class TraceSpanObserver(SpanObserver):
         """
         endpoint_info = self._endpoint_info()
 
-        # Annotation values must be bool or str type.
-        if not isinstance(annotation_value, (bool, str)):
-            annotation_value = str(annotation_value)
+        # Annotation values must be str type.
+        if not isinstance(annotation_value, str):
+            annotation_value = str(annotation_value).lower()
 
         return {"key": annotation_type, "value": annotation_value, "endpoint": endpoint_info}
 

--- a/baseplate/observers/tracing.py
+++ b/baseplate/observers/tracing.py
@@ -258,8 +258,11 @@ class TraceSpanObserver(SpanObserver):
         endpoint_info = self._endpoint_info()
 
         # Annotation values must be str type.
-        if not isinstance(annotation_value, str):
+        if isinstance(bool):
+            # only "lower" bool values so we aren't affecting any other types
             annotation_value = str(annotation_value).lower()
+        if not isinstance(annotation_value, str):
+            annotation_value = str(annotation_value)
 
         return {"key": annotation_type, "value": annotation_value, "endpoint": endpoint_info}
 

--- a/baseplate/observers/tracing.py
+++ b/baseplate/observers/tracing.py
@@ -261,7 +261,7 @@ class TraceSpanObserver(SpanObserver):
         if isinstance(bool):
             # only "lower" bool values so we aren't affecting any other types
             annotation_value = str(annotation_value).lower()
-        if not isinstance(annotation_value, str):
+        elif not isinstance(annotation_value, str):
             annotation_value = str(annotation_value)
 
         return {"key": annotation_type, "value": annotation_value, "endpoint": endpoint_info}

--- a/tests/unit/observers/tracing_tests.py
+++ b/tests/unit/observers/tracing_tests.py
@@ -207,7 +207,7 @@ class TraceSpanObserverTests(TraceTestBase):
                 debug_annotation = annotation
                 break
         self.assertIsNotNone(debug_annotation)
-        self.assertTrue(debug_annotation["value"])
+        self.assertEqual(debug_annotation["value"], "true")
 
     def test_on_finish_sets_error_annotation(self):
         self.assertIsNone(self.test_span_observer.end)
@@ -219,7 +219,7 @@ class TraceSpanObserverTests(TraceTestBase):
                 error_annotation = annotation
                 break
         self.assertIsNotNone(error_annotation)
-        self.assertTrue(error_annotation["value"])
+        self.assertEqual(error_annotation["value"], "true")
 
     def test_create_binary_annotation(self):
         annotation = self.test_span_observer._create_binary_annotation("test-key", "test-value")


### PR DESCRIPTION
Our current system for storing trace data only supports string values for binary annotations so we want to also encode boolean values as lower case strings.