### PR TITLE
Fix how we return loid of an user

### DIFF
--- a/tests/integration/pyramid_tests.py
+++ b/tests/integration/pyramid_tests.py
@@ -179,7 +179,8 @@ class ConfiguratorTests(unittest.TestCase):
             self.assertEqual(context.request_context.user.id, "t2_example")
             self.assertEqual(context.request_context.user.roles, set())
             self.assertEqual(context.request_context.user.is_logged_in, True)
-            self.assertEqual(context.request_context.user.loid, "t2_deadbeef")
+            # For logged in user, we expect loid returns logged in user id
+            self.assertEqual(context.request_context.user.loid, "t2_example")
             self.assertEqual(context.request_context.user.cookie_created_ms, 100000)
             self.assertEqual(context.request_context.oauth_client.id, None)
             self.assertFalse(context.request_context.oauth_client.is_type("third_party"))

--- a/tests/integration/thrift_tests.py
+++ b/tests/integration/thrift_tests.py
@@ -269,7 +269,8 @@ class ThriftEdgeRequestHeaderTests(GeventPatchedTestCase):
         self.assertEqual(handler.request_context.user.id, "t2_example")
         self.assertEqual(handler.request_context.user.roles, set())
         self.assertEqual(handler.request_context.user.is_logged_in, True)
-        self.assertEqual(handler.request_context.user.loid, "t2_deadbeef")
+        # For logged in user, we expect loid returns logged in user id
+        self.assertEqual(handler.request_context.user.loid, "t2_example")
         self.assertEqual(handler.request_context.user.cookie_created_ms, 100000)
         self.assertEqual(handler.request_context.oauth_client.id, None)
         self.assertFalse(handler.request_context.oauth_client.is_type("third_party"))
@@ -300,7 +301,8 @@ class ThriftEdgeRequestHeaderTests(GeventPatchedTestCase):
         self.assertEqual(handler.request_context.user.id, "t2_example")
         self.assertEqual(handler.request_context.user.roles, set())
         self.assertEqual(handler.request_context.user.is_logged_in, True)
-        self.assertEqual(handler.request_context.user.loid, "t2_deadbeef")
+        # For logged in user, we expect loid returns logged in user id
+        self.assertEqual(handler.request_context.user.loid, "t2_example")
         self.assertEqual(handler.request_context.user.cookie_created_ms, 100000)
         self.assertEqual(handler.request_context.oauth_client.id, None)
         self.assertFalse(handler.request_context.oauth_client.is_type("third_party"))
@@ -449,7 +451,8 @@ class ThriftEndToEndTests(GeventPatchedTestCase):
             self.assertEqual(handler.request_context.user.id, "t2_example")
             self.assertEqual(handler.request_context.user.roles, set())
             self.assertEqual(handler.request_context.user.is_logged_in, True)
-            self.assertEqual(handler.request_context.user.loid, "t2_deadbeef")
+            # For logged in user, we expect loid returns logged in user id
+            self.assertEqual(handler.request_context.user.loid, "t2_example")
             self.assertEqual(handler.request_context.user.cookie_created_ms, 100000)
             self.assertEqual(handler.request_context.oauth_client.id, None)
             self.assertFalse(handler.request_context.oauth_client.is_type("third_party"))

--- a/tests/unit/core_tests.py
+++ b/tests/unit/core_tests.py
@@ -358,7 +358,8 @@ class EdgeRequestContextTests(unittest.TestCase):
 
         self.assertEqual(request_context.user.id, "t2_example")
         self.assertTrue(request_context.user.is_logged_in)
-        self.assertEqual(request_context.user.loid, self.LOID_ID)
+        # For logged in user, we expect loid returns logged in user id
+        self.assertEqual(request_context.user.loid, "t2_example")
         self.assertEqual(request_context.user.cookie_created_ms, self.LOID_CREATED_MS)
         self.assertEqual(request_context.user.roles, set())
         self.assertFalse(request_context.user.has_role("test"))

--- a/tests/unit/lib/experiments/experiment_tests.py
+++ b/tests/unit/lib/experiments/experiment_tests.py
@@ -34,7 +34,7 @@ class TestExperiments(unittest.TestCase):
         self.mock_authentication_token.user_roles = set()
         self.user = User(
             authentication_token=self.mock_authentication_token,
-            loid="t2_1",
+            loid_="t2_1",
             cookie_created_ms=10000,
         )
 


### PR DESCRIPTION
We should return LoID in this order (fallback to the next one if it's
empty):

1. The logged in user id from the JWT token
2. The loid from the thrift payload
3. The loid from the JWT token