### PR TITLE
Add worker_kwargs

### DIFF
--- a/baseplate/frameworks/queue_consumer/kombu.py
+++ b/baseplate/frameworks/queue_consumer/kombu.py
@@ -73,8 +73,7 @@ class KombuConsumerWorker(ConsumerMixin, PumpWorker):
         self.kwargs = kwargs
 
     def get_consumers(self, Consumer: kombu.Consumer, channel: Channel) -> Sequence[kombu.Consumer]:
-        args = dict(queues=self.queues, on_message=self.work_queue.put)
-        args.update(self.kwargs)
+        args = dict(queues=self.queues, on_message=self.work_queue.put, **self.kwargs)
         if self.serializer:
             args["accept"] = [self.serializer.name]
         return [Consumer(**args)]

--- a/tests/unit/frameworks/queue_consumer/kombu_tests.py
+++ b/tests/unit/frameworks/queue_consumer/kombu_tests.py
@@ -137,6 +137,7 @@ class TestQueueConsumerFactory:
     @pytest.fixture
     def make_queue_consumer_factory(self, baseplate, exchange, connection, name, routing_keys):
         def _make_queue_consumer_factory(health_check_fn=None):
+            worker_kwargs = {"prefetch_limit": 1}
             return KombuQueueConsumerFactory.new(
                 baseplate=baseplate,
                 exchange=exchange,
@@ -146,6 +147,7 @@ class TestQueueConsumerFactory:
                 handler_fn=lambda ctx, body, msg: True,
                 error_handler_fn=lambda ctx, body, msg: True,
                 health_check_fn=health_check_fn,
+                worker_kwargs=worker_kwargs,
             )
 
         return _make_queue_consumer_factory
@@ -154,6 +156,7 @@ class TestQueueConsumerFactory:
         handler_fn = mock.Mock()
         error_handler_fn = mock.Mock()
         health_check_fn = mock.Mock()
+        worker_kwargs = {"prefetch_limit": 1}
         factory = KombuQueueConsumerFactory.new(
             baseplate=baseplate,
             exchange=exchange,
@@ -163,6 +166,7 @@ class TestQueueConsumerFactory:
             handler_fn=handler_fn,
             error_handler_fn=error_handler_fn,
             health_check_fn=health_check_fn,
+            worker_kwargs=worker_kwargs,
         )
         assert factory.baseplate == baseplate
         assert factory.connection == connection
@@ -174,6 +178,7 @@ class TestQueueConsumerFactory:
             assert queue.routing_key == routing_key
             assert queue.name == name
             assert queue.exchange == exchange
+        assert worker_kwargs == worker_kwargs
 
     def test_build_pump_worker(self, make_queue_consumer_factory):
         factory = make_queue_consumer_factory()
@@ -183,6 +188,7 @@ class TestQueueConsumerFactory:
         assert pump.connection == factory.connection
         assert pump.queues == factory.queues
         assert pump.work_queue == work_queue
+        assert pump.kwargs == {"prefetch_limit": 1}
 
     def test_build_message_handler(self, make_queue_consumer_factory):
         factory = make_queue_consumer_factory()


### PR DESCRIPTION
This enabled clients to provide any keyword arguments to the kombu worker constructor. This would have been very useful when diagnosing and mitigating a mailroom outage on Friday.
