### PR TITLE
Fix JSON logging of Trace ID

### DIFF
--- a/baseplate/lib/log_formatter.py
+++ b/baseplate/lib/log_formatter.py
@@ -5,7 +5,13 @@ class CustomJsonFormatter(jsonlogger.JsonFormatter):
     def process_log_record(self, log_record: dict) -> dict:
         log_record["level"] = log_record.pop("levelname", None)
         try:
-            log_record["traceID"] = int(log_record["threadName"])
+            # see if there's an integer thread name, that's probably a traceID
+            # from the logging observer.
+            trace_id = int(log_record["threadName"])
+
+            # unfortunately we have to convert back to string because our log
+            # processor can't handle giant integers.
+            log_record["traceID"] = str(trace_id)
         except (KeyError, ValueError):
             pass
         return super().process_log_record(log_record)

--- a/baseplate/server/__init__.py
+++ b/baseplate/server/__init__.py
@@ -120,7 +120,7 @@ def configure_logging(config: Configuration, debug: bool) -> None:
         logging_level = logging.INFO
 
     formatter = CustomJsonFormatter(
-        "%(levelname)s %(message)s %(funcName)s %(lineno)d %(module)s %(name)s %(pathname)s %(process)d %(processName)s %(thread)d"
+        "%(levelname)s %(message)s %(funcName)s %(lineno)d %(module)s %(name)s %(pathname)s %(process)d %(processName)s %(thread)d %(threadName)s"
     )
 
     handler = logging.StreamHandler()


### PR DESCRIPTION
We needed to ask for threadName to be in the JSON output before we could
manipulate it in the custom log formatter.

:eyeglasses: @isugimpy