### PR TITLE
Updates the event publisher to not exit on validation errors

### DIFF
--- a/baseplate/sidecars/event_publisher.py
+++ b/baseplate/sidecars/event_publisher.py
@@ -128,9 +128,11 @@ class BatchPublisher:
 
                 # we should crash if it's our fault
                 response = getattr(exc, "response", None)
-                if response is not None and response.status_code < 500:
+                if response and response.status_code < 500:
                     logger.exception("HTTP Request failed. Error: %s", response.text)
-                    raise
+                    if response.status_code != 422:
+                        # Do not exit on validation errors
+                        raise
                 logger.exception("HTTP Request failed.")
             except OSError:
                 self.metrics.counter("error.io").increment()

--- a/baseplate/sidecars/event_publisher.py
+++ b/baseplate/sidecars/event_publisher.py
@@ -128,7 +128,7 @@ class BatchPublisher:
 
                 # we should crash if it's our fault
                 response = getattr(exc, "response", None)
-                if response and response.status_code < 500:
+                if response is not None and response.status_code < 500:
                     logger.exception("HTTP Request failed. Error: %s", response.text)
                     if response.status_code != 422:
                         # Do not exit on validation errors

--- a/baseplate/sidecars/event_publisher.py
+++ b/baseplate/sidecars/event_publisher.py
@@ -133,7 +133,8 @@ class BatchPublisher:
                     if response.status_code != 422:
                         # Do not exit on validation errors
                         raise
-                logger.exception("HTTP Request failed.")
+                else:
+                    logger.exception("HTTP Request failed.")
             except OSError:
                 self.metrics.counter("error.io").increment()
                 logger.exception("HTTP Request failed")


### PR DESCRIPTION
This PR updates the event publisher sidecar to print, but not exit on `HTTPUnprocessableEntity` responses from a downstream event collector. This status code is returned when an event cannot be validated by the collector service.