### PR TITLE
metrics: By default don't log metrics when there is no configured endpoint

### DIFF
--- a/baseplate/lib/metrics.py
+++ b/baseplate/lib/metrics.py
@@ -97,9 +97,13 @@ class Transport:
 class NullTransport(Transport):
     """A transport which doesn't send messages at all."""
 
+    def __init__(self, log_if_unconfigured: bool):
+        self.log_if_unconfigured = log_if_unconfigured
+
     def send(self, serialized_metric: bytes) -> None:
-        for metric_line in serialized_metric.splitlines():
-            logger.debug("Would send metric %r", metric_line)
+        if self.log_if_unconfigured:
+            for metric_line in serialized_metric.splitlines():
+                logger.debug("Would send metric %r", metric_line)
 
     def flush(self) -> None:
         pass
@@ -514,7 +518,9 @@ class Gauge:
         self.transport.send(serialized)
 
 
-def make_client(namespace: str, endpoint: config.EndpointConfiguration) -> Client:
+def make_client(
+    namespace: str, endpoint: config.EndpointConfiguration, log_if_unconfigured: bool
+) -> Client:
     """Return a configured client.
 
     :param namespace: The root key to prefix all metrics with.
@@ -530,7 +536,7 @@ def make_client(namespace: str, endpoint: config.EndpointConfiguration) -> Clien
     if endpoint:
         transport = RawTransport(endpoint)
     else:
-        transport = NullTransport()
+        transport = NullTransport(log_if_unconfigured)
     return Client(transport, namespace)
 
 
@@ -544,6 +550,9 @@ def metrics_client_from_config(raw_config: config.RawConfig) -> Client:
     ``metrics.endpoint``
         A ``host:port`` pair, e.g. ``localhost:2014``. If an empty string, a
         client that discards all metrics will be returned.
+    `metrics.log_if_unconfigured``
+        Whether to log metrics when there is no unconfigured endpoint.
+        Defaults to false.
 
     :param raw_config: The application configuration which should have
         settings for the metrics client.
@@ -556,9 +565,10 @@ def metrics_client_from_config(raw_config: config.RawConfig) -> Client:
             "metrics": {
                 "namespace": config.Optional(config.String, default=""),
                 "endpoint": config.Optional(config.Endpoint),
+                "log_if_unconfigured": config.Optional(config.Boolean, default=False),
             }
         },
     )
 
     # pylint: disable=maybe-no-member
-    return make_client(cfg.metrics.namespace, cfg.metrics.endpoint)
+    return make_client(cfg.metrics.namespace, cfg.metrics.endpoint, cfg.metrics.log_if_unconfigured)

--- a/tests/unit/lib/metrics_tests.py
+++ b/tests/unit/lib/metrics_tests.py
@@ -399,9 +399,9 @@ class HistogramTests(unittest.TestCase):
 
 class MakeClientTests(unittest.TestCase):
     def test_no_endpoint(self):
-        client = metrics.make_client("namespace", None, False)
+        client = metrics.make_client("namespace", None, log_if_unconfigured=False)
         self.assertIsInstance(client.transport, metrics.NullTransport)
 
     def test_valid_endpoint(self):
-        client = metrics.make_client("namespace", EXAMPLE_ENDPOINT, False)
+        client = metrics.make_client("namespace", EXAMPLE_ENDPOINT, log_if_unconfigured=False)
         self.assertIsInstance(client.transport, metrics.RawTransport)

--- a/tests/unit/lib/metrics_tests.py
+++ b/tests/unit/lib/metrics_tests.py
@@ -47,7 +47,7 @@ class FormatTagsTest(unittest.TestCase):
 class NullTransportTests(unittest.TestCase):
     @mock.patch("socket.socket")
     def test_nothing_sent(self, mock_make_socket):
-        transport = metrics.NullTransport()
+        transport = metrics.NullTransport(log_if_unconfigured=False)
         transport.send(b"metric")
         self.assertEqual(mock_make_socket.call_count, 0)
 
@@ -399,9 +399,9 @@ class HistogramTests(unittest.TestCase):
 
 class MakeClientTests(unittest.TestCase):
     def test_no_endpoint(self):
-        client = metrics.make_client("namespace", None)
+        client = metrics.make_client("namespace", None, False)
         self.assertIsInstance(client.transport, metrics.NullTransport)
 
     def test_valid_endpoint(self):
-        client = metrics.make_client("namespace", EXAMPLE_ENDPOINT)
+        client = metrics.make_client("namespace", EXAMPLE_ENDPOINT, False)
         self.assertIsInstance(client.transport, metrics.RawTransport)


### PR DESCRIPTION
https://github.com/reddit/baseplate.py/issues/500

Usually the metrics endpoint isn't enabled during local development, so
the debug logging of unsent metrics was very noisy.

👓 @spladug @foreverest