### PR TITLE
Add support for wavefront tagging to baseplate

### DIFF
--- a/baseplate/observers/metrics_tagged.py
+++ b/baseplate/observers/metrics_tagged.py
@@ -1,0 +1,232 @@
+from enum import Enum
+from random import random
+from typing import Any
+from typing import Dict
+from typing import Optional
+from typing import Set
+
+from baseplate import _ExcInfo
+from baseplate import BaseplateObserver
+from baseplate import LocalSpan
+from baseplate import RequestContext
+from baseplate import Span
+from baseplate import SpanObserver
+from baseplate.lib import config
+from baseplate.lib import metrics
+from baseplate.observers.timeout import ServerTimeout
+
+
+class Errors(Enum):
+    TIMED_OUT = "timed_out"
+    EXCEPTION = "internal_server_error"
+
+
+class TaggedMetricsBaseplateObserver(BaseplateObserver):
+    """Metrics collecting observer.
+
+    This observer reports metrics to statsd in the Influx StatsD format. It does three important things:
+
+    * it tracks the time taken in serving each request.
+    * it batches all metrics generated during a request into as few packets
+      as possible.
+    * it adds tags to the metric if they are in the config tag whitelist
+
+    The batch is accessible to your application during requests as the
+    ``metrics`` attribute on the :py:class:`~baseplate.RequestContext`.
+
+    :param client: The client where metrics will be sent.
+    :param cfg: the parsed application config with the tag whitelist
+
+    """
+
+    def __init__(self, client: metrics.Client, whitelist: Set[str], sample_rate: float = 1.0):
+        self.client = client
+        self.whitelist = whitelist
+        self.sample_rate = sample_rate
+
+    @classmethod
+    def from_config_and_client(
+        cls, raw_config: config.RawConfig, client: metrics.Client
+    ) -> "TaggedMetricsBaseplateObserver":
+        cfg = config.parse_config(
+            raw_config,
+            {
+                "metrics": {
+                    "whitelist": config.Optional(
+                        config.TupleOf(config.String),
+                        default=["client", "endpoint", "success", "error"],
+                    ),
+                },
+                "metrics_observer": {"sample_rate": config.Optional(config.Percent, default=1.0)},
+            },
+        )
+        return cls(
+            client,
+            whitelist=set(cfg.metrics.whitelist),
+            sample_rate=cfg.metrics_observer.sample_rate,
+        )
+
+    def on_server_span_created(self, context: RequestContext, server_span: Span) -> None:
+        batch = self.client.batch()
+        context.metrics = batch
+        if self.sample_rate == 1.0 or random() < self.sample_rate:
+            observer: SpanObserver = TaggedMetricsServerSpanObserver(
+                batch, server_span, self.whitelist, self.sample_rate
+            )
+        else:
+            observer = TaggedMetricsServerSpanDummyObserver(batch)
+        server_span.register(observer)
+
+
+class TaggedMetricsServerSpanDummyObserver(SpanObserver):
+    # for requests that aren't sampled
+    def __init__(self, batch: metrics.Batch):
+        self.batch = batch
+
+    def on_start(self) -> None:
+        pass
+
+    def on_incr_tag(self, key: str, delta: float) -> None:
+        pass
+
+    def on_finish(self, exc_info: Optional[_ExcInfo]) -> None:
+        self.batch.flush()
+
+    def on_child_span_created(self, span: Span) -> None:
+        pass
+
+
+class TaggedMetricsServerSpanObserver(SpanObserver):
+    def __init__(
+        self, batch: metrics.Batch, server_span: Span, whitelist: Set[str], sample_rate: float = 1.0
+    ):
+        self.batch = batch
+        self.span = server_span
+        self.base_name = "baseplate.server"
+        self.whitelist = whitelist
+        self.tags: Dict[str, Any] = {}
+        self.timer = batch.timer(self.base_name)
+        self.counters: Dict[str, float] = {}
+        self.sample_rate = sample_rate
+
+    def on_start(self) -> None:
+        self.tags["endpoint"] = self.span.name
+        self.timer.start(self.sample_rate)
+
+    def on_incr_tag(self, key: str, delta: float) -> None:
+        self.counters[key] = delta
+
+    def on_set_tag(self, key: str, value: Any) -> None:
+        new_tags = {}
+        if key == "error":
+            if isinstance(value, Errors):
+                new_tags[key] = value.value
+        else:
+            new_tags[key] = value
+        self.tags.update(new_tags)
+
+    def on_child_span_created(self, span: Span) -> None:
+        observer: SpanObserver
+        if isinstance(span, LocalSpan):
+            observer = TaggedMetricsLocalSpanObserver(
+                self.batch, span, self.whitelist, self.sample_rate
+            )
+        else:
+            observer = TaggedMetricsClientSpanObserver(
+                self.batch, span, self.whitelist, self.sample_rate
+            )
+        span.register(observer)
+
+    def on_finish(self, exc_info: Optional[_ExcInfo]) -> None:
+        if not exc_info:
+            self.tags["success"] = True
+        else:
+            self.tags["success"] = False
+            if exc_info[0] is not None and issubclass(ServerTimeout, exc_info[0]):
+                self.tags["timed_out"] = True
+        filtered_tags = {k: v for (k, v) in self.tags.items() if k in self.whitelist}
+        self.tags = filtered_tags
+        for key, delta in self.counters.items():
+            self.batch.counter(key, self.tags).increment(delta, sample_rate=self.sample_rate)
+        self.timer.update_tags(self.tags)
+        self.timer.stop()
+        self.batch.flush()
+
+
+class TaggedMetricsLocalSpanObserver(SpanObserver):
+    def __init__(
+        self, batch: metrics.Batch, span: Span, whitelist: Set[str], sample_rate: float = 1.0
+    ):
+        self.batch = batch
+        self.span = span
+        self.tags: Dict[str, Any] = {}
+        self.timer = batch.timer("baseplate.local")
+        self.whitelist = whitelist
+        self.counters: Dict[str, float] = {}
+        self.sample_rate = sample_rate
+
+    def on_start(self) -> None:
+        self.timer.start(self.sample_rate)
+        self.tags["endpoint"] = self.span.name
+
+    def on_incr_tag(self, key: str, delta: float) -> None:
+        self.counters[key] = delta
+
+    def on_set_tag(self, key: str, value: Any) -> None:
+        if key == "error":
+            if isinstance(value, Errors):
+                self.tags["error"] = value.value
+        else:
+            self.tags[key] = value
+
+    def on_finish(self, exc_info: Optional[_ExcInfo]) -> None:
+        filtered_tags = {k: v for (k, v) in self.tags.items() if k in self.whitelist}
+        for key, delta in self.counters.items():
+            self.batch.counter(key, self.tags).increment(delta, sample_rate=self.sample_rate)
+        self.tags = filtered_tags
+        self.timer.update_tags(self.tags)
+        self.timer.stop()
+        self.batch.flush()
+
+
+class TaggedMetricsClientSpanObserver(SpanObserver):
+    def __init__(
+        self, batch: metrics.Batch, span: Span, whitelist: Set[str], sample_rate: float = 1.0
+    ):
+        self.batch = batch
+        self.span = span
+        self.base_name = "baseplate.client"
+        self.tags: Dict[str, Any] = {}
+        self.timer = batch.timer(self.base_name)
+        self.whitelist = whitelist
+        self.counters: Dict[str, float] = {}
+        self.sample_rate = sample_rate
+
+    def on_start(self) -> None:
+        self.timer.start(self.sample_rate)
+        self.tags["client"] = self.span.name.split(".")[0]
+        self.tags["endpoint"] = self.span.name.split(".")[1]
+
+    def on_incr_tag(self, key: str, delta: float) -> None:
+        self.counters[key] = delta
+
+    def on_set_tag(self, key: str, value: Any) -> None:
+        if key == "error":
+            if isinstance(value, Errors):
+                self.tags["error"] = value.value
+        else:
+            self.tags[key] = value
+
+    def on_log(self, name: str, payload: Any) -> None:
+        if name == "error.object":
+            self.tags["error"] = Errors.EXCEPTION.value
+
+    def on_finish(self, exc_info: Optional[_ExcInfo]) -> None:
+        self.tags["success"] = not exc_info
+        filtered_tags = {k: v for (k, v) in self.tags.items() if k in self.whitelist}
+        self.tags = filtered_tags
+        for key, delta in self.counters.items():
+            self.batch.counter(key, self.tags).increment(delta, sample_rate=self.sample_rate)
+        self.timer.update_tags(self.tags)
+        self.timer.stop()
+        self.batch.flush()

