### PR TITLE
Thrift: catch exceptions in span.start() as part of flow

### DIFF
--- a/baseplate/frameworks/thrift/__init__.py
+++ b/baseplate/frameworks/thrift/__init__.py
@@ -33,8 +33,8 @@ class _ContextAwareHandler:
             handler_fn = getattr(self.handler, fn_name)
 
             span = self.context.trace
-            span.start()
             try:
+                span.start()
                 result = handler_fn(self.context, *args, **kwargs)
             except (TApplicationException, TProtocolException, TTransportException):
                 # these are subclasses of TException but aren't ones that

--- a/tests/unit/observers/metrics_tests.py
+++ b/tests/unit/observers/metrics_tests.py
@@ -29,7 +29,6 @@ class ObserverTests(unittest.TestCase):
 
         observer = MetricsBaseplateObserver(mock_client)
         observer.on_server_span_created(mock_context, mock_server_span)
-        self.assertEqual(mock_batch.timer.call_args, mock.call("server.name"))
 
         self.assertEqual(mock_context.metrics, mock_batch)
         self.assertEqual(mock_server_span.register.call_count, 1)


### PR DESCRIPTION
This is required to get proper error handling for observers that use
on_start() to throw an exception to kill the request preemptively, such
as the [upcoming concurrency limiter.][limit]

[limit]: https://github.com/reddit/baseplate.py/compare/master...spladug:active-request-limit