### PR TITLE
Add requests-based HTTP clients

### DIFF
--- a/baseplate/clients/requests.py
+++ b/baseplate/clients/requests.py
@@ -1,0 +1,322 @@
+import base64
+import ipaddress
+
+from typing import Any
+from typing import Type
+from typing import Union
+
+from advocate import AddrValidator
+from advocate import ValidatingHTTPAdapter
+from requests import PreparedRequest
+from requests import Request
+from requests import Response
+from requests import Session
+from requests.adapters import HTTPAdapter
+
+from baseplate import Span
+from baseplate.clients import ContextFactory
+from baseplate.lib import config
+
+
+def http_adapter_from_config(
+    app_config: config.RawConfig, prefix: str, **kwargs: Any
+) -> HTTPAdapter:
+    """Make an HTTPAdapter from a configuration dictionary.
+
+    The keys useful to :py:func:`http_adapter_from_config` should be prefixed,
+    e.g. ``http.pool_connections``, ``http.max_retries``, etc. The ``prefix``
+    argument specifies the prefix used. Each key is mapped to a corresponding
+    keyword argument on the :py:class:`~requests.adapters.HTTPAdapter`
+    constructor.
+
+    Supported keys:
+
+    * ``pool_connections``: The number of connections to cache (default: 10).
+    * ``pool_maxsize``: The maximum number of connections to keep in the pool
+      (default: 10).
+    * ``max_retries``: How many times to retry DNS lookups or connection
+      attempts, but never sending data (default: 0).
+    * ``pool_block``: Whether the connection pool will block when trying to get
+      a connection (default: false).
+
+    Additionally, the rules for Advocate's address filtering can be configured
+    with the ``filter`` sub-keys:
+
+    * ``filter.ip_allowlist``: A comma-delimited list of IP addresses (1.2.3.4)
+        or CIDR-notation (1.2.3.0/24) ranges that the client can always connect to
+        (default: anything not on the local network).
+    * ``filter.ip_denylist``: A comma-delimited list of IP addresses or
+        CIDR-notation ranges the client may never connect to (default: the local network).
+    * ``filter.port_allowlist``: A comma-delimited list of TCP port numbers
+        that the client can connect to (default: 80, 8080, 443, 8443, 8000).
+    * ``filter.port_denylist``: A comma-delimited list of TCP port numbers that
+        the client may never connect to (default: none).
+    * ``filter.hostname_denylist``: A comma-delimited list of hostnames that
+        the client may never connect to (default: none).
+    * ``filter.allow_ipv6``: Should the client be allowed to connect to IPv6
+        hosts? (default: false, note: IPv6 is tricky to apply filtering rules
+        comprehensively to).
+
+    """
+
+    assert prefix.endswith(".")
+    parser = config.SpecParser(
+        {
+            "pool_connections": config.Optional(config.Integer, default=10),
+            "pool_maxsize": config.Optional(config.Integer, default=10),
+            "max_retries": config.Optional(config.Integer, default=0),
+            "pool_block": config.Optional(config.Boolean, default=False),
+            "filter": {
+                "ip_allowlist": config.Optional(config.TupleOf(ipaddress.ip_network)),
+                "ip_denylist": config.Optional(config.TupleOf(ipaddress.ip_network)),
+                "port_allowlist": config.Optional(config.TupleOf(int)),
+                "port_denylist": config.Optional(config.TupleOf(int)),
+                "hostname_denylist": config.Optional(config.TupleOf(config.String)),
+                "allow_ipv6": config.Optional(config.Boolean, default=False),
+            },
+        }
+    )
+    options = parser.parse(prefix[:-1], app_config)
+
+    if options.pool_connections is not None:
+        kwargs.setdefault("pool_connections", options.pool_connections)
+    if options.pool_maxsize is not None:
+        kwargs.setdefault("pool_maxsize", options.pool_maxsize)
+    if options.max_retries is not None:
+        kwargs.setdefault("max_retries", options.max_retries)
+    if options.pool_block is not None:
+        kwargs.setdefault("pool_block", options.pool_block)
+
+    kwargs.setdefault(
+        "validator",
+        AddrValidator(
+            ip_whitelist=options.filter.ip_allowlist,
+            ip_blacklist=options.filter.ip_denylist,
+            port_whitelist=options.filter.port_allowlist,
+            port_blacklist=options.filter.port_denylist,
+            hostname_blacklist=options.filter.hostname_denylist,
+            allow_ipv6=options.filter.allow_ipv6,
+        ),
+    )
+    return ValidatingHTTPAdapter(**kwargs)
+
+
+class BaseplateSession:
+    """A proxy for :py:class:`requests.Session`.
+
+    Requests sent with this client will be instrumented automatically.
+
+    """
+
+    def __init__(self, adapter: HTTPAdapter, name: str, span: Span) -> None:
+        self.adapter = adapter
+        self.name = name
+        self.span = span
+
+    def delete(self, url: str, **kwargs: Any) -> Response:
+        """Send a DELETE request.
+
+        See :py:func:`requests.request` for valid keyword arguments.
+
+        """
+        return self.request("DELETE", url, **kwargs)
+
+    def get(self, url: str, **kwargs: Any) -> Response:
+        """Send a GET request.
+
+        See :py:func:`requests.request` for valid keyword arguments.
+
+        """
+        return self.request("GET", url, **kwargs)
+
+    def head(self, url: str, **kwargs: Any) -> Response:
+        """Send a HEAD request.
+
+        See :py:func:`requests.request` for valid keyword arguments.
+
+        """
+        return self.request("HEAD", url, **kwargs)
+
+    def options(self, url: str, **kwargs: Any) -> Response:
+        """Send an OPTIONS request.
+
+        See :py:func:`requests.request` for valid keyword arguments.
+
+        """
+        return self.request("OPTIONS", url, **kwargs)
+
+    def patch(self, url: str, **kwargs: Any) -> Response:
+        """Send a PATCH request.
+
+        See :py:func:`requests.request` for valid keyword arguments.
+
+        """
+        return self.request("PATCH", url, **kwargs)
+
+    def put(self, url: str, **kwargs: Any) -> Response:
+        """Send a PUT request.
+
+        See :py:func:`requests.request` for valid keyword arguments.
+
+        """
+        return self.request("PUT", url, **kwargs)
+
+    def prepare_request(self, request: Request) -> PreparedRequest:
+        """Construct a :py:class:`~requests.PreparedRequest` for later use.
+
+        The prepared request can be stored or manipulated and then used with
+        :py:meth:`send`.
+
+        """
+        return request.prepare()
+
+    def request(self, method: str, url: Union[str, bytes], **kwargs: Any) -> Response:
+        """Send a request.
+
+        :param method: The HTTP method of the request, e.g. ``GET``, ``PUT``, etc.
+        :param url: The URL to send the request to.
+
+        See :py:func:`requests.request` for valid keyword arguments.
+
+        """
+        request = Request(method=method.upper(), url=url, **kwargs)
+        prepared = self.prepare_request(request)
+        return self.send(prepared)
+
+    def send(self, request: PreparedRequest) -> Response:
+        """Send a :py:class:`~requests.PreparedRequest`."""
+
+        with self.span.make_child(f"{self.name}.request") as span:
+            span.set_tag("http.method", request.method)
+            span.set_tag("http.url", request.url)
+
+            # we cannot re-use the same session every time because sessions re-use the same
+            # CookieJar and so we'd muddle cookies cross-request. if the application wants
+            # to keep track of cookies, it should do so itself.
+            #
+            # note: we're still getting connection pooling because we're re-using the adapter.
+            session = Session()
+            session.mount("http://", self.adapter)
+            session.mount("https://", self.adapter)
+            response = session.send(request)
+
+            span.set_tag("http.status_code", response.status_code)
+        return response
+
+
+class InternalBaseplateSession(BaseplateSession):
+    def send(self, request: PreparedRequest) -> Response:
+        request.headers["X-Trace"] = str(self.span.trace_id)
+        request.headers["X-Parent"] = str(self.span.parent_id)
+        request.headers["X-Span"] = str(self.span.id)
+        if self.span.sampled:
+            request.headers["X-Sampled"] = "1"
+        if self.span.flags is not None:
+            request.headers["X-Flags"] = str(self.span.flags)
+
+        try:
+            edge_context = self.span.context.raw_request_context
+        except AttributeError:
+            pass
+        else:
+            request.headers["X-Edge-Context"] = base64.b64encode(edge_context).decode()
+        return super().send(request)
+
+
+class RequestsContextFactory(ContextFactory):
+    """Requests client context factory.
+
+    This factory will attach a
+    :py:class:`~baseplate.clients.requests.BaseplateSession` to an attribute
+    on the :py:class:`~baseplate.RequestContext`. When HTTP requests are sent
+    via this session, they will use connections from the provided
+    :py:class:`~requests.adapters.HTTPAdapter` connection pools and
+    automatically record diagnostic information.
+
+    Note that though the connection pool is shared across calls, a new
+    :py:class:`~requests.Session` is created for each request so that cookies
+    and other state are not accidentally shared between requests. If you do
+    want to persist state, you will need to do it in your application.
+
+    :param adapter: A transport adapter for making HTTP requests. See
+        :py:func:`http_adapter_from_config`.
+    :param session_cls: The type for the actual session object to put on the
+        request context.
+
+    """
+
+    def __init__(self, adapter: HTTPAdapter, session_cls: Type[BaseplateSession]) -> None:
+        self.adapter = adapter
+        self.session_cls = session_cls
+
+    def make_object_for_context(self, name: str, span: Span) -> BaseplateSession:
+        return self.session_cls(self.adapter, name, span)
+
+
+class InternalRequestsClient(config.Parser):
+    """Configure a Requests client for use with internal Baseplate HTTP services.
+
+    Requests made with this client **will** include trace context and
+    :doc:`edge context </api/baseplate/lib/edge_context>`. This client should
+    only be used to speak to trusted internal services.  URLs that resolve to
+    public addresses will be rejected.  It is not possible to override the
+    Advocate address validator used by this client.
+
+    .. warning:: Requesting user-specified URLs with this client could lead to
+        `Server-Side Request Forgery`_. Ensure that you only request trusted URLs
+        e.g. hard-coded or from a local configuration file.
+
+    .. _`Server-Side Request Forgery`: https://en.wikipedia.org/wiki/Server-side_request_forgery
+
+    This is meant to be used with
+    :py:meth:`baseplate.Baseplate.configure_context`.
+
+    See :py:func:`http_adapter_from_config` for available configuration settings.
+
+    """
+
+    def __init__(self, **kwargs: Any) -> None:
+        self.kwargs = kwargs
+
+        if "validator" in kwargs:
+            raise Exception("validator is hard-coded for internal clients")
+
+    def parse(self, key_path: str, raw_config: config.RawConfig) -> RequestsContextFactory:
+        # use advocate to ensure this client only ever gets used
+        # with internal services over the internal network.
+        #
+        # the allowlist takes precedence. allow loopback and 10./8 private
+        # addresses, deny the rest.
+        validator = AddrValidator(
+            ip_whitelist={ipaddress.ip_network("127.0.0.0/8"), ipaddress.ip_network("10.0.0.0/8")},
+            ip_blacklist={ipaddress.ip_network("0.0.0.0/0")},
+            port_blacklist=[0],  # disable the default allowlist by giving an explicit denylist
+            allow_ipv6=False,
+        )
+
+        adapter = http_adapter_from_config(
+            raw_config, prefix=f"{key_path}.", validator=validator, **self.kwargs
+        )
+        return RequestsContextFactory(adapter, session_cls=InternalBaseplateSession)
+
+
+class ExternalRequestsClient(config.Parser):
+    """Configure a Requests client for use with external HTTP services.
+
+    Requests made with this client **will not** include trace context and
+    :doc:`edge context </api/baseplate/lib/edge_context>`. This client is
+    suitable for use with third party or untrusted services.
+
+    This is meant to be used with
+    :py:meth:`baseplate.Baseplate.configure_context`.
+
+    See :py:func:`http_adapter_from_config` for available configuration settings.
+
+    """
+
+    def __init__(self, **kwargs: Any) -> None:
+        self.kwargs = kwargs
+
+    def parse(self, key_path: str, raw_config: config.RawConfig) -> RequestsContextFactory:
+        adapter = http_adapter_from_config(raw_config, f"{key_path}.", **self.kwargs)
+        return RequestsContextFactory(adapter, session_cls=BaseplateSession)

