### PR TITLE
Allow disabling server timeouts and disable them by default

### DIFF
--- a/baseplate/lib/config.py
+++ b/baseplate/lib/config.py
@@ -89,6 +89,7 @@ from typing import Dict
 from typing import Generic
 from typing import IO
 from typing import NamedTuple
+from typing import NewType
 from typing import Optional as OptionalType
 from typing import Sequence
 from typing import Set
@@ -273,6 +274,17 @@ def TimespanWithLegacyFallback(text: str) -> datetime.timedelta:  # noqa: D401
         return Timespan(text)
     except ValueError:
         return datetime.timedelta(seconds=Float(text))
+
+
+InfiniteTimespanType = NewType("InfiniteTimespanType", object)
+InfiniteTimespan = InfiniteTimespanType(object())
+
+
+def TimespanOrInfinite(text: str) -> Union[datetime.timedelta, InfiniteTimespanType]:  # noqa: D401
+    """A span of time or the string 'infinite' indicating forever."""
+    if text == "infinite":
+        return InfiniteTimespan
+    return Timespan(text)
 
 
 def Percent(text: str) -> float:  # noqa: D401

--- a/docs/api/baseplate/observers/timeout.rst
+++ b/docs/api/baseplate/observers/timeout.rst
@@ -28,9 +28,11 @@ configuration settings allow you to customize this.
 
    ...
 
-   # optional: defaults to 10 seconds if not specified. this timeout
+   # optional: defaults to no timeout if not specified. this timeout
    # is used for any endpoint not specified in the by_endpoint
    # section below.
+   # note: leaving this unconfigured is deprecated.
+   # can be set to 'infinite' to disable the timeout altogether.
    server_timeout.default = 200 milliseconds
 
    # optional: defaults to false. if enabled, tracebacks will be
@@ -42,6 +44,7 @@ configuration settings allow you to customize this.
    # this overrides the default timeout.
    # - thrift services: the name of the thrift RPC method
    # - pyramid services: the name of the route (config.add_route)
+   # can be set to 'infinite' to disable the timeout altogether.
    server_timeout.by_endpoint.is_healthy = 300 milliseoncds
    server_timeout.by_endpoint.my_method = 12 seconds
 


### PR DESCRIPTION
They don't make sense in all situations (e.g. cron jobs) and the ideal
is that we explicitly configure them in the future but in the interest
of compatibility we'll just emit a deprecation warning for now.