### PR TITLE
Add file-age-watcher that monitors the age of files

### DIFF
--- a/baseplate/sidecars/file_age_watcher.py
+++ b/baseplate/sidecars/file_age_watcher.py
@@ -34,7 +34,7 @@ def main() -> NoReturn:
     parser = configparser.RawConfigParser()
     parser.read(args.config_file.name)
     watcher_config = dict(parser.items("file-age-watcher"))
-    cfg = config.parse_config(watcher_config, {"file": config.DictOf({"dest": config.String})})
+    cfg = config.parse_config(watcher_config, {"file": config.DictOf({"path": config.String})})
 
     metrics_client = metrics_client_from_config(watcher_config)
     while True:
@@ -42,7 +42,7 @@ def main() -> NoReturn:
         now = time.time()
         for name, file in cfg.file.items():
             try:
-                mtime = os.path.getmtime(file.dest)
+                mtime = os.path.getmtime(file.path)
             except OSError:
                 mtime = 0
 

--- a/baseplate/sidecars/file_age_watcher.py
+++ b/baseplate/sidecars/file_age_watcher.py
@@ -1,0 +1,54 @@
+"""Calculate the age of files sync'd to disk by the baseplate live-data watcher.
+
+The watcher periodically updates the mtime even if data hasn't changed, so we
+can alert on excessive age as an indication that data sync isn't working.
+"""
+import argparse
+import configparser
+import os
+import sys
+import time
+
+from typing import NoReturn
+
+from baseplate import config
+from baseplate.lib.metrics import metrics_client_from_config
+
+
+HEARTBEAT_INTERVAL = 10
+
+
+def main() -> NoReturn:
+    """
+    Sidecar that tracks the age of the file monitored by live-data watcher and secrets fetcher.
+
+    Use this with live_data_watcher and secrets_fetcher to monitor their files and ensure that
+    these sidecars are not failing silently.
+    """
+    arg_parser = argparse.ArgumentParser(description=sys.modules[__name__].__doc__)
+    arg_parser.add_argument(
+        "config_file", type=argparse.FileType("r"), help="path to a configuration file"
+    )
+    args = arg_parser.parse_args()
+
+    parser = configparser.RawConfigParser()
+    parser.read(args.config_file.name)
+    watcher_config = dict(parser.items("file-age-watcher"))
+    cfg = config.parse_config(watcher_config, {"file": config.DictOf({"dest": config.String})})
+
+    metrics_client = metrics_client_from_config(watcher_config)
+    while True:
+        time.sleep(HEARTBEAT_INTERVAL)
+        now = time.time()
+        for name, file in cfg.file.items():
+            try:
+                mtime = os.path.getmtime(file.dest)
+            except OSError:
+                mtime = 0
+
+            age = now - mtime
+            metrics_client.histogram(f"file-age-watcher.{name}.age").add_sample(age)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This expects a file with configs of:
``file.<name>.dest = <file_location>``

So ideally, the files that you're watching from live-data and secrets fetcher are put in here as entries;


This script will run as a sidecar with all N pods from reddit-service-listing ( or any other service ) and based on the config, it will get the age of the file and send to metrics backend as a histogram.


From here, we can figure out if at least one of the N pods contains a stale file. From here, alert that live-data-fetcher may be faulty.