### PR TITLE
Make queue consumer healthchecks go through logging system

### DIFF
--- a/baseplate/server/queue_consumer.py
+++ b/baseplate/server/queue_consumer.py
@@ -16,6 +16,7 @@ from typing import Optional
 from typing import Sequence
 from typing import TYPE_CHECKING
 
+from gevent.pywsgi import LoggingLogAdapter
 from gevent.pywsgi import WSGIServer
 from gevent.server import StreamServer
 
@@ -47,7 +48,11 @@ def make_simple_healthchecker(
         start_response("503 UNAVAILABLE", [("Content-Type", "text/plain")])
         return [b"he's dead jim"]
 
-    return WSGIServer(listener=listener, application=healthcheck)
+    return WSGIServer(
+        listener=listener,
+        application=healthcheck,
+        log=LoggingLogAdapter(logger, level=logging.DEBUG),
+    )
 
 
 class PumpWorker(abc.ABC):


### PR DESCRIPTION
This squelches them outside debug mode but gives applications the
ability to control the logging through the normal Python logging system.
Previously it always went to stderr and was rather spammy.