### PR TITLE
Thrift pool overflow #1

### DIFF
--- a/baseplate/lib/thrift_pool.py
+++ b/baseplate/lib/thrift_pool.py
@@ -142,9 +142,6 @@ class ThriftConnectionPool:
 
     """
 
-    class _PoolCheckoutException(Exception):
-        pass
-
     # pylint: disable=too-many-arguments
     def __init__(
         self,
@@ -178,26 +175,16 @@ class ThriftConnectionPool:
         for _ in range(size):
             self.pool.put(None)
 
-    def _acquire(self) -> TProtocolBase:
+    def _get_from_pool(self) -> Optional[TProtocolBase]:
         try:
-            prot = self.pool.get(block=True, timeout=self.timeout)
+            return self.pool.get(block=True, timeout=self.timeout)
         except queue.Empty:
             raise TTransportException(
                 type=TTransportException.NOT_OPEN, message="timed out waiting for a connection slot"
             )
-        except:  # noqa: E722
-            # at least ServerTimeout exception can be caught here, but expecting others too.
-            # raising the special exception to flag the case where connection
-            # hasn't left the pool.
-            raise self._PoolCheckoutException
 
+    def _create_connection(self) -> TProtocolBase:
         for _ in self.retry_policy:
-            if prot:
-                if time.time() - prot.baseplate_birthdate < self.max_age:
-                    return prot
-                prot.trans.close()
-                prot = None
-
             trans = _make_transport(self.endpoint)
             trans.setTimeout(self.timeout * 1000.0)
             prot = self.protocol_factory.getProtocol(trans)
@@ -206,7 +193,6 @@ class ThriftConnectionPool:
                 prot.trans.open()
             except TTransportException as exc:
                 logger.info("Failed to connect to %r: %s", self.endpoint, exc)
-                prot = None
                 continue
 
             prot.baseplate_birthdate = time.time()
@@ -217,6 +203,12 @@ class ThriftConnectionPool:
             type=TTransportException.NOT_OPEN,
             message="giving up after multiple attempts to connect",
         )
+
+    def _is_stale(self, prot: TProtocolBase) -> bool:
+        if time.time() - prot.baseplate_birthdate > self.max_age:
+            prot.trans.close()
+            return True
+        return False
 
     def _release(self, prot: Optional[TProtocolBase]) -> None:
         if prot and prot.trans.isOpen():
@@ -238,10 +230,12 @@ class ThriftConnectionPool:
         unknown.
 
         """
-        prot: Optional[TProtocolBase] = None
-        skip_release = False
+        prot = self._get_from_pool()
+
         try:
-            prot = self._acquire()
+            if not prot or self._is_stale(prot):
+                prot = self._create_connection()
+
             try:
                 yield prot
             except socket.timeout:
@@ -264,10 +258,6 @@ class ThriftConnectionPool:
             # (expected) errors which should be safe for the connection.
             # don't close the transport here!
             raise
-        except self._PoolCheckoutException:
-            # acquisition from the pool hasn't happened and thus releasing
-            # should be skipped too.
-            skip_release = True
         except:  # noqa: E722
             # anything else coming out of thrift usually means parsing failed
             # or something nastier. we'll just play it safe and close the
@@ -276,8 +266,7 @@ class ThriftConnectionPool:
                 prot.trans.close()
             raise
         finally:
-            if not skip_release:
-                self._release(prot)
+            self._release(prot)
 
     @property
     def checkedout(self) -> int:

--- a/tests/unit/lib/thrift_pool_tests.py
+++ b/tests/unit/lib/thrift_pool_tests.py
@@ -98,7 +98,7 @@ class ThriftConnectionPoolTests(unittest.TestCase):
         self.mock_queue.get.side_effect = queue.Empty
 
         with self.assertRaises(TTransport.TTransportException):
-            self.pool._acquire()
+            self.pool._get_from_pool()
 
     def test_pool_with_framed_protocol_factory(self):
         def framed_protocol_factory(trans):
