### PR TITLE
Fix reporting of redis connection pool statistics

### DIFF
--- a/baseplate/clients/redis.py
+++ b/baseplate/clients/redis.py
@@ -100,10 +100,13 @@ class RedisContextFactory(ContextFactory):
             return
 
         size = self.connection_pool.max_connections
-        in_use = len(self.connection_pool._connections)  # type: ignore
+        open = len(self.connection_pool._connections)  # type: ignore
+        available = self.connection_pool.pool.qsize()
+        in_use = size - available
 
         batch.gauge("pool.size").replace(size)
         batch.gauge("pool.in_use").replace(in_use)
+        batch.gauge("pool.open_and_available").replace(open - in_use)
 
     def make_object_for_context(self, name: str, span: Span) -> "MonitoredRedisConnection":
         return MonitoredRedisConnection(name, span, self.connection_pool)


### PR DESCRIPTION
The "in_use" number was actually the total number of open connections,
even if they were checked back into the pool and available for use.

Here's the relevant code for sanity checking: https://github.com/andymccurdy/redis-py/blob/15dafb1414f05ce24ef336fc539e06ad6a2b3d19/redis/connection.py#L1227-L1378