### PR TITLE
Kombu: Add ability to pass in error_handler_fn

### DIFF
--- a/baseplate/frameworks/queue_consumer/kombu.py
+++ b/baseplate/frameworks/queue_consumer/kombu.py
@@ -120,7 +120,8 @@ class KombuMessageHandler(MessageHandler):
                 logger.info("Recieved a fatal error, terminating the server.")
                 raise
         else:
-            message.ack()
+            if not self.error_handler_fn:
+                message.ack()
 
 
 class KombuQueueConsumerFactory(QueueConsumerFactory):

--- a/baseplate/frameworks/queue_consumer/kombu.py
+++ b/baseplate/frameworks/queue_consumer/kombu.py
@@ -109,7 +109,6 @@ class KombuMessageHandler(MessageHandler):
                 span.set_tag("amqp.delivery_tag", delivery_info.get("delivery_tag", ""))
                 span.set_tag("amqp.exchange", delivery_info.get("exchange", ""))
                 self.handler_fn(context, message_body, message)
-                message.ack()
         except Exception as exc:
             logger.exception(
                 "Unhandled error while trying to process a message.  The message "
@@ -123,6 +122,8 @@ class KombuMessageHandler(MessageHandler):
             if isinstance(exc, FatalMessageHandlerError):
                 logger.info("Recieved a fatal error, terminating the server.")
                 raise
+        else:
+            message.ack()
 
 
 class KombuQueueConsumerFactory(QueueConsumerFactory):

--- a/baseplate/frameworks/queue_consumer/kombu.py
+++ b/baseplate/frameworks/queue_consumer/kombu.py
@@ -157,8 +157,12 @@ class KombuQueueConsumerFactory(QueueConsumerFactory):
         :param routing_keys: List of routing keys that you will create :py:class:`~kombu.Queue` s
             to consume from.
         :param handler_fn: A function that will process an individual message from a queue.
+            If `error_handler_fn` is passed in, this function is responsible for calling
+            `message.ack` or `message.requeue` when a message is successfully processed.
         :param error_handler_fn: A function that will be called when an error is thrown
-            while executing the `handler_fn`.
+            while executing the `handler_fn`. This function will be responsible for calling
+            `message.ack` or `message.requeue` as it will not be automatically called by
+            `KombuMessageHandler`'s `handle` function.
         :param health_check_fn: A `baseplate.server.queue_consumer.HealthcheckCallback`
             function that can be used to customize your health check.
         :param serializer: A `baseplate.clients.kombu.KombuSerializer` that should
@@ -200,8 +204,12 @@ class KombuQueueConsumerFactory(QueueConsumerFactory):
         :param routing_keys: List of routing keys that you will create
             :py:class:`~kombu.Queue` s to consume from.
         :param handler_fn: A function that will process an individual message from a queue.
+            If `error_handler_fn` is passed in, this function is responsible for calling
+            `message.ack` or `message.requeue` when a message is successfully processed.
         :param error_handler_fn: A function that will be called when an error is thrown
-            while executing the `handler_fn`.
+            while executing the `handler_fn`. This function will be responsible for calling
+            `message.ack` or `message.requeue` as it will not be automatically called by
+            `KombuMessageHandler`'s `handle` function.
         :param health_check_fn: A `baseplate.server.queue_consumer.HealthcheckCallback`
             function that can be used to customize your health check.
         :param serializer: A `baseplate.clients.kombu.KombuSerializer` that should

--- a/baseplate/frameworks/queue_consumer/kombu.py
+++ b/baseplate/frameworks/queue_consumer/kombu.py
@@ -153,8 +153,9 @@ class KombuQueueConsumerFactory(QueueConsumerFactory):
         :param queue_name: Name for your queue.
         :param routing_keys: List of routing keys that you will create :py:class:`~kombu.Queue` s
             to consume from.
-        :param handler_fn: A `baseplate.frameworks.queue_consumer.komub.Handler`
-            function that will process an individual message from a queue.
+        :param handler_fn: A function that will process an individual message from a queue.
+        :param error_handler_fn: A function that will be called when an error is thrown
+            while executing the `handler_fn`.
         :param health_check_fn: A `baseplate.server.queue_consumer.HealthcheckCallback`
             function that can be used to customize your health check.
         :param serializer: A `baseplate.clients.kombu.KombuSerializer` that should
@@ -195,11 +196,9 @@ class KombuQueueConsumerFactory(QueueConsumerFactory):
         :param queue_name: Name for your queue.
         :param routing_keys: List of routing keys that you will create
             :py:class:`~kombu.Queue` s to consume from.
-        :param handler_fn: A `baseplate.frameworks.queue_consumer.kombu.Handler`
-            function that will process an individual message from a queue.
-        :param error_handler_fn: A `baseplate.frameworks.queue_consumer.kombu.Handler`
-            function that will be called when an error is thrown while executing the
-            `handler_fn`.
+        :param handler_fn: A function that will process an individual message from a queue.
+        :param error_handler_fn: A function that will be called when an error is thrown
+            while executing the `handler_fn`.
         :param health_check_fn: A `baseplate.server.queue_consumer.HealthcheckCallback`
             function that can be used to customize your health check.
         :param serializer: A `baseplate.clients.kombu.KombuSerializer` that should

--- a/tests/unit/frameworks/queue_consumer/kombu_tests.py
+++ b/tests/unit/frameworks/queue_consumer/kombu_tests.py
@@ -114,6 +114,7 @@ class TestKombuMessageHandler:
         with expectation:
             handler.handle(message)
         error_handler_fn.assert_called_once_with(context, message.decode(), message)
+        message.ack.assert_not_called()
         message.requeue.assert_not_called()
 
 

--- a/tests/unit/frameworks/queue_consumer/kombu_tests.py
+++ b/tests/unit/frameworks/queue_consumer/kombu_tests.py
@@ -113,7 +113,7 @@ class TestKombuMessageHandler:
         handler = KombuMessageHandler(baseplate, name, handler_fn, error_handler_fn)
         with expectation:
             handler.handle(message)
-        error_handler_fn.assert_called_once_with(context, message.decode(), message)
+        error_handler_fn.assert_called_once_with(context, message.decode(), message, err)
         message.ack.assert_not_called()
         message.requeue.assert_not_called()
 

--- a/tests/unit/frameworks/queue_consumer/kombu_tests.py
+++ b/tests/unit/frameworks/queue_consumer/kombu_tests.py
@@ -95,6 +95,27 @@ class TestKombuMessageHandler:
             handler.handle(message)
         message.requeue.assert_called_once()
 
+    @pytest.mark.parametrize(
+        "err,expectation",
+        [
+            (ValueError(), does_not_raise()),
+            (FatalMessageHandlerError(), pytest.raises(FatalMessageHandlerError)),
+        ],
+    )
+    def test_errors_with_error_handler_fn(
+        self, err, expectation, context, baseplate, name, message
+    ):
+        def handler_fn(ctx, body, msg):
+            raise err
+
+        error_handler_fn = mock.Mock()
+
+        handler = KombuMessageHandler(baseplate, name, handler_fn, error_handler_fn)
+        with expectation:
+            handler.handle(message)
+        error_handler_fn.assert_called_once_with(context, message.decode(), message)
+        message.requeue.assert_not_called()
+
 
 @pytest.fixture
 def connection():
@@ -122,6 +143,7 @@ class TestQueueConsumerFactory:
                 queue_name=name,
                 routing_keys=routing_keys,
                 handler_fn=lambda ctx, body, msg: True,
+                error_handler_fn=lambda ctx, body, msg: True,
                 health_check_fn=health_check_fn,
             )
 
