### PR TITLE
Add missing POST function to Requests HTTP client

### DIFF
--- a/baseplate/clients/requests.py
+++ b/baseplate/clients/requests.py
@@ -153,6 +153,14 @@ class BaseplateSession:
         """
         return self.request("PATCH", url, **kwargs)
 
+    def post(self, url: str, **kwargs: Any) -> Response:
+        """Send a POST request.
+
+        See :py:func:`requests.request` for valid keyword arguments.
+
+        """
+        return self.request("POST", url, **kwargs)
+
     def put(self, url: str, **kwargs: Any) -> Response:
         """Send a PUT request.
 

--- a/tests/integration/requests_tests.py
+++ b/tests/integration/requests_tests.py
@@ -65,7 +65,7 @@ def http_server(gevent_socket):
 
 
 @pytest.mark.parametrize("client_cls", [InternalRequestsClient, ExternalRequestsClient])
-@pytest.mark.parametrize("method", ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "PUT"])
+@pytest.mark.parametrize("method", ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "PUT", "POST"])
 def test_client_makes_client_span(client_cls, method, http_server):
     baseplate = Baseplate(
         {"myclient.filter.ip_allowlist": "127.0.0.0/8", "myclient.filter.port_denylist": "0"}


### PR DESCRIPTION
Found this missing while dogfooding it. :grimacing: 