### PR TITLE
Allow redis locking

### DIFF
--- a/baseplate/clients/redis.py
+++ b/baseplate/clients/redis.py
@@ -155,10 +155,6 @@ class MonitoredRedisConnection(redis.StrictRedis):
         """Not currently implemented."""
         raise NotImplementedError
 
-    def lock(self, *args: Any, **kwargs: Any) -> Any:
-        """Not currently implemented."""
-        raise NotImplementedError
-
     def pubsub(self, *args: Any, **kwargs: Any) -> Any:
         """Not currently implemented."""
         raise NotImplementedError

--- a/tests/integration/redis_tests.py
+++ b/tests/integration/redis_tests.py
@@ -55,6 +55,18 @@ class RedisIntegrationTests(unittest.TestCase):
         self.assertTrue(span_observer.on_finish_called)
         self.assertIsNotNone(span_observer.on_finish_exc_info)
 
+    def test_lock(self):
+        with self.server_span:
+            with self.context.redis.lock("foo"):
+                pass
+
+        server_span_observer = self.baseplate_observer.get_only_child()
+
+        self.assertGreater(len(server_span_observer.children), 0)
+        for span_observer in server_span_observer.children:
+            self.assertTrue(span_observer.on_start_called)
+            self.assertTrue(span_observer.on_finish_called)
+
     def test_pipeline(self):
         with self.server_span:
             with self.context.redis.pipeline("foo") as pipeline:


### PR DESCRIPTION
The upstream implementation calls back through our client so this ends up being instrumented just fine, but rather granularly. Is this OK or should we go to the effort of figuring out a higher level span system for it?

The spans emitted look like: `redis.SET` and `redis.EVALSHA` (the latter running a LUA script server-side)