### PR TITLE
create context.metrics even when request is not sampled

### DIFF
--- a/baseplate/lib/metrics.py
+++ b/baseplate/lib/metrics.py
@@ -124,9 +124,10 @@ class BufferedTransport(Transport):
         self.buffer.append(serialized_metric)
 
     def flush(self) -> None:
-        metrics, self.buffer = self.buffer, []
-        message = b"\n".join(metrics)
-        self.transport.send(message)
+        if self.buffer:
+            metrics, self.buffer = self.buffer, []
+            message = b"\n".join(metrics)
+            self.transport.send(message)
 
 
 class BaseClient:

--- a/baseplate/lib/metrics.py
+++ b/baseplate/lib/metrics.py
@@ -347,6 +347,8 @@ class Counter:
         :param sample_rate: What rate this counter is sampled at. [0-1].
 
         """
+        if delta == 0:
+            return
         parts = [self.name + (f":{delta:g}".encode()), b"c"]
 
         if sample_rate != 1.0:

--- a/baseplate/lib/metrics.py
+++ b/baseplate/lib/metrics.py
@@ -348,8 +348,6 @@ class Counter:
         :param sample_rate: What rate this counter is sampled at. [0-1].
 
         """
-        if delta == 0:
-            return
         parts = [self.name + (f":{delta:g}".encode()), b"c"]
 
         if sample_rate != 1.0:

--- a/baseplate/observers/metrics.py
+++ b/baseplate/observers/metrics.py
@@ -50,9 +50,9 @@ class MetricsBaseplateObserver(BaseplateObserver):
         return cls(client, sample_rate=sample_rate)
 
     def on_server_span_created(self, context: RequestContext, server_span: Span) -> None:
+        batch = self.client.batch()
+        context.metrics = batch
         if self.sample_rate == 1.0 or random() < self.sample_rate:
-            batch = self.client.batch()
-            context.metrics = batch
             observer = MetricsServerSpanObserver(batch, server_span, self.sample_rate)
             server_span.register(observer)
 


### PR DESCRIPTION
Fixup to this pr:
https://github.com/reddit/baseplate.py/pull/400

Many applications access context.metrics directly, which currently throws an error because `context.metrics` is not assigned if the request is not sampled.