### PR TITLE
Add sampling to metrics created by timers

### DIFF
--- a/baseplate/lib/metrics.py
+++ b/baseplate/lib/metrics.py
@@ -274,7 +274,7 @@ class Timer:
 
         self.start_time: Optional[float] = None
         self.stopped: bool = False
-        self.sample_rate = None
+        self.sample_rate = 1.0
 
     def start(self, sample_rate: float = 1.0) -> None:
         """Record the current time as the start of the timer."""
@@ -304,7 +304,7 @@ class Timer:
 
         """
         serialized = self.name + (f":{(elapsed * 1000.0):g}|ms".encode())
-        if self.sample_rate and self.sample_rate < 1.0:
+        if self.sample_rate < 1.0:
             sampling_info = f"@{self.sample_rate:g}".encode()
             serialized = serialized + b"|" + sampling_info
         self.transport.send(serialized)

--- a/baseplate/lib/metrics.py
+++ b/baseplate/lib/metrics.py
@@ -274,9 +274,11 @@ class Timer:
 
         self.start_time: Optional[float] = None
         self.stopped: bool = False
+        self.sample_rate = None
 
-    def start(self) -> None:
+    def start(self, sample_rate: float = 1.0) -> None:
         """Record the current time as the start of the timer."""
+        self.sample_rate = sample_rate
         assert not self.start_time, "timer already started"
         assert not self.stopped, "timer already stopped"
 
@@ -292,7 +294,7 @@ class Timer:
         self.send(elapsed)
         self.stopped = True
 
-    def send(self, elapsed: float, sample_rate: float = 1.0) -> None:
+    def send(self, elapsed: float) -> None:
         """Directly send a timer value without having to stop/start.
 
         This can be useful when the timing was managed elsewhere and we just
@@ -302,8 +304,8 @@ class Timer:
 
         """
         serialized = self.name + (f":{(elapsed * 1000.0):g}|ms".encode())
-        if sample_rate < 1.0:
-            sampling_info = f"@{sample_rate:g}".encode()
+        if self.sample_rate and self.sample_rate < 1.0:
+            sampling_info = f"@{self.sample_rate:g}".encode()
             serialized = serialized + b"|" + sampling_info
         self.transport.send(serialized)
 

--- a/baseplate/lib/metrics.py
+++ b/baseplate/lib/metrics.py
@@ -278,10 +278,10 @@ class Timer:
 
     def start(self, sample_rate: float = 1.0) -> None:
         """Record the current time as the start of the timer."""
-        self.sample_rate = sample_rate
         assert not self.start_time, "timer already started"
         assert not self.stopped, "timer already stopped"
 
+        self.sample_rate = sample_rate
         self.start_time = time.time()
 
     def stop(self) -> None:
@@ -291,10 +291,10 @@ class Timer:
 
         now = time.time()
         elapsed = now - self.start_time
-        self.send(elapsed)
+        self.send(elapsed, self.sample_rate)
         self.stopped = True
 
-    def send(self, elapsed: float) -> None:
+    def send(self, elapsed: float, sample_rate: float = 1.0) -> None:
         """Directly send a timer value without having to stop/start.
 
         This can be useful when the timing was managed elsewhere and we just