--- a/docs/api/baseplate/clients/index.rst
+++ b/docs/api/baseplate/clients/index.rst
@@ -14,6 +14,7 @@ Instrumented Client Libraries
    baseplate.clients.kombu: Client for publishing to queues <kombu>
    baseplate.clients.memcache: Memcached Client <memcache>
    baseplate.clients.redis: Redis Client <redis>
+   baseplate.clients.requests: Requests (HTTP) Client <requests>
    baseplate.clients.sqlalchemy: SQL Client for relational databases (e.g. PostgreSQL) <sqlalchemy>
    baseplate.clients.thrift: Thrift client for RPC to other backend services <thrift>
 

--- a/docs/api/baseplate/clients/requests.rst
+++ b/docs/api/baseplate/clients/requests.rst
@@ -1,0 +1,85 @@
+``baseplate.clients.requests``
+==============================
+
+:doc:`Requests <requests:user/quickstart>` is a library for making HTTP
+requests. Baseplate provides two wrappers for Requests: the "external" client
+is suitable for communication with third party, potentially untrusted,
+services; the "internal" client is suitable for talking to first-party services
+and automatically includes trace and edge context data in requests. Baseplate
+uses `Advocate`_ to prevent the external client from talking to internal
+services and vice versa.
+
+.. _`Advocate`: https://pypi.org/project/advocate/
+
+.. automodule:: baseplate.clients.requests
+
+.. versionadded:: 1.4
+
+Example
+-------
+
+To integrate ``requests`` with your application, add the appropriate client
+declaration to your context configuration::
+
+   baseplate.configure_context(
+      {
+         ...
+         # see above for when to use which of these
+         "foo": ExternalRequestsClient(),
+         "bar": InternalRequestsClient(),
+         ...
+      }
+   )
+
+configure it in your application's configuration file:
+
+.. code-block:: ini
+
+   [app:main]
+
+   ...
+
+   # optional: the number of connections to cache
+   foo.pool_connections = 10
+
+   # optional: the maximum number of connections to keep in the pool
+   foo.pool_maxsize = 10
+
+   # optional: how many times to retry DNS/connection attempts
+   # (not data requests)
+   foo.max_retries = 0
+
+   # optional: whether or not to block waiting for connections
+   # from the pool
+   foo.pool_block = false
+
+   # optional: address filter configuration, see
+   # http_adapter_from_config for all options
+   foo.filter.ip_allowlist = 1.2.3.0/24
+
+   ...
+
+
+and then use the attached :py:class:`~requests.Session`-like object in
+request::
+
+   def my_method(request):
+       request.foo.get("http://html5zombo.com")
+
+Configuration
+-------------
+
+.. autoclass:: ExternalRequestsClient
+
+.. autoclass:: InternalRequestsClient
+
+.. autofunction:: http_adapter_from_config
+
+Classes
+-------
+
+.. autoclass:: BaseplateSession
+   :members:
+
+.. autoclass:: RequestsContextFactory
+   :members:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,13 +26,14 @@ extensions = [
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3.7", None),
-    "pyramid": ("https://docs.pylonsproject.org/projects/pyramid/en/1.9-branch", None,),
+    "pyramid": ("https://docs.pylonsproject.org/projects/pyramid/en/1.9-branch", None),
     "cassandra": ("https://datastax.github.io/python-driver/", None),
     "pymemcache": ("https://pymemcache.readthedocs.io/en/latest/", None),
     "kazoo": ("https://kazoo.readthedocs.io/en/latest/", None),
     "kombu": ("https://kombu.readthedocs.io/en/latest/", None),
     "redis": ("https://redis-py.readthedocs.io/en/latest/", None),
     "sqlalchemy": ("https://docs.sqlalchemy.org/en/13/", None),
+    "requests": ("https://requests.readthedocs.io/en/stable/", None),
 }
 
 # The suffix of source filenames.

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -3,6 +3,7 @@
 # this is used inside CI and tox, so we don't need anything useful outside the
 # direct test environment like tox itself.
 -f https://reddit-wheels.s3.amazonaws.com/index.html
