### PR TITLE
Make BaseplateRequest play more nicely with superclass methods

### DIFF
--- a/baseplate/frameworks/pyramid/__init__.py
+++ b/baseplate/frameworks/pyramid/__init__.py
@@ -124,9 +124,10 @@ class StaticTrustHandler(HeaderTrustHandler):
 
 # pylint: disable=too-many-ancestors
 class BaseplateRequest(RequestContext, pyramid.request.Request):
-    def __init__(self, context_config: Dict[str, Any], environ: Dict[str, str]):
-        RequestContext.__init__(self, context_config)
-        pyramid.request.Request.__init__(self, environ)
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        context_config = kwargs.pop("context_config", None)
+        RequestContext.__init__(self, context_config=context_config)
+        pyramid.request.Request.__init__(self, *args, **kwargs)
 
 
 class RequestFactory:
@@ -134,11 +135,11 @@ class RequestFactory:
         self.baseplate = baseplate
 
     def __call__(self, environ: Dict[str, str]) -> BaseplateRequest:
-        return BaseplateRequest(self.baseplate._context_config, environ)
+        return BaseplateRequest(environ, context_config=self.baseplate._context_config)
 
     def blank(self, path: str) -> BaseplateRequest:
         environ = webob.request.environ_from_url(path)
-        return BaseplateRequest(self.baseplate._context_config, environ)
+        return BaseplateRequest(environ, context_config=self.baseplate._context_config)
 
 
 class BaseplateConfigurator:


### PR DESCRIPTION
(Landing this after the 1.4 release because it's pretty low-level and I'd like it to bake for a while before going into a release. But it'll be really nice to have for the testing helpers I'm building out in Harold2)

[Things like Request.from_file call the current subclass's constructor
with a specific order of arguments.][1] This doesn't work if we put our
context config at the front and make it required.

By reordering like this we play nicely as a subclass and can still get
our data in when we need it.

[1]: https://github.com/Pylons/webob/blob/ac2d238f50bed7fbbf115818ab7f208b71d7bdca/src/webob/request.py#L1251-L1253