### PR TITLE
Provide ability for config to be pulled from the environment.

### DIFF
--- a/baseplate/lib/config.py
+++ b/baseplate/lib/config.py
@@ -406,7 +406,7 @@ def DefaultFromEnv(
         if val:
             return val
 
-        raise ValueError("No value provided.")
+        raise ValueError("no value provided")
 
     return default_from_env
 

--- a/baseplate/lib/config.py
+++ b/baseplate/lib/config.py
@@ -394,7 +394,7 @@ def DefaultFromEnv(
 ) -> Callable[[str], OptionalType[T]]:  # noqa: D401
     """An option of type T or a default.
 
-    The default is sourced from an environment variable with the name ``default_src``.
+    The default is sourced from an environment variable with the name specified in ``default_src``.
     Either the option or the default must be provided
     """
     default = None

--- a/baseplate/lib/config.py
+++ b/baseplate/lib/config.py
@@ -390,23 +390,21 @@ def TupleOf(item_parser: Callable[[str], T]) -> Callable[[str], Sequence[T]]:  #
 
 
 def DefaultFromEnv(
-    item_parser: Callable[[str], T], default_src: str
+    item_parser: Callable[[str], T], default_src: str, fallback: OptionalType[T] = None
 ) -> Callable[[str], OptionalType[T]]:  # noqa: D401
     """An option of type T or a default.
 
     The default is sourced from an environment variable with the name specified in ``default_src``.
-    Either the option or the default must be provided
+    If the environment variable is not set, then the fallback will be used.
+    One of the following values must be provided: fallback, default_src, or the provided configuration
     """
-    default = None
-    env = os.getenv(default_src)
-    if env:
-        default = Optional(item_parser)(env)
+    env = os.getenv(default_src) or ""
+    default = Optional(item_parser, fallback)(env)
 
     def default_from_env(text: str) -> OptionalType[T]:
-        if text:
-            return Optional(item_parser)(text)
-        if default:
-            return default
+        val = Optional(item_parser, default)(text)
+        if val:
+            return val
 
         raise ValueError("No value provided.")
 

--- a/baseplate/sidecars/secrets_fetcher.py
+++ b/baseplate/sidecars/secrets_fetcher.py
@@ -377,17 +377,18 @@ def main() -> None:
     parser.read_file(args.config_file)
     fetcher_config = dict(parser.items("secret-fetcher"))
 
+    default_mount_point = os.getenv("BASEPLATE_DEFAULT_VAULT_MOUNT_POINT") or "aws-ec2"
     cfg = config.parse_config(
         fetcher_config,
         {
             "vault": {
-                "url": config.String,
+                "url": config.DefaultFromEnv(config.String, "BASEPLATE_DEFAULT_VAULT_URL"),
                 "role": config.String,
                 "auth_type": config.Optional(
                     config.OneOf(**VaultClientFactory.auth_types()),
                     default=VaultClientFactory.auth_types()["aws"],
                 ),
-                "mount_point": config.Optional(config.String, default="aws-ec2"),
+                "mount_point": config.Optional(config.String, default=default_mount_point),
             },
             "output": {
                 "path": config.Optional(config.String, default="/var/local/secrets.json"),

--- a/baseplate/sidecars/secrets_fetcher.py
+++ b/baseplate/sidecars/secrets_fetcher.py
@@ -388,7 +388,7 @@ def main() -> None:
                     default=VaultClientFactory.auth_types()["aws"],
                 ),
                 "mount_point": config.DefaultFromEnv(
-                    config.String, "BASEPLATE_VAULT_MOUNT_POINT", "aws-ec2"
+                    config.String, "BASEPLATE_VAULT_MOUNT_POINT", fallback="aws-ec2"
                 ),
             },
             "output": {

--- a/baseplate/sidecars/secrets_fetcher.py
+++ b/baseplate/sidecars/secrets_fetcher.py
@@ -377,7 +377,6 @@ def main() -> None:
     parser.read_file(args.config_file)
     fetcher_config = dict(parser.items("secret-fetcher"))
 
-    default_mount_point = os.getenv("BASEPLATE_DEFAULT_VAULT_MOUNT_POINT") or "aws-ec2"
     cfg = config.parse_config(
         fetcher_config,
         {
@@ -388,7 +387,9 @@ def main() -> None:
                     config.OneOf(**VaultClientFactory.auth_types()),
                     default=VaultClientFactory.auth_types()["aws"],
                 ),
-                "mount_point": config.Optional(config.String, default=default_mount_point),
+                "mount_point": config.DefaultFromEnv(
+                    config.String, "BASEPLATE_VAULT_MOUNT_POINT", "aws-ec2"
+                ),
             },
             "output": {
                 "path": config.Optional(config.String, default="/var/local/secrets.json"),

--- a/docs/config_example.ini
+++ b/docs/config_example.ini
@@ -6,3 +6,4 @@ nested.really.deep = 3 seconds
 some_file = /var/lib/whatever.txt
 sample_rate = 37.1%
 interval = 30 seconds
+default_from_env = example 

--- a/tests/unit/lib/config_tests.py
+++ b/tests/unit/lib/config_tests.py
@@ -3,6 +3,8 @@ import socket
 import tempfile
 import unittest
 
+from unittest.mock import patch
+
 from baseplate.lib import config
 
 
@@ -240,48 +242,27 @@ class TupleTests(unittest.TestCase):
             parser("a, b")
 
 
+@patch.dict("os.environ", {"BASEPLATE_DEFAULT_VALUE": "default", "NOT_PROVIDED": ""})
 class DefaultFromEnvTests(unittest.TestCase):
-    def __init__(self, name):
-        self.unset_env_var_name = "NOT_PROVIDED"
-        self.env_var_name = "BASEPLATE_DEFAULT_VALUE"
-        self.env_var_value = "default"
-        return super().__init__(name)
-
-    def setUp(self):
-        cur_value = os.getenv(self.env_var_name)
-        self.set_env(self.env_var_name, self.env_var_value)
-        self.addCleanup(self.set_env, self.env_var_value, cur_value)
-
-        cur_value = os.getenv(self.unset_env_var_name)
-        self.set_env(self.unset_env_var_name, "")
-        self.addCleanup(self.set_env, self.unset_env_var_name, cur_value)
-
-    def set_env(self, key, value):
-        if key:
-            if value:
-                os.environ[key] = value
-            else:
-                os.environ[key] = ""
-
     def test_use_default_from_env(self):
-        parser = config.DefaultFromEnv(config.String, self.env_var_name)
-        self.assertEqual(parser(""), self.env_var_value)
+        parser = config.DefaultFromEnv(config.String, "BASEPLATE_DEFAULT_VALUE")
+        self.assertEqual(parser(""), "default")
 
     def test_empty_default(self):
-        parser = config.DefaultFromEnv(config.String, self.unset_env_var_name)
+        parser = config.DefaultFromEnv(config.String, "NOT_PROVIDED")
         self.assertEqual(parser("foo"), "foo")
 
     def test_use_provided(self):
-        parser = config.DefaultFromEnv(config.String, self.env_var_name)
+        parser = config.DefaultFromEnv(config.String, "BASEPALTE_DEFAULT_VALUE")
         self.assertEqual(parser("foo"), "foo")
 
     def test_provide_none(self):
-        parser = config.DefaultFromEnv(config.String, self.unset_env_var_name)
+        parser = config.DefaultFromEnv(config.String, "NOT_PROVIDED")
         self.assertRaises(ValueError, parser, "")
 
     def test_fallback(self):
         fallback_value = 5
-        parser = config.DefaultFromEnv(config.Integer, self.unset_env_var_name, fallback_value)
+        parser = config.DefaultFromEnv(config.Integer, "NOT_PROVIDED", fallback_value)
         self.assertEqual(parser(""), fallback_value)
 
 

--- a/tests/unit/lib/config_tests.py
+++ b/tests/unit/lib/config_tests.py
@@ -1,4 +1,3 @@
-import os
 import socket
 import tempfile
 import unittest

--- a/tests/unit/lib/config_tests.py
+++ b/tests/unit/lib/config_tests.py
@@ -242,7 +242,8 @@ class TupleTests(unittest.TestCase):
 
 class DefaultFromEnvTests(unittest.TestCase):
     def __init__(self, name):
-        self.env_var_name = "DASEPLATE_DEFAULT_VALUE"
+        self.unset_env_var_name = "NOT_PROVIDED"
+        self.env_var_name = "BASEPLATE_DEFAULT_VALUE"
         self.env_var_value = "default"
         return super().__init__(name)
 
@@ -250,6 +251,10 @@ class DefaultFromEnvTests(unittest.TestCase):
         cur_value = os.getenv(self.env_var_name)
         self.set_env(self.env_var_name, self.env_var_value)
         self.addCleanup(self.set_env, self.env_var_value, cur_value)
+
+        cur_value = os.getenv(self.unset_env_var_name)
+        self.set_env(self.unset_env_var_name, "")
+        self.addCleanup(self.set_env, self.unset_env_var_name, cur_value)
 
     def set_env(self, key, value):
         if key:
@@ -263,7 +268,7 @@ class DefaultFromEnvTests(unittest.TestCase):
         self.assertEqual(parser(""), self.env_var_value)
 
     def test_empty_default(self):
-        parser = config.DefaultFromEnv(config.String, "NOT_DEFINED")
+        parser = config.DefaultFromEnv(config.String, self.unset_env_var_name)
         self.assertEqual(parser("foo"), "foo")
 
     def test_use_provided(self):
@@ -271,8 +276,13 @@ class DefaultFromEnvTests(unittest.TestCase):
         self.assertEqual(parser("foo"), "foo")
 
     def test_provide_none(self):
-        parser = config.DefaultFromEnv(config.String, "NOT_DEFINED")
+        parser = config.DefaultFromEnv(config.String, self.unset_env_var_name)
         self.assertRaises(ValueError, parser, "")
+
+    def test_fallback(self):
+        fallback_value = 5
+        parser = config.DefaultFromEnv(config.Integer, self.unset_env_var_name, fallback_value)
+        self.assertEqual(parser(""), fallback_value)
 
 
 class OptionalTests(unittest.TestCase):


### PR DESCRIPTION
Provide a utility to load default configuration values from the environment. Currently Infrared uses this following bash command to manually load values from the environment:
```
mkdir -p /etc/baseplate && cat /opt/baseplate/secrets-fetcher.ini  | sed 's^VAULT_URL^'"$REDDIT_VAULT_URL"'^'  |
        sed 's^VAULT_MOUNT^'"$REDDIT_VAULT_MOUNT"'^'  > $BASEPLATE_CONFIG_PATH  &&
        python3 -m baseplate.sidecars.secrets_fetcher $BASEPLATE_CONFIG_PATH
```
It would be great to have this be a native feature of Baseplate's configuration loading.

Environment variables as defaults may also soon be used to provide default trace publishing endpoints and other variables which are environment, often Kubernetes cluster, specific.