### PR TITLE
thrift pool: Discard closed connections when fetching from pool

### DIFF
--- a/baseplate/lib/thrift_pool.py
+++ b/baseplate/lib/thrift_pool.py
@@ -205,7 +205,7 @@ class ThriftConnectionPool:
         )
 
     def _is_stale(self, prot: TProtocolBase) -> bool:
-        if time.time() - prot.baseplate_birthdate > self.max_age:
+        if not prot.trans.isOpen() or time.time() - prot.baseplate_birthdate > self.max_age:
             prot.trans.close()
             return True
         return False


### PR DESCRIPTION
Inspired by changes @fishy made to the Thrift Go library ([THRIFT-5214]) and, by proxy, [this blog post] I'm making the Python Thrift library [check if the server is still connected][2] in `TSocket.isOpen()`. This change to Baseplate.py's Thrift pool should be a no-op while Thrift is unchanged, but once Thrift is updated we'll automatically discard connections that are already closed before we try to use them. This costs about a hundred microseconds in tests but means that we don't serialize and send a message just to get an error as soon as we try to read the response so should overall save quite a lot of time. This also means we don't need to retry every thrift call quite as heavily because we're worried about already-dead connections.

[THRIFT-5214]: https://issues.apache.org/jira/browse/THRIFT-5214
[this blog post]: https://github.blog/2020-05-20-three-bugs-in-the-go-mysql-driver/
[2]: https://github.com/apache/thrift/compare/master...spladug:python-stricter-isOpen

~Drone Cloud is still broken but I promise the tests passed locally :(~

cc: @fishy 