### PR TITLE
thrift pool: Discard closed connections when fetching from pool

### DIFF
--- a/baseplate/lib/thrift_pool.py
+++ b/baseplate/lib/thrift_pool.py
@@ -205,7 +205,7 @@ class ThriftConnectionPool:
         )
 
     def _is_stale(self, prot: TProtocolBase) -> bool:
-        if time.time() - prot.baseplate_birthdate > self.max_age:
+        if not prot.trans.isOpen() or time.time() - prot.baseplate_birthdate > self.max_age:
             prot.trans.close()
             return True
         return False


### PR DESCRIPTION
With no other changes to Thrift this is a no-op, but when [Thrift's
TSocket.isOpen() starts checking if the socket is still readable][thrift] Baseplate will
discard sockets where the server has closed the connection which saves
us from a doomed attempt at serializing and sending an RPC just to get
an error.

Drone Cloud is still broken but I promise the tests passed locally :(

cc: @fishy 

[thrift]: https://github.com/apache/thrift/compare/master...spladug:python-stricter-isOpen