--- a/docs/api/baseplate/observers/index.rst
+++ b/docs/api/baseplate/observers/index.rst
@@ -25,6 +25,7 @@ configuration options are available.
 
    logging
    statsd
+   tagged_statsd
    sentry
    tracing
    timeout

--- a/docs/api/baseplate/observers/tagged_statsd.rst
+++ b/docs/api/baseplate/observers/tagged_statsd.rst
@@ -1,0 +1,93 @@
+StatsD Tagged Metrics
+=====================
+
+The tagged metrics observer emits `StatsD`_-compatible time-series metrics about the
+performance of your application with tags in the InfluxStatsD format. The tags added to 
+the metrics are configurable: any tags that pass through the span.set_tag() 
+function are filtered through a user-supplied whitelist in the configuration file.
+
+.. _`StatsD`: https://github.com/statsd/statsd
+
+Configuration
+-------------
+
+Make sure your service calls
+:py:meth:`~baseplate.Baseplate.configure_observers` during application startup
+and then add the following to your configuration file to enable and configure
+the StatsD tagged metrics observer.
+
+Do not include a metrics.namespace parameter in the configuration file, as it incompatible with 
+the service.
+
+.. code-block:: ini
+
+   [app:main]
+
+   ...
+
+   # required to enable observer
+   metrics.tagging = true
+
+   # optional: whitelist of tags to allow predefined tags from baseplate separated by commas
+   # defaults to [ endpoint, success, error ] if no value is provided
+   metrics.whitelist = endpoint, success, error
+
+   # optional: the percent of statsd metrics to sample
+   # if not specified, it will default to 100% (all metrics sent)
+   # config must be passed to the `Baseplate` constructor to use this option
+   metrics_observer.sample_rate = 100%
+
+   ...
+
+Whitelist Options
+-----------------
+Wavefront supports a maximum of 20 tags per cluster and 1000 distinct time series per 
+metric. Baseplate integrations of frameworks come out of the box with some default tags set via span.set_tag(), 
+but to append them to the metrics they must be present in the configuration file via metrics.whitelist. 
+
+In order to find these tags to put in the whitelist, look through the code base for calls to span.set_tag()
+or check a zipkin trace in Wavefront to see all the tags on a span. 
+   
+Outputs
+-------
+
+For each span in the application, the metrics observer emits a
+:py:class:`~baseplate.lib.metrics.Timer` tracking how long the span took and
+increments a :py:class:`~baseplate.lib.metrics.Counter` for success or failure
+of the span (failure being an unexpected exception).
+
+A key differentiation from the :doc:`untagged StatsD metrics observer <statsd>` is that the emitted
+outputs from baseplate no longer contain a namespace prefix. Prepending the namespace must be configured
+in Telegraf via the ``name_prefix`` input plugin configuration.
+
+For the :py:class:`~baseplate.ServerSpan` representing the request the server
+is handling, the timer has a name like
+``baseplate.server,endpoint={route_or_method_name}`` and the counter looks like
+``baseplate.server,success={true,false},endpoint={route_or_method_name}``. If the request
+:doc:`timed out <timeout>` an additional tag will be added to make it 
+``baseplate.server,success={true,false},endpoint={route_or_method_name},timed_out={true,false}``
+assuming that success, endpoint, and timed_out are all present in the whitelist.
+
+For each span representing a call to a remote service or database, the timer
+has a name like ``baseplate.clients,endpoint={method}`` and the counter
+``baseplate.clients,endpoint={method},success={true,false}``.
+
+When using :program:`baseplate-serve`, various process-level runtime metrics
+will also be emitted. These are not tied to individual requests but instead
+give insight into how the whole application is functioning. See
+:ref:`runtime-metrics` for more information.
+
+Direct Use
+----------
+
+When enabled, the metrics observer also adds a
+:py:class:`~baseplate.lib.metrics.Client` object as an attribute named
+``metrics`` to the :py:class:`~baseplate.RequestContext` which can take an optional
+tags parameter in the form of a ``dict``::
+
+   def my_handler(request):
+       request.metrics.counter("foo", {"bar": "baz"}).increment()
+
+To keep your application more generic, it's better to use local spans for
+custom local timers and :py:meth:`~baseplate.Span.incr_tag` for custom
+counters.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,10 +26,7 @@ extensions = [
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3.7", None),
-    "pyramid": (
-        "https://docs.pylonsproject.org/projects/pyramid/en/1.9-branch",
-        None,
-    ),
+    "pyramid": ("https://docs.pylonsproject.org/projects/pyramid/en/1.9-branch", None,),
     "cassandra": ("https://datastax.github.io/python-driver/", None),
     "pymemcache": ("https://pymemcache.readthedocs.io/en/latest/", None),
     "kazoo": ("https://kazoo.readthedocs.io/en/latest/", None),
@@ -76,9 +73,7 @@ html_theme = "alabaster"
 
 # which templates to put in the sidebar.  we're just removing the relations
 # section from the defaults here, that's "next article" and "previous article"
-html_sidebars = {
-    "**": ["about.html", "searchbox.html", "navigation.html"]
-}
+html_sidebars = {"**": ["about.html", "searchbox.html", "navigation.html"]}
 
 html_theme_options = {
     "description": "Reddit's Python Service Framework",

--- a/setup.py
+++ b/setup.py
@@ -40,10 +40,7 @@ setup(
     ],
     # the thrift compiler must be able to find baseplate.thrift to build
     # services which extend BaseplateService.
-    package_data={
-        "baseplate": ["py.typed"],
-        "baseplate.thrift": ["*.thrift"],
-    },
+    package_data={"baseplate": ["py.typed"], "baseplate.thrift": ["*.thrift"]},
     zip_safe=False,
     entry_points={
         "distutils.commands": [

--- a/tests/integration/message_queue_tests.py
+++ b/tests/integration/message_queue_tests.py
@@ -54,7 +54,7 @@ class TestMessageQueueCreation(unittest.TestCase):
             with self.assertRaises(TimedOutError):
                 mq.put(b"x", timeout=0.1)
             elapsed = time.time() - start
-            self.assertAlmostEqual(elapsed, 0.1, places=2)
+            self.assertAlmostEqual(elapsed, 0.1, places=1)
 
     def test_put_zero_timeout(self):
         message_queue = MessageQueue(self.qname, max_messages=1, max_message_size=1)

--- a/tests/unit/observers/metrics_tagged_tests.py
+++ b/tests/unit/observers/metrics_tagged_tests.py
@@ -1,0 +1,273 @@
+import unittest
+
+from unittest import mock
+
+from baseplate import LocalSpan
+from baseplate import ServerSpan
+from baseplate import Span
+from baseplate.lib.metrics import Batch
+from baseplate.lib.metrics import Client
+from baseplate.lib.metrics import Counter
+from baseplate.lib.metrics import Timer
+from baseplate.observers.metrics_tagged import Errors
+from baseplate.observers.metrics_tagged import TaggedMetricsBaseplateObserver
+from baseplate.observers.metrics_tagged import TaggedMetricsClientSpanObserver
+from baseplate.observers.metrics_tagged import TaggedMetricsLocalSpanObserver
+from baseplate.observers.metrics_tagged import TaggedMetricsServerSpanObserver
+from baseplate.observers.timeout import ServerTimeout
+
+
+class TestException(Exception):
+    pass
+
+
+class ObserverTests(unittest.TestCase):
+    def test_add_to_context(self):
+        mock_client = mock.Mock(spec=Client)
+        mock_batch = mock_client.batch.return_value
+        mock_context = mock.Mock()
+        mock_server_span = mock.Mock(spec=ServerSpan)
+        mock_server_span.name = "name"
+        mock_whitelist = ["endpoint", "success", "error", "client"]
+        mock_sample_rate = 1.0
+
+        observer = TaggedMetricsBaseplateObserver(mock_client, mock_whitelist, mock_sample_rate)
+        observer.on_server_span_created(mock_context, mock_server_span)
+
+        self.assertEqual(mock_context.metrics, mock_batch)
+        self.assertEqual(mock_server_span.register.call_count, 1)
+
+
+class ServerSpanObserverTests(unittest.TestCase):
+    def setUp(self):
+        super().setUp()
+        self.mock_batch = mock.Mock(spec=Batch)
+        self.mock_timer = mock.Mock(spec=Timer)
+        self.mock_counter = mock.Mock(spec=Counter)
+        self.mock_batch.timer.return_value = self.mock_timer
+        self.mock_batch.counter.return_value = self.mock_counter
+        mock_whitelist = ["endpoint", "success", "error", "incr"]
+        mock_whitelist_empty = []
+
+        mock_server_span = mock.Mock(spec=ServerSpan)
+        mock_server_span.name = "request_name"
+
+        self.observer = TaggedMetricsServerSpanObserver(
+            self.mock_batch, mock_server_span, mock_whitelist
+        )
+        self.observer_empty_whitelist = TaggedMetricsServerSpanObserver(
+            self.mock_batch, mock_server_span, mock_whitelist_empty
+        )
+
+    def test_on_start(self):
+        self.observer.on_start()
+        self.assertEqual(self.mock_timer.start.call_count, 1)
+
+    def test_on_incr_tag(self):
+        self.observer.on_incr_tag("incr", delta=1)
+        self.observer_empty_whitelist.on_incr_tag("incr", delta=1)
+
+        self.assertEqual(self.mock_counter.increment.call_count, 0)
+
+        self.assertTrue("incr" in self.observer.counters)
+
+        self.observer.on_finish(exc_info=None)
+        self.observer_empty_whitelist.on_finish(exc_info=None)
+
+        self.assertEqual(self.mock_counter.increment.call_count, 2)
+
+    def test_on_set_tag(self):
+        self.observer.on_set_tag("test", "value")
+        self.observer_empty_whitelist.on_set_tag("error", Errors.EXCEPTION)
+
+        self.observer.on_set_tag("error", "error")
+        self.assertFalse("error" in self.observer.tags)
+
+        self.observer.on_set_tag("error", Errors.EXCEPTION)
+        self.assertTrue("error" in self.observer.tags)
+
+    def test_on_child_span_created(self):
+        mock_child_span = mock.Mock()
+        mock_child_span.name = "example"
+        self.observer.on_child_span_created(mock_child_span)
+        self.assertEqual(mock_child_span.register.call_count, 1)
+
+    def test_on_finish(self):
+        self.observer.on_start()
+        self.observer_empty_whitelist.on_start()
+
+        self.observer.on_set_tag("test", "value")
+        self.observer.on_set_tag("error", Errors.EXCEPTION)
+        self.observer_empty_whitelist.on_set_tag("test", "value")
+        self.observer_empty_whitelist.on_set_tag("error", Errors.EXCEPTION)
+
+        self.observer.on_finish(exc_info=None)
+        self.observer_empty_whitelist.on_finish(exc_info=None)
+        self.assertEqual(self.mock_timer.stop.call_count, 2)
+        self.assertEqual(self.mock_batch.flush.call_count, 2)
+
+        self.assertFalse("test" in self.observer.tags)
+        self.assertEqual(self.observer.tags["error"], "internal_server_error")
+
+        self.assertFalse("error" in self.observer_empty_whitelist.tags)
+        self.assertFalse("test" in self.observer_empty_whitelist.tags)
+
+        self.observer.on_finish(exc_info=(ServerTimeout, ServerTimeout("timeout", 3.0, False)))
+        self.assertFalse(self.observer.tags["success"])
+        self.assertFalse("timed_out" in self.observer.tags)
+
+
+class LocalSpanObserverTests(unittest.TestCase):
+    def setUp(self):
+        super().setUp()
+        self.mock_batch = mock.Mock(spec=Batch)
+        self.mock_timer = mock.Mock(spec=Timer)
+        self.mock_counter = mock.Mock(spec=Counter)
+        self.mock_batch.timer.return_value = self.mock_timer
+        self.mock_batch.counter.return_value = self.mock_counter
+        mock_whitelist = ["endpoint", "success", "error", "incr"]
+        mock_whitelist_empty = []
+
+        mock_server_span = mock.Mock(spec=ServerSpan)
+        mock_server_span.name = "request_name"
+
+        self.observer = TaggedMetricsServerSpanObserver(
+            self.mock_batch, mock_server_span, mock_whitelist
+        )
+        self.observer_empty_whitelist = TaggedMetricsServerSpanObserver(
+            self.mock_batch, mock_server_span, mock_whitelist_empty
+        )
+        self.mock_timer = mock.Mock(spec=Timer)
+        self.mock_counter = mock.Mock(spec=Counter)
+        self.mock_batch = mock.Mock(spec=Batch)
+        self.mock_batch.timer.return_value = self.mock_timer
+        self.mock_batch.counter.return_value = self.mock_counter
+        mock_whitelist = ["endpoint", "success", "error"]
+        mock_whitelist_empty = []
+
+        mock_local_span = mock.Mock(spec=LocalSpan)
+        mock_local_span.name = "example"
+        mock_local_span.component_name = "some_component"
+
+        self.observer = TaggedMetricsLocalSpanObserver(
+            self.mock_batch, mock_local_span, mock_whitelist
+        )
+        self.observer_empty_whitelist = TaggedMetricsLocalSpanObserver(
+            self.mock_batch, mock_local_span, mock_whitelist_empty
+        )
+
+    def test_on_start(self):
+        self.observer.on_start()
+        self.assertEqual(self.mock_timer.start.call_count, 1)
+
+    def test_on_incr_tag(self):
+        self.observer.on_incr_tag("test", delta=1)
+        self.assertEqual(self.mock_counter.increment.call_count, 0)
+        self.assertTrue("test" in self.observer.counters)
+        self.observer.on_finish(exc_info=None)
+        self.assertEqual(self.mock_counter.increment.call_count, 1)
+
+    def test_on_set_tag(self):
+        self.observer.on_set_tag("test", "value")
+        self.observer_empty_whitelist.on_set_tag("error", Errors.EXCEPTION)
+
+        self.observer.on_set_tag("error", "error")
+        self.assertFalse("error" in self.observer.tags)
+
+        self.observer.on_set_tag("error", Errors.EXCEPTION)
+        self.assertTrue("error" in self.observer.tags)
+
+    def test_on_finish(self):
+        self.observer.on_start()
+        self.observer_empty_whitelist.on_start()
+
+        self.observer.on_set_tag("test", "value")
+        self.observer.on_set_tag("error", Errors.EXCEPTION)
+        self.observer_empty_whitelist.on_set_tag("test", "value")
+        self.observer_empty_whitelist.on_set_tag("error", Errors.EXCEPTION)
+
+        self.observer.on_finish(exc_info=None)
+        self.observer_empty_whitelist.on_finish(exc_info=None)
+        self.assertEqual(self.mock_timer.stop.call_count, 2)
+        self.assertEqual(self.mock_batch.flush.call_count, 2)
+
+        self.assertFalse("test" in self.observer.tags)
+        self.assertEqual(self.observer.tags["error"], "internal_server_error")
+
+        self.assertFalse("error" in self.observer_empty_whitelist.tags)
+        self.assertFalse("test" in self.observer_empty_whitelist.tags)
+
+
+class ClientSpanObserverTests(unittest.TestCase):
+    def setUp(self):
+        super().setUp()
+        self.mock_timer = mock.Mock(spec=Timer)
+        self.mock_counter = mock.Mock(spec=Counter)
+        self.mock_batch = mock.Mock(spec=Batch)
+        self.mock_batch.timer.return_value = self.mock_timer
+        self.mock_batch.counter.return_value = self.mock_counter
+        mock_whitelist = ["endpoint", "success", "error"]
+        mock_whitelist_empty = []
+
+        mock_client_span = mock.Mock(spec=Span)
+        mock_client_span.name = "client.endpoint"
+
+        self.observer = TaggedMetricsClientSpanObserver(
+            self.mock_batch, mock_client_span, mock_whitelist
+        )
+        self.observer_empty_whitelist = TaggedMetricsClientSpanObserver(
+            self.mock_batch, mock_client_span, mock_whitelist_empty
+        )
+
+    def test_on_start(self):
+        self.observer.on_start()
+        self.assertEqual(self.mock_timer.start.call_count, 1)
+        self.assertEqual(self.observer.tags["client"], "client")
+        self.assertEqual(self.observer.tags["endpoint"], "endpoint")
+
+    def test_incr_tag(self):
+        self.observer.on_incr_tag("test", delta=1)
+        self.mock_counter.increment.assert_not_called()
+        self.assertTrue("test" in self.observer.counters)
+        self.observer.on_finish(exc_info=None)
+        self.mock_counter.increment.assert_called()
+
+    def test_on_set_tag(self):
+        self.observer.on_set_tag("test", "value")
+        self.observer_empty_whitelist.on_set_tag("error", Errors.EXCEPTION)
+
+        self.observer.on_set_tag("error", "error")
+        self.assertFalse("error" in self.observer.tags)
+
+        self.observer.on_set_tag("error", Errors.EXCEPTION)
+        self.assertTrue("error" in self.observer.tags)
+
+    def test_on_log(self):
+        self.observer.on_log("any", {})
+        self.assertFalse("error" in self.observer.tags)
+        self.observer.on_log("error.object", {})
+        self.assertEqual(self.observer.tags["error"], "internal_server_error")
+
+    def test_on_finish(self):
+        self.observer.on_start()
+        self.observer_empty_whitelist.on_start()
+
+        self.observer.on_set_tag("test", "value")
+        self.observer.on_set_tag("error", Errors.EXCEPTION)
+        self.observer_empty_whitelist.on_set_tag("test", "value")
+        self.observer_empty_whitelist.on_set_tag("error", Errors.EXCEPTION)
+
+        self.observer.on_finish(exc_info=None)
+        self.observer_empty_whitelist.on_finish(exc_info=None)
+        self.assertEqual(self.mock_timer.stop.call_count, 2)
+        self.assertEqual(self.mock_batch.flush.call_count, 2)
+
+        self.assertFalse("test" in self.observer.tags)
+        self.assertEqual(self.observer.tags["error"], "internal_server_error")
+
+        self.assertFalse("error" in self.observer_empty_whitelist.tags)
+        self.assertFalse("test" in self.observer_empty_whitelist.tags)
+
+        self.observer.on_finish(exc_info=(ServerTimeout, ServerTimeout("timeout", 3.0, False)))
+        self.assertFalse(self.observer.tags["success"])
+        self.assertFalse("timed_out" in self.observer.tags)


### PR DESCRIPTION
added new metrics observer that forwards tags in influxstatsd format to wavefront, added documentation and tests, retrofitted with sample_rate changes

https://github.com/reddit/baseplate.py/pull/418