@@ -304,8 +304,8 @@ class Timer:
 
         """
         serialized = self.name + (f":{(elapsed * 1000.0):g}|ms".encode())
-        if self.sample_rate < 1.0:
-            sampling_info = f"@{self.sample_rate:g}".encode()
+        if sample_rate < 1.0:
+            sampling_info = f"@{sample_rate:g}".encode()
             serialized = b"|".join([serialized, sampling_info])
         self.transport.send(serialized)
 

--- a/baseplate/lib/metrics.py
+++ b/baseplate/lib/metrics.py
@@ -306,7 +306,7 @@ class Timer:
         serialized = self.name + (f":{(elapsed * 1000.0):g}|ms".encode())
         if self.sample_rate < 1.0:
             sampling_info = f"@{self.sample_rate:g}".encode()
-            serialized = serialized + b"|" + sampling_info
+            serialized = b"|".join([serialized, sampling_info])
         self.transport.send(serialized)
 
     def __enter__(self) -> None:

--- a/baseplate/observers/metrics.py
+++ b/baseplate/observers/metrics.py
@@ -1,5 +1,3 @@
-import typing
-
 from random import random
 from typing import Any
 from typing import Optional
@@ -85,8 +83,8 @@ class MetricsServerSpanObserver(SpanObserver):
         self.sample_rate = sample_rate
 
     def on_start(self) -> None:
-        self.timer = self.batch.timer(self.base_name, self.sample_rate)
-        self.timer.start()
+        self.timer = self.batch.timer(self.base_name)
+        self.timer.start(self.sample_rate)
 
     def on_incr_tag(self, key: str, delta: float) -> None:
         self.batch.counter(key).increment(delta, sample_rate=self.sample_rate)
@@ -121,13 +119,11 @@ class MetricsServerSpanObserver(SpanObserver):
 class MetricsLocalSpanObserver(SpanObserver):
     def __init__(self, batch: metrics.Batch, span: Span, sample_rate: float = 1.0):
         self.batch = batch
-        self.timer = batch.timer(
-            typing.cast(str, span.component_name) + "." + span.name, sample_rate
-        )
+        self.timer = batch.timer(f"{span.component_name}.{span.name}")
         self.sample_rate = sample_rate
 
     def on_start(self) -> None:
-        self.timer.start()
+        self.timer.start(self.sample_rate)
 
     def on_incr_tag(self, key: str, delta: float) -> None:
         self.batch.counter(key).increment(delta, sample_rate=self.sample_rate)
@@ -140,11 +136,11 @@ class MetricsClientSpanObserver(SpanObserver):
     def __init__(self, batch: metrics.Batch, span: Span, sample_rate: float = 1.0):
         self.batch = batch
         self.base_name = f"clients.{span.name}"
-        self.timer = batch.timer(self.base_name, sample_rate)
+        self.timer = batch.timer(self.base_name)
         self.sample_rate = sample_rate
 
     def on_start(self) -> None:
-        self.timer.start()
+        self.timer.start(self.sample_rate)
 
     def on_incr_tag(self, key: str, delta: float) -> None:
         self.batch.counter(key).increment(delta, sample_rate=self.sample_rate)

--- a/baseplate/observers/metrics.py
+++ b/baseplate/observers/metrics.py
@@ -53,8 +53,28 @@ class MetricsBaseplateObserver(BaseplateObserver):
         batch = self.client.batch()
         context.metrics = batch
         if self.sample_rate == 1.0 or random() < self.sample_rate:
-            observer = MetricsServerSpanObserver(batch, server_span, self.sample_rate)
-            server_span.register(observer)
+            observer: SpanObserver = MetricsServerSpanObserver(batch, server_span, self.sample_rate)
+        else:
+            observer = MetricsServerSpanDummyObserver(batch)
+        server_span.register(observer)
+
+
+class MetricsServerSpanDummyObserver(SpanObserver):
+    # for requests that aren't sampled
+    def __init__(self, batch: metrics.Batch):
+        self.batch = batch
+
+    def on_start(self) -> None:
+        pass
+
+    def on_incr_tag(self, key: str, delta: float) -> None:
+        pass
+
+    def on_finish(self, exc_info: Optional[_ExcInfo]) -> None:
+        self.batch.flush()
+
+    def on_child_span_created(self, span: Span) -> None:
+        pass
 
 
 class MetricsServerSpanObserver(SpanObserver):
@@ -65,7 +85,7 @@ class MetricsServerSpanObserver(SpanObserver):
         self.sample_rate = sample_rate
 
     def on_start(self) -> None:
-        self.timer = self.batch.timer(self.base_name)
+        self.timer = self.batch.timer(self.base_name, self.sample_rate)
         self.timer.start()
 
     def on_incr_tag(self, key: str, delta: float) -> None:
@@ -101,7 +121,9 @@ class MetricsServerSpanObserver(SpanObserver):
 class MetricsLocalSpanObserver(SpanObserver):
     def __init__(self, batch: metrics.Batch, span: Span, sample_rate: float = 1.0):
         self.batch = batch
-        self.timer = batch.timer(typing.cast(str, span.component_name) + "." + span.name)
+        self.timer = batch.timer(
+            typing.cast(str, span.component_name) + "." + span.name, sample_rate
+        )
         self.sample_rate = sample_rate
 
     def on_start(self) -> None:
@@ -118,7 +140,7 @@ class MetricsClientSpanObserver(SpanObserver):
     def __init__(self, batch: metrics.Batch, span: Span, sample_rate: float = 1.0):
         self.batch = batch
         self.base_name = f"clients.{span.name}"
-        self.timer = batch.timer(self.base_name)
+        self.timer = batch.timer(self.base_name, sample_rate)
         self.sample_rate = sample_rate
 
     def on_start(self) -> None:

--- a/tests/unit/observers/metrics_tests.py
+++ b/tests/unit/observers/metrics_tests.py
@@ -76,7 +76,7 @@ class ClientSpanObserverTests(unittest.TestCase):
 
         observer = MetricsClientSpanObserver(mock_batch, mock_client_span)
         self.assertEqual(mock_batch.timer.call_count, 1)
-        self.assertEqual(mock_batch.timer.call_args, mock.call("clients.example"))
+        self.assertEqual(mock_batch.timer.call_args, mock.call("clients.example", 1.0))
 
         observer.on_start()
         self.assertEqual(mock_timer.start.call_count, 1)
@@ -109,7 +109,7 @@ class LocalSpanObserverTests(unittest.TestCase):
 
         observer = MetricsLocalSpanObserver(mock_batch, mock_local_span)
         self.assertEqual(mock_batch.timer.call_count, 1)
-        self.assertEqual(mock_batch.timer.call_args, mock.call("some_component.example"))
+        self.assertEqual(mock_batch.timer.call_args, mock.call("some_component.example", 1.0))
 
         observer.on_start()
         self.assertEqual(mock_timer.start.call_count, 1)

--- a/tests/unit/observers/metrics_tests.py
+++ b/tests/unit/observers/metrics_tests.py
@@ -76,7 +76,7 @@ class ClientSpanObserverTests(unittest.TestCase):
 
         observer = MetricsClientSpanObserver(mock_batch, mock_client_span)
         self.assertEqual(mock_batch.timer.call_count, 1)
-        self.assertEqual(mock_batch.timer.call_args, mock.call("clients.example", 1.0))
+        self.assertEqual(mock_batch.timer.call_args, mock.call("clients.example"))
 
         observer.on_start()
         self.assertEqual(mock_timer.start.call_count, 1)
@@ -109,7 +109,7 @@ class LocalSpanObserverTests(unittest.TestCase):
 
         observer = MetricsLocalSpanObserver(mock_batch, mock_local_span)
         self.assertEqual(mock_batch.timer.call_count, 1)
-        self.assertEqual(mock_batch.timer.call_args, mock.call("some_component.example", 1.0))
+        self.assertEqual(mock_batch.timer.call_args, mock.call("some_component.example"))
 
         observer.on_start()
         self.assertEqual(mock_timer.start.call_count, 1)


### PR DESCRIPTION
The previous sampling PR failed to account for the fact that some counters are created implicitly by timers. These counters need to know about sampling or telegraf won't be able to compensate for it correctly on the backend.

This should also make sampling more backwards compatible with the old context.metrics syntax by removing the error where context.metrics doesn't exist. 