+advocate==1.0.0
 amqp==2.3.2
 asn1crypto==0.24.0
 astroid==2.3.3
@@ -30,6 +31,8 @@ kombu==4.2.0
 lazy-object-proxy==1.4.3
 mccabe==0.6.1
 more-itertools==5.0.0
+ndg-httpsclient==0.5.0
+netifaces==0.10.9
 objgraph==3.4.1
 PasteDeploy==1.5.2
 plaster==1.0
@@ -37,14 +40,16 @@ plaster-pastedeploy==0.4.2
 pluggy==0.12.0
 posix-ipc==1.0.4
 py==1.7.0
+pyasn1==0.4.8
 pycparser==2.19
-python-json-logger~=0.1
 PyJWT==1.6.3
 pylint==2.4.4
 pymemcache==1.3.2
+pyOpenSSL==19.0.0
 pyramid==1.9.1
 pytest==4.6.3
 pytest-cov==2.6.1
+python-json-logger~=0.1
 pytz==2018.9
 raven==6.10.0
 redis==3.3.8

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
         "memcache": ["pymemcache>=1.3.0,<=2.0.0"],
         "pyramid": ["pyramid>=1.9.0"],
         "redis": ["redis>=2.10.0,<=4.0.0"],
+        "requests": ["advocate>=1.0.0"],
         "sql": ["sqlalchemy>=1.1.0"],
         "vault": ["hvac>=0.2.17"],
         "zookeeper": ["kazoo>=2.5.0"],

