### PR TITLE
Add options to let redis-py decode strings

### DIFF
--- a/baseplate/clients/redis.py
+++ b/baseplate/clients/redis.py
@@ -171,6 +171,8 @@ class MonitoredRedisConnection(redis.StrictRedis):
         if decode_responses is not None:
             superkwargs['decode_responses'] = decode_responses
 
+        print(superkwargs)
+
         super().__init__(
             connection_pool=connection_pool,
             **superkwargs,

--- a/baseplate/clients/redis.py
+++ b/baseplate/clients/redis.py
@@ -163,20 +163,17 @@ class MonitoredRedisConnection(redis.StrictRedis):
         self.context_name = context_name
         self.server_span = server_span
 
-        superkwargs = {}
+        kwargs = {}
         if encoding is not None:
-            superkwargs['encoding'] = encoding
+            kwargs["encoding"] = encoding
         if encoding_errors is not None:
-            superkwargs['encoding_errors'] = encoding_errors
+            kwargs["encoding_errors"] = encoding_errors
         if decode_responses is not None:
-            superkwargs['decode_responses'] = decode_responses
+            kwargs["decode_responses"] = decode_responses
 
-        print(superkwargs)
+        print(kwargs)
 
-        super().__init__(
-            connection_pool=connection_pool,
-            **superkwargs,
-        )
+        super().__init__(connection_pool=connection_pool, **kwargs)
 
     def execute_command(self, *args: Any, **kwargs: Any) -> Any:
         command = args[0]

--- a/baseplate/clients/redis.py
+++ b/baseplate/clients/redis.py
@@ -73,8 +73,8 @@ class RedisClient(config.Parser):
     :param encoding: String encoding for given bytes. Default is '`utf-8`'
     See :py:func:`bytes.decode` for more info.
 
-    :param encoding_errors: Default for errors is '`strict`' meaning errors will 
-    raise a `UnicodeError`. See :py:func:`bytes.decode` for more info. 
+    :param encoding_errors: Default for errors is '`strict`' meaning errors will
+    raise a `UnicodeError`. See :py:func:`bytes.decode` for more info.
     """
 
     def __init__(

--- a/baseplate/clients/redis.py
+++ b/baseplate/clients/redis.py
@@ -163,11 +163,17 @@ class MonitoredRedisConnection(redis.StrictRedis):
         self.context_name = context_name
         self.server_span = server_span
 
+        superkwargs = {}
+        if encoding is not None:
+            superkwargs['encoding'] = encoding
+        if encoding_errors is not None:
+            superkwargs['encoding_errors'] = encoding_errors
+        if decode_responses is not None:
+            superkwargs['decode_responses'] = decode_responses
+
         super().__init__(
             connection_pool=connection_pool,
-            encoding=encoding,
-            encoding_errors=encoding_errors,
-            decode_responses=decode_responses,
+            **superkwargs,
         )
 
     def execute_command(self, *args: Any, **kwargs: Any) -> Any:

--- a/tests/integration/redis_tests.py
+++ b/tests/integration/redis_tests.py
@@ -76,7 +76,8 @@ class RedisDecodingIntegrationTests(unittest.TestCase):
     def setUp(self):
         baseplate = Baseplate()
         baseplate.configure_context(
-            {"redis.url": f"redis://{redis_endpoint}/0"}, {"redis": RedisClient(decode_responses=True)}
+            {"redis.url": f"redis://{redis_endpoint}/0"}, 
+            {"redis": RedisClient(decode_responses=True)},
         )
 
         self.context = baseplate.make_context_object()

--- a/tests/integration/redis_tests.py
+++ b/tests/integration/redis_tests.py
@@ -81,6 +81,7 @@ class RedisDecodingIntegrationTests(unittest.TestCase):
         )
 
         self.context = baseplate.make_context_object()
+        self.server_span = baseplate.make_server_span(self.context, "test")
 
     def test_put_get(self):
         context_redis: MonitoredRedisConnection = self.context.redis

--- a/tests/integration/redis_tests.py
+++ b/tests/integration/redis_tests.py
@@ -76,7 +76,7 @@ class RedisDecodingIntegrationTests(unittest.TestCase):
     def setUp(self):
         baseplate = Baseplate()
         baseplate.configure_context(
-            {"redis.url": f"redis://{redis_endpoint}/0"}, 
+            {"redis.url": f"redis://{redis_endpoint}/0"},
             {"redis": RedisClient(decode_responses=True)},
         )
 

--- a/tests/integration/redis_tests.py
+++ b/tests/integration/redis_tests.py
@@ -71,7 +71,7 @@ class RedisIntegrationTests(unittest.TestCase):
 
 
 class RedisDecodingIntegrationTests(unittest.TestCase):
-    qname = "redisTestDecode"
+    test_field = "redisTestDecode"
 
     def setUp(self):
         baseplate = Baseplate()
@@ -83,12 +83,21 @@ class RedisDecodingIntegrationTests(unittest.TestCase):
         self.context = baseplate.make_context_object()
         self.server_span = baseplate.make_server_span(self.context, "test")
 
-    def test_put_get(self):
+    def test_set_get(self):
         context_redis: MonitoredRedisConnection = self.context.redis
-        context_redis.set("test", "value")
-        message = context_redis.get("test")
+        context_redis.set(self.test_field, "value")
+        message = context_redis.get(self.test_field)
+
+
+        client = RedisClient(decode_responses=True)
+        print(f"client {client.decode_responses}")
+
+        print(context_redis.connection_pool.__dict__)
 
         self.assertEqual(message, "value")
+
+    def tearDown(self):
+        self.context.redis.delete(self.test_field)
 
 
 class RedisMessageQueueTests(unittest.TestCase):


### PR DESCRIPTION
`redis-py` has an option `decode_responses`, which will automatically decode all string values.  Having redis-py do all of the conversions makes the calling code cleaner and possibly slightly more performant.

When `decode_responses` is True, `redis-py` will take the values returned from the server and call [`bytes.decode`](https://docs.python.org/3/library/stdtypes.html#bytes.decode).  `encoding` and `encoding_errors` are passed into the decode function.