### PR TITLE
Switch from 'embedding' to 'starting' IPython

### DIFF
--- a/baseplate/server/__init__.py
+++ b/baseplate/server/__init__.py
@@ -376,7 +376,16 @@ def load_and_run_shell() -> None:
         # try to use IPython if possible
         from IPython import start_ipython
 
-        start_ipython(argv=[], user_ns=env)
+        try:
+            # IPython 5.x+
+            from traitlets.config.loader import Config
+        except ImportError:
+            # IPython 4 and below
+            from IPython import Config
+
+        ipython_config = Config()
+        ipython_config.TerminalInteractiveShell.banner2 = banner
+        start_ipython(argv=[], user_ns=env, config=ipython_config)
         raise SystemExit
     except ImportError:
         import code

--- a/baseplate/server/__init__.py
+++ b/baseplate/server/__init__.py
@@ -374,11 +374,10 @@ def load_and_run_shell() -> None:
 
     try:
         # try to use IPython if possible
-        from IPython.terminal.embed import InteractiveShellEmbed
-        from IPython.core.interactiveshell import DummyMod
+        from IPython import start_ipython
 
-        shell = InteractiveShellEmbed(banner2=banner)
-        shell(local_ns=env, module=DummyMod())
+        start_ipython(argv=[], user_ns=env)
+        raise SystemExit
     except ImportError:
         import code
 


### PR DESCRIPTION
Embedding IPython results in issues where import statements and other
globals changes in the shell environment don't work as expected.[1]
As an example, the following commands result in a NameError:

```ipython
In [1]: import time

In [2]: def foo():
   ...:     print(time.time())
   ...:

In [3]: foo()
---------------------------------------------------------------------------
NameError                                 Traceback (most recent call last)
<ipython-input-3-c19b6d9633cf> in <module>
----> 1 foo()

<ipython-input-2-a038e7f91c93> in foo()
      1 def foo():
----> 2     print(time.time())
      3

NameError: name 'time' is not defined
```

By switching to use "start_ipython()" instead, we get an environment
more similar to what we get by running `ipython` directly.

```ipython
In [1]: import time

In [2]: def foo():
   ...:     print(time.time())
   ...: 

In [3]: foo()
1603919279.0674398
```

[1] https://github.com/ipython/ipython/issues/62