### PR TITLE
Add asserts in kafka tests

### DIFF
--- a/tests/unit/frameworks/queue_consumer/kafka_tests.py
+++ b/tests/unit/frameworks/queue_consumer/kafka_tests.py
@@ -548,13 +548,13 @@ class TestKafkaConsumerWorker:
             stopped_value.side_effect = [False, False, False, True]
             consumer_worker.run()
 
-        baseplate.make_context_object.mock_calls == [mock.call(), mock.call(), mock.call()]
-        baseplate.make_server_span.mock_calls == [
+        assert baseplate.make_context_object.mock_calls == [mock.call(), mock.call(), mock.call()]
+        assert baseplate.make_server_span.mock_calls == [
             mock.call(context, f"{name}.pump"),
             mock.call(context, f"{name}.pump"),
             mock.call(context, f"{name}.pump"),
         ]
-        span.make_child.mock_calls == [
+        assert span.make_child.mock_calls == [
             mock.call("kafka.consume"),
             mock.call("kafka.work_queue_put"),
             mock.call("kafka.consume"),


### PR DESCRIPTION
Starting to contribute to baseplate with fixing a few test statements :)

Noticed a few tests in kafka tests file don't have asserts.
