### PR TITLE
Send and receive service names in Thrift

### DIFF
--- a/baseplate/clients/thrift.py
+++ b/baseplate/clients/thrift.py
@@ -151,6 +151,12 @@ def _build_thrift_proxy_method(name: str) -> Callable[..., Any]:
 
             try:
                 with self.pool.connection() as prot:
+                    baseplate = span.baseplate
+                    if baseplate:
+                        service_name = baseplate.service_name
+                        if service_name:
+                            prot.trans.set_header(b"User-Agent", service_name.encode())
+
                     prot.trans.set_header(b"Trace", str(span.trace_id).encode())
                     prot.trans.set_header(b"Parent", str(span.parent_id).encode())
                     prot.trans.set_header(b"Span", str(span.id).encode())

--- a/baseplate/frameworks/thrift/__init__.py
+++ b/baseplate/frameworks/thrift/__init__.py
@@ -107,7 +107,14 @@ def baseplateify_processor(
                 # downstream even if we don't know how to handle it.
                 context.raw_request_context = edge_payload
 
-            baseplate.make_server_span(context, name=fn_name, trace_info=trace_info)
+            span = baseplate.make_server_span(context, name=fn_name, trace_info=trace_info)
+
+            try:
+                service_name = headers[b"User-Agent"].decode()
+            except (KeyError, UnicodeDecodeError):
+                pass
+            else:
+                span.set_tag("peer.service", service_name)
 
             context.headers = headers
 

--- a/baseplate/lib/__init__.py
+++ b/baseplate/lib/__init__.py
@@ -1,5 +1,6 @@
 """Internal library helpers."""
 import functools
+import inspect
 import warnings
 
 from typing import Callable
@@ -45,3 +46,15 @@ class cached_property(Generic[T, R]):
         ret = self.wrapped(instance)
         setattr(instance, self.wrapped.__name__, ret)
         return ret
+
+
+class UnknownCallerError(Exception):
+    def __init__(self) -> None:
+        super().__init__("Could not determine calling module's name")
+
+
+def get_calling_module_name() -> str:
+    module = inspect.getmodule(inspect.stack()[2].frame)
+    if not module:
+        raise UnknownCallerError
+    return module.__name__

--- a/baseplate/observers/metrics.py
+++ b/baseplate/observers/metrics.py
@@ -35,17 +35,13 @@ class MetricsBaseplateObserver(BaseplateObserver):
 
     @classmethod
     def from_config_and_client(
-        cls, raw_config: Optional[config.RawConfig], client: metrics.Client
+        cls, raw_config: config.RawConfig, client: metrics.Client
     ) -> "MetricsBaseplateObserver":
-        sample_rate = 1.0
-        if raw_config:
-            cfg = config.parse_config(
-                raw_config,
-                {"metrics_observer": {"sample_rate": config.Optional(config.Percent, default=1.0)}},
-            )
-            sample_rate = cfg.metrics_observer.sample_rate
-
-        return cls(client, sample_rate=sample_rate)
+        cfg = config.parse_config(
+            raw_config,
+            {"metrics_observer": {"sample_rate": config.Optional(config.Percent, default=1.0)}},
+        )
+        return cls(client, sample_rate=cfg.metrics_observer.sample_rate)
 
     def on_server_span_created(self, context: RequestContext, server_span: Span) -> None:
         batch = self.client.batch()

--- a/docs/api/baseplate/index.rst
+++ b/docs/api/baseplate/index.rst
@@ -44,7 +44,7 @@ various other frameworks (e.g. Thrift, Pyramid, etc.) using one of :doc:`the
 integrations <frameworks/index>`.
 
 .. autoclass:: Baseplate
-   :members: configure_observers, configure_context, add_to_context
+   :members: __init__, configure_observers, configure_context, add_to_context
 
 Per-request Context
 -------------------


### PR DESCRIPTION
This gives services an identity and sends it to downstreams in Thrift
calls. Thrift servers also accept this identity and attach it to the
server span as the peer.service tag.

The idea is to allow servers to get better information about who is
calling them.