### PR TITLE
Thrift pool overflow #2

### DIFF
--- a/baseplate/lib/thrift_pool.py
+++ b/baseplate/lib/thrift_pool.py
@@ -205,8 +205,6 @@ class ThriftConnectionPool:
 
             return prot
 
-        self.pool.put(None)
-
         raise TTransportException(
             type=TTransportException.NOT_OPEN,
             message="giving up after multiple attempts to connect",

--- a/tests/unit/lib/thrift_pool_tests.py
+++ b/tests/unit/lib/thrift_pool_tests.py
@@ -179,9 +179,6 @@ class ThriftConnectionPoolTests(unittest.TestCase):
         with self.assertRaises(TTransport.TTransportException):
             self.pool._acquire()
 
-        self.assertEqual(self.mock_queue.put.call_count, 1)
-        self.assertEqual(self.mock_queue.put.call_args, mock.call(None))
-
     def test_release_open(self):
         mock_prot = mock.Mock(spec=THeaderProtocol.THeaderProtocol)
         mock_prot.trans = mock.Mock(spec=TSocket.TSocket)
@@ -294,4 +291,5 @@ class ThriftConnectionPoolTests(unittest.TestCase):
                 pass
 
         self.assertEqual(self.mock_queue.get.call_count, 1)
-        self.assertEqual(self.mock_queue.put.call_count, 2)  # <- the issue: it should be 1
+        self.assertEqual(self.mock_queue.put.call_count, 1)
+        self.assertEqual(self.mock_queue.put.call_args, mock.call(None))


### PR DESCRIPTION
This PR solves another instance of the issue described in #431 (i.e. excess items get into the pool, `thrift_pool.checkedout` returns a negative value).

This time the issue happens when the retry policy exhausted trying to connect to a service. In this case, `self.pool.put(None)` gets called twice: in both `_acquire` and `_release` methods.

Note: I removed two assertions from the `test_max_retry_on_connect` test as they no longer make sense (and fail).

@spladug @m104 Please take a look.