@@ -129,6 +151,7 @@ class TestQueueConsumerFactory:
 
     def test_new(self, baseplate, exchange, connection, name, routing_keys):
         handler_fn = mock.Mock()
+        error_handler_fn = mock.Mock()
         health_check_fn = mock.Mock()
         factory = KombuQueueConsumerFactory.new(
             baseplate=baseplate,
@@ -137,12 +160,14 @@ class TestQueueConsumerFactory:
             queue_name=name,
             routing_keys=routing_keys,
             handler_fn=handler_fn,
+            error_handler_fn=error_handler_fn,
             health_check_fn=health_check_fn,
         )
         assert factory.baseplate == baseplate
         assert factory.connection == connection
         assert factory.name == name
         assert factory.handler_fn == handler_fn
+        assert factory.error_handler_fn == error_handler_fn
         assert factory.health_check_fn == health_check_fn
         for routing_key, queue in zip(routing_keys, factory.queues):
             assert queue.routing_key == routing_key
@@ -165,6 +190,7 @@ class TestQueueConsumerFactory:
         assert handler.baseplate == factory.baseplate
         assert handler.name == factory.name
         assert handler.handler_fn == factory.handler_fn
+        assert handler.error_handler_fn == factory.error_handler_fn
 
     @pytest.mark.parametrize("health_check_fn", [None, lambda req: True])
     def test_build_health_checker(self, health_check_fn, make_queue_consumer_factory):


### PR DESCRIPTION
Current behavior when an error occurs is to requeue the message. This
allows the ability to override that behavior by passing in a function