### PR TITLE
Change `name` to `experiment_name` on `Experiments.expose`

### DIFF
--- a/baseplate/lib/experiments/__init__.py
+++ b/baseplate/lib/experiments/__init__.py
@@ -140,6 +140,7 @@ class Experiments:
     @overload
     def variant(
         self,
+        *,
         name: str,
         user: Optional[User] = None,
         bucketing_event_override: Optional[bool] = None,
@@ -149,6 +150,7 @@ class Experiments:
     @overload
     def variant(
         self,
+        *,
         experiment_name: str,
         user: Optional[User] = None,
         bucketing_event_override: Optional[bool] = None,

--- a/baseplate/lib/experiments/__init__.py
+++ b/baseplate/lib/experiments/__init__.py
@@ -144,6 +144,7 @@ class Experiments:
         name: str,
         user: Optional[User] = None,
         bucketing_event_override: Optional[bool] = None,
+        **kwargs: str,
     ) -> Optional[str]:
         ...
 
@@ -154,6 +155,7 @@ class Experiments:
         experiment_name: str,
         user: Optional[User] = None,
         bucketing_event_override: Optional[bool] = None,
+        **kwargs: str,
     ) -> Optional[str]:
         ...
 

--- a/baseplate/lib/experiments/__init__.py
+++ b/baseplate/lib/experiments/__init__.py
@@ -10,6 +10,7 @@ from typing import Set
 from baseplate import Span
 from baseplate.clients import ContextFactory
 from baseplate.lib import config
+from baseplate.lib import warn_deprecated
 from baseplate.lib.edge_context import User
 from baseplate.lib.events import DebugLogger
 from baseplate.lib.events import EventLogger
@@ -137,9 +138,10 @@ class Experiments:
 
     def variant(
         self,
-        name: str,
+        experiment_name: Optional[str] = None,
         user: Optional[User] = None,
         bucketing_event_override: Optional[bool] = None,
+        name: Optional[str] = None,  # DEPRECATED
         **kwargs: str,
     ) -> Optional[str]:
         r"""Return which variant, if any, is active.
@@ -161,7 +163,8 @@ class Experiments:
         will be exposed to the user, you can use `bucketing_event_override` to
         disabled bucketing events for that check.
 
-        :param name: Name of the experiment you want to run.
+        :param experiment_name: Name of the experiment you want to run.
+        :param name: DEPRECATED - use experiment_name instead
         :param user: User object for the user you want to check the experiment
             variant for.  If you set user, the experiment parameters for that user
             ("user_id", "logged_in", and "user_roles") will be extracted and added
@@ -183,7 +186,13 @@ class Experiments:
 
         :return: Variant name if a variant is active, None otherwise.
         """
-        experiment = self._get_experiment(name)
+        experiment_name = experiment_name or name
+        assert experiment_name
+        if name:
+            warn_deprecated(
+                f"The 'name' parameter on 'variant' method is deprecated, use 'experiment_name' instead. (name={name})"
+            )
+        experiment = self._get_experiment(experiment_name)
 
         if experiment is None:
             return None

--- a/baseplate/lib/experiments/__init__.py
+++ b/baseplate/lib/experiments/__init__.py
@@ -4,6 +4,7 @@ import logging
 from enum import Enum
 from typing import Dict
 from typing import Optional
+from typing import overload
 from typing import Sequence
 from typing import Set
 
@@ -136,6 +137,24 @@ class Experiments:
         """
         return self._get_experiment(name) is not None
 
+    @overload
+    def variant(
+        self,
+        name: str,
+        user: Optional[User] = None,
+        bucketing_event_override: Optional[bool] = None,
+    ) -> Optional[str]:
+        ...
+
+    @overload
+    def variant(
+        self,
+        experiment_name: str,
+        user: Optional[User] = None,
+        bucketing_event_override: Optional[bool] = None,
+    ) -> Optional[str]:
+        ...
+
     def variant(
         self,
         experiment_name: Optional[str] = None,
@@ -185,6 +204,9 @@ class Experiments:
             be passed to the logger.
 
         :return: Variant name if a variant is active, None otherwise.
+
+        .. versionchanged:: 1.5
+            ``name`` was renamed to ``experiment_name``
         """
         experiment_name = experiment_name or name
         assert experiment_name


### PR DESCRIPTION
This addresses #486

Currently, the `Experiments` class has two methods that are used in tandem quite often, `variant` and `expose`. And they both have different parameters for the name of the experiment.

`variant` -> `name`
`expose` -> `experiment_name`

This PR will introduce `experiment_name` to `variant` and log a deprecation warning for `name`.