### PR TITLE
Add convenience function for creating quick server span contexts

### DIFF
--- a/docs/api/baseplate/index.rst
+++ b/docs/api/baseplate/index.rst
@@ -69,6 +69,7 @@ else might be helpful.
 
 .. automethod:: Baseplate.make_context_object
 .. automethod:: Baseplate.make_server_span
+.. automethod:: Baseplate.server_context
 
 .. autoclass:: ServerSpan
    :members:

--- a/tests/unit/core_tests.py
+++ b/tests/unit/core_tests.py
@@ -5,6 +5,7 @@ from unittest import mock
 from baseplate import Baseplate
 from baseplate import BaseplateObserver
 from baseplate import LocalSpan
+from baseplate import RequestContext
 from baseplate import ServerSpan
 from baseplate import ServerSpanObserver
 from baseplate import Span
@@ -98,6 +99,16 @@ class BaseplateTests(unittest.TestCase):
             self.assertTrue(context.enable_some_fancy_feature)
             self.assertIsNotNone(context.thrift.foo)
             self.assertIsNotNone(context.thrift.bar)
+
+    def test_with_server_context(self):
+        baseplate = Baseplate()
+        observer = mock.Mock(spec=BaseplateObserver)
+        baseplate.register(observer)
+
+        observer.on_server_span_created.assert_not_called()
+        with baseplate.server_context("example") as context:
+            observer.on_server_span_created.assert_called_once()
+            self.assertIsInstance(context, RequestContext)
 
 
 class SpanTests(unittest.TestCase):


### PR DESCRIPTION
This pattern comes up pretty frequently:

    context = baseplate.make_context_object()
    with baseplate.make_server_span(context, "foo"):
        context.foo.bar()

and while we do need the context object creation and span creation to be separate for different frameworks to have full control of things we can also have some nice sugar for the common case:

    with baseplate.server_context("foo") as context:
        context.foo.bar()

:eyeglasses: @melissacole @pacejackson 