--- a/tests/integration/requests_tests.py
+++ b/tests/integration/requests_tests.py
@@ -1,0 +1,149 @@
+import importlib
+
+import gevent
+import pytest
+import requests
+
+from baseplate import Baseplate
+from baseplate.clients.requests import ExternalRequestsClient
+from baseplate.clients.requests import InternalRequestsClient
+from baseplate.lib import config
+from baseplate.server import make_listener
+from baseplate.server.wsgi import make_server
+
+from . import TestBaseplateObserver
+
+
+@pytest.fixture
+def gevent_socket():
+    try:
+        gevent.monkey.patch_socket()
+        yield
+    finally:
+        import socket
+
+        importlib.reload(socket)
+
+
+@pytest.fixture
+def http_server(gevent_socket):
+    class HttpServer:
+        def __init__(self, address):
+            self.url = f"http://{address[0]}:{address[1]}/"
+            self.requests = []
+            self.response_status = "204 No Content"
+            self.response_headers = []
+            self.response_body = []
+
+        def __call__(self, environ, start_response):
+            self.requests.append(environ)
+            start_response(self.response_status, self.response_headers)
+            return self.response_body
+
+    server_bind_endpoint = config.Endpoint("127.0.0.1:0")
+    listener = make_listener(server_bind_endpoint)
+    server_address = listener.getsockname()
+    http_server = HttpServer(server_address)
+    server = make_server({"stop_timeout": "1 millisecond"}, listener, http_server)
+
+    server_greenlet = gevent.spawn(server.serve_forever)
+    try:
+        yield http_server
+    finally:
+        server_greenlet.kill()
+
+
+@pytest.mark.parametrize("client_cls", [InternalRequestsClient, ExternalRequestsClient])
+@pytest.mark.parametrize("method", ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "PUT"])
+def test_client_makes_client_span(client_cls, method, http_server):
+    baseplate = Baseplate(
+        {"myclient.filter.ip_allowlist": "127.0.0.0/8", "myclient.filter.port_denylist": "0"}
+    )
+    baseplate.configure_context({"myclient": client_cls()})
+
+    observer = TestBaseplateObserver()
+    baseplate.register(observer)
+
+    with baseplate.server_context("test") as context:
+        fn = getattr(context.myclient, method.lower())
+        response = fn(http_server.url)
+
+    assert response.status_code == 204
+
+    server_span_observer = observer.children[0]
+    assert len(server_span_observer.children) == 1
+
+    client_span_observer = server_span_observer.children[0]
+    assert client_span_observer.span.name == "myclient.request"
+    assert client_span_observer.on_start_called
+    assert client_span_observer.on_finish_called
+    assert client_span_observer.on_finish_exc_info is None
+    assert client_span_observer.tags["http.url"] == http_server.url
+    assert client_span_observer.tags["http.method"] == method
+    assert client_span_observer.tags["http.status_code"] == 204
+
+
+@pytest.mark.parametrize("client_cls", [InternalRequestsClient, ExternalRequestsClient])
+def test_connection_error(client_cls):
+    baseplate = Baseplate(
+        {"myclient.filter.ip_allowlist": "127.0.0.0/8", "myclient.filter.port_denylist": "0"}
+    )
+    baseplate.configure_context({"myclient": client_cls()})
+
+    observer = TestBaseplateObserver()
+    baseplate.register(observer)
+
+    bogus_url = "http://localhost:1/"
+    with pytest.raises(requests.exceptions.ConnectionError):
+        with baseplate.server_context("test") as context:
+            context.myclient.get(bogus_url)
+
+    server_span_observer = observer.children[0]
+    assert len(server_span_observer.children) == 1
+
+    client_span_observer = server_span_observer.children[0]
+    assert client_span_observer.span.name == "myclient.request"
+    assert client_span_observer.on_start_called
+    assert client_span_observer.on_finish_called
+    assert client_span_observer.on_finish_exc_info is not None
+    assert client_span_observer.tags["http.url"] == bogus_url
+    assert client_span_observer.tags["http.method"] == "GET"
+    assert "http.status_code" not in client_span_observer.tags
+
+
+def test_internal_client_sends_headers(http_server):
+    baseplate = Baseplate()
+    baseplate.configure_context({"internal": InternalRequestsClient()})
+
+    with baseplate.server_context("test") as context:
+        setattr(context, "raw_request_context", b"contextual")
+
+        response = context.internal.get(http_server.url)
+
+        assert response.status_code == 204
+        assert response.text == ""
+        assert http_server.requests[0]["REQUEST_METHOD"] == "GET"
+        assert http_server.requests[0]["HTTP_X_TRACE"] == str(context.trace.trace_id)
+        assert http_server.requests[0]["HTTP_X_PARENT"] == str(context.trace.parent_id)
+        assert http_server.requests[0]["HTTP_X_SPAN"] == str(context.trace.id)
+        assert http_server.requests[0]["HTTP_X_EDGE_CONTEXT"] == "Y29udGV4dHVhbA=="
+
+
+def test_external_client_doesnt_send_headers(http_server):
+    baseplate = Baseplate(
+        {"external.filter.ip_allowlist": "127.0.0.0/8", "external.filter.port_denylist": "0"}
+    )
+    baseplate.configure_context({"external": ExternalRequestsClient()})
+
+    with baseplate.server_context("test") as context:
+        setattr(context, "raw_request_context", b"contextual")
+
+        response = context.external.get(http_server.url)
+
+        assert response.status_code == 204
+        assert response.text == ""
+        assert http_server.requests[0]["REQUEST_METHOD"] == "GET"
+        assert "HTTP_X_TRACE" not in http_server.requests[0]
+        assert "HTTP_X_PARENT" not in http_server.requests[0]
+        assert "HTTP_X_SPAN" not in http_server.requests[0]
+        assert "HTTP_X_EDGE_CONTEXT" not in http_server.requests[0]


### PR DESCRIPTION
This adds two HTTP clients: 

* The internal client is for use with first-party services and propagates trace and edge context. 
* The external client is for use with third-party services and does not propagate the extra context.

We use @jordanmilne's Advocate library (now updated for modern requests!) to enforce that the internal client only talks to local addresses and the external client only talks to external addresses. The cost of doing this is about 100 microseconds per request.

Fixes #448 