### PR TITLE
Redis: unlock pubsub() and add connection pool runtime metrics

### DIFF
--- a/baseplate/clients/redis.py
+++ b/baseplate/clients/redis.py
@@ -109,8 +109,6 @@ class MonitoredRedisConnection(redis.StrictRedis):
     :py:meth:`~baseplate.clients.redis.MonitoredRedisConnection.pipeline`
     method.
 
-    .. note:: Locks and PubSub are currently unsupported.
-
     """
 
     def __init__(self, context_name: str, server_span: Span, connection_pool: redis.ConnectionPool):
@@ -152,10 +150,6 @@ class MonitoredRedisConnection(redis.StrictRedis):
 
     # these commands are not yet implemented, but probably not unimplementable
     def transaction(self, *args: Any, **kwargs: Any) -> Any:
-        """Not currently implemented."""
-        raise NotImplementedError
-
-    def pubsub(self, *args: Any, **kwargs: Any) -> Any:
         """Not currently implemented."""
         raise NotImplementedError
 

--- a/docs/api/baseplate/clients/redis.rst
+++ b/docs/api/baseplate/clients/redis.rst
@@ -74,3 +74,29 @@ Classes
 
 .. autoclass:: MessageQueue
    :members:
+
+Runtime Metrics
+---------------
+
+In addition to request-level metrics reported through spans, this wrapper
+reports connection pool statistics periodically via the :ref:`runtime-metrics`
+system.  All metrics are prefixed as follows:
+
+.. code-block:: none
+
+   {namespace}.runtime.{hostname}.PID{pid}.clients.{name}
+
+where ``namespace`` is the application's namespace, ``hostname`` and ``pid``
+come from the operating system, and ``name`` is the name given to
+:py:meth:`~baseplate.Baseplate.add_to_context` when registering this
+context factory.
+
+The following metrics are reported:
+
+``pool.size``
+   The size limit for the connection pool.
+``pool.in_use``
+   How many connections have been established and are currently checked out and
+   being used.
+
+.. versionadded:: 1.5


### PR DESCRIPTION
Unlocking pubsub is like unlocking locks: c3143199489245144d720ef0eb221720682eeb04. We're just letting the underlying magic in execute() deal with it for us.

Runtime metrics are documented in the .rst file modified below. This should be helpful for tracking connection pool usage in prod, especially with things like pubsub in use.