### PR TITLE
Pin setuptools version

### DIFF
--- a/requirements-lint.txt
+++ b/requirements-lint.txt
@@ -18,4 +18,5 @@ pydocstyle==3.0.0
 pyflakes==2.2.0
 regex==2020.1.8
 reorder-python-imports==1.6.0
+setuptools==50.3.0
 typing-extensions==3.7.4


### PR DESCRIPTION
This usually isn't part of 'pip freeze' since it's part of the environment, but setuptools broke lints recently in v50 and drone started picking that version up but not their subsequent v50.2 which reverted the breakage. So we're going to pin them and
make sure we choose to upgrade when we want to.