@@ -121,7 +121,7 @@ class ThriftConnectionPoolTests(unittest.TestCase):
         mock_prot.baseplate_birthdate = 122
         self.mock_queue.get.return_value = mock_prot
 
-        prot = self.pool._acquire()
+        prot = self.pool._get_from_pool()
 
         self.assertEqual(prot, mock_prot)
 
@@ -139,7 +139,8 @@ class ThriftConnectionPoolTests(unittest.TestCase):
         fresh_trans.protocol_id = THeaderTransport.THeaderSubprotocolID.BINARY
         mock_make_transport.return_value = fresh_trans
 
-        prot = self.pool._acquire()
+        with self.pool.connection() as prot:
+            pass
 
         self.assertTrue(stale_prot.trans.close.called)
         self.assertEqual(prot.trans._transport, fresh_trans)
@@ -159,7 +160,7 @@ class ThriftConnectionPoolTests(unittest.TestCase):
 
         mock_make_transport.side_effect = [broken_trans, ok_trans]
 
-        prot = self.pool._acquire()
+        prot = self.pool._create_connection()
 
         self.assertEqual(prot.trans._transport, ok_trans)
         self.assertEqual(ok_trans.open.call_count, 1)
@@ -177,7 +178,7 @@ class ThriftConnectionPoolTests(unittest.TestCase):
         mock_make_transport.side_effect = [broken_trans] * 3
 
         with self.assertRaises(TTransport.TTransportException):
-            self.pool._acquire()
+            self.pool._create_connection()
 
     def test_release_open(self):
         mock_prot = mock.Mock(spec=THeaderProtocol.THeaderProtocol)

--- a/tests/unit/lib/thrift_pool_tests.py
+++ b/tests/unit/lib/thrift_pool_tests.py
@@ -306,4 +306,4 @@ class ThriftConnectionPoolTests(unittest.TestCase):
             with pool.connection() as _:
                 pass
 
-        self.assertEqual(-1, pool.checkedout)  # the issue: it should be 0
+        self.assertEqual(0, pool.checkedout)

--- a/tests/unit/lib/thrift_pool_tests.py
+++ b/tests/unit/lib/thrift_pool_tests.py
@@ -293,3 +293,17 @@ class ThriftConnectionPoolTests(unittest.TestCase):
         self.assertEqual(self.mock_queue.get.call_count, 1)
         self.assertEqual(self.mock_queue.put.call_count, 1)
         self.assertEqual(self.mock_queue.put.call_args, mock.call(None))
+
+    def test_pool_checkout_exception(self):
+        pool = thrift_pool.ThriftConnectionPool(EXAMPLE_ENDPOINT)
+
+        def mock_get():
+            raise Exception
+
+        pool.pool.get = mock_get
+
+        with self.assertRaises(Exception):
+            with pool.connection() as _:
+                pass
+
+        self.assertEqual(-1, pool.checkedout)  # the issue: it should be 0


### PR DESCRIPTION
When an exception (other than `queue.Empty`) happens in line 180,
https://github.com/reddit/baseplate.py/blob/887f9be99f367be27d0e58fecdb274cb090a1585/baseplate/lib/thrift_pool.py#L179-L184
it results in a call of
https://github.com/reddit/baseplate.py/blob/887f9be99f367be27d0e58fecdb274cb090a1585/baseplate/lib/thrift_pool.py#L267-L268
which puts an excess item in the queue (above `self.size`).

One of the subsequences of it is:
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/dist-packages/baseplate/server/runtime_monitor.py", line 146, in report
    reporter(batch)
  File "/usr/local/lib/python3.7/dist-packages/baseplate/clients/thrift.py", line 86, in report_runtime_metrics
    batch.gauge("pool.in_use").replace(self.pool.checkedout)
  File "/usr/local/lib/python3.7/dist-packages/baseplate/lib/metrics.py", line 467, in replace
    assert new_value >= 0, "gauges cannot be replaced with negative numbers"
```

This PR proposes a fix for the issue. @m104 @spladug please take a look.