### PR TITLE
Raises warning instead of exception on empty Kafka message

### DIFF
--- a/baseplate/frameworks/queue_consumer/kafka.py
+++ b/baseplate/frameworks/queue_consumer/kafka.py
@@ -3,6 +3,7 @@ import logging
 import queue
 import socket
 import time
+import warnings
 
 from typing import Any
 from typing import Callable
@@ -130,6 +131,10 @@ class KafkaMessageHandler(MessageHandler):
                 span.set_tag("kafka.timestamp", message.timestamp())
 
                 blob: bytes = message.value()
+
+                if not blob:
+                    warnings.warn("empty message body", BytesWarning)
+                    return
 
                 try:
                     data = self.message_unpack_fn(blob)

--- a/baseplate/frameworks/queue_consumer/kafka.py
+++ b/baseplate/frameworks/queue_consumer/kafka.py
@@ -130,10 +130,10 @@ class KafkaMessageHandler(MessageHandler):
                 span.set_tag("kafka.timestamp", message.timestamp())
 
                 blob: bytes = message.value()
+                data: Any = None
                 message_latency: Optional[int] = None
 
                 if not blob:
-                    data = None
                     logger.debug("null message value")
                     context.trace.incr_tag(f"{self.name}.{topic}.null_message_value")
 


### PR DESCRIPTION
Skips attempting to deserialize an empty Kafka message and raises a suppressible warning instead. This is useful for cases such as consuming CDC row updates from kSQL where keyed messages with a null value indicate no change to the row.