### PR TITLE
add experiment global cache

### DIFF
--- a/baseplate/lib/experiments/__init__.py
+++ b/baseplate/lib/experiments/__init__.py
@@ -66,8 +66,7 @@ class ExperimentsContextFactory(ContextFactory):
 
             if mtime > self.cfg_mtime:
                 self.cfg_mtime = mtime
-                if self._global_cache:
-                    self._global_cache = {}
+                self._global_cache = {}
         except WatchedFileNotAvailableError as exc:
             logger.warning("Experiment config unavailable: %s", str(exc))
         except TypeError as exc:

--- a/baseplate/lib/experiments/__init__.py
+++ b/baseplate/lib/experiments/__init__.py
@@ -73,6 +73,7 @@ class ExperimentsContextFactory(ContextFactory):
             logger.warning("Could not load experiment config: %s", str(exc))
 
         return Experiments(
+            config_watcher=self._filewatcher,
             server_span=span,
             context_name=name,
             cfg_data=config_data,
@@ -93,25 +94,41 @@ class Experiments:
 
     def __init__(
         self,
+        config_watcher: FileWatcher,
         server_span: Span,
         context_name: str,
-        cfg_data: Dict[str, Dict[str, str]],
-        global_cache: Dict[str, Optional[Experiment]],
+        cfg_data: Optional[Dict[str, Dict[str, str]]] = None,
+        global_cache: Optional[Dict[str, Optional[Experiment]]] = None,
         event_logger: Optional[EventLogger] = None,
     ):
+        self._config_watcher = config_watcher
         self._span = server_span
         self._context_name = context_name
         self._already_bucketed: Set[str] = set()
         self._cfg_data = cfg_data
-        self._global_cache = global_cache
+        self._global_cache = global_cache if global_cache is not None else {}
         if event_logger:
             self._event_logger = event_logger
         else:
             self._event_logger = DebugLogger()
 
+    def _get_config(self) -> Dict[str, Dict[str, str]]:
+        """Warn: Deprecate in Baseplate 2.0."""
+        try:
+            return self._config_watcher.get_data()
+        except WatchedFileNotAvailableError as exc:
+            logger.warning("Experiment config unavailable: %s", str(exc))
+        except TypeError as exc:
+            logger.warning("Could not load experiment config: %s", str(exc))
+        return {}
+
     def _get_experiment(self, name: str) -> Optional[Experiment]:
         if name in self._global_cache:
             return self._global_cache[name]
+
+        if self._cfg_data is None:
+            warn_deprecated("config_watcher will be removed in Baseplate 2.0.")
+            self._cfg_data = self._get_config()
 
         if name not in self._cfg_data:
             logger.info("Experiment <%r> not found in experiment config", name)
@@ -130,6 +147,8 @@ class Experiments:
 
         :return: List of all valid experiment names.
         """
+        if self._cfg_data is None:
+            self._cfg_data = self._config_watcher.get_data()
         experiment_names = list(self._cfg_data.keys())
         return experiment_names
 

--- a/baseplate/lib/experiments/__init__.py
+++ b/baseplate/lib/experiments/__init__.py
@@ -7,6 +7,7 @@ from typing import Optional
 from typing import overload
 from typing import Sequence
 from typing import Set
+from typing import Tuple
 
 from baseplate import Span
 from baseplate.clients import ContextFactory
@@ -17,7 +18,7 @@ from baseplate.lib.events import DebugLogger
 from baseplate.lib.events import EventLogger
 from baseplate.lib.experiments.providers import parse_experiment
 from baseplate.lib.experiments.providers.base import Experiment
-from baseplate.lib.file_watcher import FileWatcher
+from baseplate.lib.file_watcher import FileWatcherWithUpdatedFlag
 from baseplate.lib.file_watcher import WatchedFileNotAvailableError
 
 
@@ -27,6 +28,42 @@ logger = logging.getLogger(__name__)
 class EventType(Enum):
     EXPOSE = "expose"
     BUCKET = "choose"
+
+
+class ExperimentsGlobalCache:
+    """Experiment global cache store the parsed experiment.
+
+    Every time gets the global cache, it reads the data from FileWatcher,
+    if file has been updated, it assign its cache to new empty dictionary.
+    Global_cache will be passed to each request's experiment object,
+    parsed experiment will be lazily added when each request parse its experiment
+    if it does not exist in the global_cache.
+    """
+
+    def __init__(self, filewatcher: FileWatcherWithUpdatedFlag):
+        self._filewatcher = filewatcher
+        self._global_cache: Dict[str, Optional[Experiment]] = {}
+
+    def _get_config(self) -> Optional[Dict[str, Dict[str, str]]]:
+        try:
+            config_data: Dict[str, Dict[str, str]]
+            config_data, updated = self._filewatcher.get_data()
+
+            if updated and self._global_cache:
+                self._global_cache = {}
+            return config_data
+        except WatchedFileNotAvailableError as exc:
+            logger.warning("Experiment config unavailable: %s", str(exc))
+            return None
+        except TypeError as exc:
+            logger.warning("Could not load experiment config: %s", str(exc))
+            return None
+
+    def get_cfg_and_global_cache(
+        self,
+    ) -> Tuple[Optional[Dict[str, Dict[str, str]]], Dict[str, Optional[Experiment]]]:
+        cfg = self._get_config()
+        return cfg, self._global_cache
 
 
 class ExperimentsContextFactory(ContextFactory):
@@ -54,14 +91,18 @@ class ExperimentsContextFactory(ContextFactory):
         timeout: Optional[float] = None,
         backoff: Optional[float] = None,
     ):
-        self._filewatcher = FileWatcher(path, json.load, timeout=timeout, backoff=backoff)
+        self._experiments_global_cache: ExperimentsGlobalCache = ExperimentsGlobalCache(
+            FileWatcherWithUpdatedFlag(path, json.load, timeout=timeout, backoff=backoff)
+        )
         self._event_logger = event_logger
 
     def make_object_for_context(self, name: str, span: Span) -> "Experiments":
+        cfg_data, global_cache = self._experiments_global_cache.get_cfg_and_global_cache()
         return Experiments(
-            config_watcher=self._filewatcher,
             server_span=span,
             context_name=name,
+            cfg_data=cfg_data,
+            global_cache=global_cache,
             event_logger=self._event_logger,
         )
 
@@ -78,54 +119,50 @@ class Experiments:
 
     def __init__(
         self,
-        config_watcher: FileWatcher,
         server_span: Span,
         context_name: str,
+        cfg_data: Optional[Dict[str, Dict[str, str]]],
+        global_cache: Dict[str, Optional[Experiment]],
         event_logger: Optional[EventLogger] = None,
     ):
-        self._config_watcher = config_watcher
         self._span = server_span
         self._context_name = context_name
         self._already_bucketed: Set[str] = set()
-        self._experiment_cache: Dict[str, Optional[Experiment]] = {}
+        self._cfg_data = cfg_data
+        self._global_cache = global_cache
         if event_logger:
             self._event_logger = event_logger
         else:
             self._event_logger = DebugLogger()
 
-    def _get_config(self, name: str) -> Optional[Dict[str, str]]:
-        try:
-            config_data = self._config_watcher.get_data()
-            return config_data[name]
-        except WatchedFileNotAvailableError as exc:
-            logger.warning("Experiment config unavailable: %s", str(exc))
-        except KeyError:
-            logger.info("Experiment <%r> not found in experiment config", name)
-        except TypeError as exc:
-            logger.warning("Could not load experiment config: %s", str(exc))
-        return None
-
     def _get_experiment(self, name: str) -> Optional[Experiment]:
-        if name not in self._experiment_cache:
-            experiment_config = self._get_config(name)
-            if not experiment_config:
-                experiment = None
-            else:
-                try:
-                    experiment = parse_experiment(experiment_config)
-                except Exception as err:
-                    logger.error("Invalid configuration for experiment %s: %s", name, err)
-                    return None
-            self._experiment_cache[name] = experiment
-        return self._experiment_cache[name]
+
+        if not self._cfg_data:
+            return None
+
+        if name in self._global_cache:
+            return self._global_cache[name]
+
+        if name not in self._cfg_data:
+            logger.info("Experiment <%r> not found in experiment config", name)
+            return None
+
+        try:
+            experiment = parse_experiment(self._cfg_data[name])
+            self._global_cache[name] = experiment
+            return experiment
+        except Exception as err:
+            logger.error("Invalid configuration for experiment %s: %s", name, err)
+            return None
 
     def get_all_experiment_names(self) -> Sequence[str]:
         """Return a list of all valid experiment names from the configuration file.
 
         :return: List of all valid experiment names.
         """
-        cfg = self._config_watcher.get_data()
-        experiment_names = list(cfg.keys())
+        if not self._cfg_data:
+            return []
+        experiment_names = list(self._cfg_data.keys())
         return experiment_names
 
     def is_valid_experiment(self, name: str) -> bool:

--- a/baseplate/lib/experiments/__init__.py
+++ b/baseplate/lib/experiments/__init__.py
@@ -113,7 +113,7 @@ class Experiments:
             self._event_logger = DebugLogger()
 
     def _get_config(self) -> Dict[str, Dict[str, str]]:
-        """Warn: Deprecate in Baseplate 2.0."""
+        # Warn: Deprecate in Baseplate 2.0.
         try:
             return self._config_watcher.get_data()
         except WatchedFileNotAvailableError as exc:

--- a/baseplate/lib/file_watcher.py
+++ b/baseplate/lib/file_watcher.py
@@ -156,62 +156,40 @@ class FileWatcher(Generic[T]):
         the freshest data.
 
         """
-        try:
-            current_mtime = os.path.getmtime(self._path)
-        except OSError as exc:
-            if self._data is _NOT_LOADED:
-                raise WatchedFileNotAvailableError(self._path, exc)
-            return typing.cast(T, self._data)
+        return self.get_data_and_mtime()[0]
 
-        if self._mtime < current_mtime:
-            logger.debug("Loading %s.", self._path)
-            try:
-                with open(self._path, **self._open_options._asdict()) as f:
-                    self._data = self._parser(f)
-            except Exception as exc:
-                if self._data is _NOT_LOADED:
-                    raise WatchedFileNotAvailableError(self._path, exc)
-                logger.warning("%s: failed to load, using cached data: %s", self._path, exc)
-            self._mtime = current_mtime
-
-        return typing.cast(T, self._data)
-
-
-class FileWatcherWithUpdatedFlag(FileWatcher):
-    def get_data(self) -> Tuple[T, bool]:
-        """Return tuple of the current contents of the file and updated flag.
+    def get_data_and_mtime(self) -> Tuple[T, float]:
+        """Return tuple of the current contents of the file and file mtime.
 
         The watcher ensures that the file is re-loaded and parsed whenever its
         contents change. Parsing only occurs when necessary, not on each call
         to this method. This method returns whatever the most recent call to
         the parser returned.
 
-        When file content was changed, it returns the flag 'updated' to True,
-        notify the caller the content was different from previous cached.
+        When file content was changed, it returns the recent mtime,
+        notify the caller the content is different from previous cached.
 
         Make sure to call this method each time you need data from the file
         rather than saving its results elsewhere. This ensures you always have
         the freshest data.
 
         """
-        updated = False
         try:
             current_mtime = os.path.getmtime(self._path)
         except OSError as exc:
             if self._data is _NOT_LOADED:
                 raise WatchedFileNotAvailableError(self._path, exc)
-            return typing.cast(T, self._data), updated
+            return typing.cast(T, self._data), self._mtime
 
         if self._mtime < current_mtime:
             logger.debug("Loading %s.", self._path)
             try:
                 with open(self._path, **self._open_options._asdict()) as f:
                     self._data = self._parser(f)
-                    updated = True
             except Exception as exc:
                 if self._data is _NOT_LOADED:
                     raise WatchedFileNotAvailableError(self._path, exc)
                 logger.warning("%s: failed to load, using cached data: %s", self._path, exc)
             self._mtime = current_mtime
 
-        return typing.cast(T, self._data), updated
+        return typing.cast(T, self._data), self._mtime

--- a/tests/unit/lib/experiments/experiment_tests.py
+++ b/tests/unit/lib/experiments/experiment_tests.py
@@ -13,7 +13,8 @@ from baseplate.lib.experiments import EventType
 from baseplate.lib.experiments import Experiments
 from baseplate.lib.experiments import experiments_client_from_config
 from baseplate.lib.experiments import ExperimentsContextFactory
-from baseplate.lib.file_watcher import FileWatcher
+from baseplate.lib.experiments import ExperimentsGlobalCache
+from baseplate.lib.file_watcher import FileWatcherWithUpdatedFlag
 from baseplate.lib.file_watcher import WatchedFileNotAvailableError
 
 
@@ -24,7 +25,8 @@ class TestExperiments(unittest.TestCase):
     def setUp(self):
         super().setUp()
         self.event_logger = mock.Mock(spec=DebugLogger)
-        self.mock_filewatcher = mock.Mock(spec=FileWatcher)
+        self._mock_filewatcher = mock.Mock(spec=FileWatcherWithUpdatedFlag)
+        self.mock_experiments_global_cache = ExperimentsGlobalCache(self._mock_filewatcher)
         self.mock_span = mock.MagicMock(spec=ServerSpan)
         self.mock_span.context = None
         self.mock_span.trace_id = "123456"
@@ -39,26 +41,31 @@ class TestExperiments(unittest.TestCase):
         )
 
     def test_bucketing_event_fields(self):
-        self.mock_filewatcher.get_data.return_value = {
-            "test": {
-                "id": 1,
-                "name": "test",
-                "owner": "test_owner",
-                "type": "r2",
-                "version": "1",
-                "start_ts": time.time() - THIRTY_DAYS,
-                "stop_ts": time.time() + THIRTY_DAYS,
-                "experiment": {
+        self._mock_filewatcher.get_data.return_value = (
+            {
+                "test": {
                     "id": 1,
                     "name": "test",
-                    "variants": {"active": 10, "control_1": 10, "control_2": 10},
-                },
-            }
-        }
+                    "owner": "test_owner",
+                    "type": "r2",
+                    "version": "1",
+                    "start_ts": time.time() - THIRTY_DAYS,
+                    "stop_ts": time.time() + THIRTY_DAYS,
+                    "experiment": {
+                        "id": 1,
+                        "name": "test",
+                        "variants": {"active": 10, "control_1": 10, "control_2": 10},
+                    },
+                }
+            },
+            True,
+        )
+        cfg_data, global_cache = self.mock_experiments_global_cache.get_cfg_and_global_cache()
         experiments = Experiments(
-            config_watcher=self.mock_filewatcher,
             server_span=self.mock_span,
             context_name="test",
+            cfg_data=cfg_data,
+            global_cache=global_cache,
             event_logger=self.event_logger,
         )
 
@@ -84,26 +91,31 @@ class TestExperiments(unittest.TestCase):
         self.assertEqual(getattr(event_fields["experiment"], "version"), "1")
 
     def test_bucketing_event_fields_without_baseplate_user(self):
-        self.mock_filewatcher.get_data.return_value = {
-            "test": {
-                "id": 1,
-                "name": "test",
-                "owner": "test_owner",
-                "type": "r2",
-                "version": "1",
-                "start_ts": time.time() - THIRTY_DAYS,
-                "stop_ts": time.time() + THIRTY_DAYS,
-                "experiment": {
+        self._mock_filewatcher.get_data.return_value = (
+            {
+                "test": {
                     "id": 1,
                     "name": "test",
-                    "variants": {"active": 10, "control_1": 10, "control_2": 10},
-                },
-            }
-        }
+                    "owner": "test_owner",
+                    "type": "r2",
+                    "version": "1",
+                    "start_ts": time.time() - THIRTY_DAYS,
+                    "stop_ts": time.time() + THIRTY_DAYS,
+                    "experiment": {
+                        "id": 1,
+                        "name": "test",
+                        "variants": {"active": 10, "control_1": 10, "control_2": 10},
+                    },
+                }
+            },
+            True,
+        )
+        cfg_data, global_cache = self.mock_experiments_global_cache.get_cfg_and_global_cache()
         experiments = Experiments(
-            config_watcher=self.mock_filewatcher,
             server_span=self.mock_span,
             context_name="test",
+            cfg_data=cfg_data,
+            global_cache=global_cache,
             event_logger=self.event_logger,
         )
 
@@ -128,26 +140,31 @@ class TestExperiments(unittest.TestCase):
         self.assertEqual(getattr(event_fields["experiment"], "version"), "1")
 
     def test_that_we_only_send_bucketing_event_once(self):
-        self.mock_filewatcher.get_data.return_value = {
-            "test": {
-                "id": 1,
-                "name": "test",
-                "owner": "test",
-                "type": "r2",
-                "version": "1",
-                "start_ts": time.time() - THIRTY_DAYS,
-                "stop_ts": time.time() + THIRTY_DAYS,
-                "experiment": {
+        self._mock_filewatcher.get_data.return_value = (
+            {
+                "test": {
                     "id": 1,
                     "name": "test",
-                    "variants": {"active": 10, "control_1": 10, "control_2": 10},
-                },
-            }
-        }
+                    "owner": "test",
+                    "type": "r2",
+                    "version": "1",
+                    "start_ts": time.time() - THIRTY_DAYS,
+                    "stop_ts": time.time() + THIRTY_DAYS,
+                    "experiment": {
+                        "id": 1,
+                        "name": "test",
+                        "variants": {"active": 10, "control_1": 10, "control_2": 10},
+                    },
+                }
+            },
+            True,
+        )
+        cfg_data, global_cache = self.mock_experiments_global_cache.get_cfg_and_global_cache()
         experiments = Experiments(
-            config_watcher=self.mock_filewatcher,
             server_span=self.mock_span,
             context_name="test",
+            cfg_data=cfg_data,
+            global_cache=global_cache,
             event_logger=self.event_logger,
         )
 
@@ -161,26 +178,31 @@ class TestExperiments(unittest.TestCase):
             self.assertEqual(self.event_logger.log.call_count, 1)
 
     def test_exposure_event_fields(self):
-        self.mock_filewatcher.get_data.return_value = {
-            "test": {
-                "id": 1,
-                "name": "test",
-                "owner": "test_owner",
-                "type": "r2",
-                "version": "1",
-                "start_ts": time.time() - THIRTY_DAYS,
-                "stop_ts": time.time() + THIRTY_DAYS,
-                "experiment": {
+        self._mock_filewatcher.get_data.return_value = (
+            {
+                "test": {
                     "id": 1,
                     "name": "test",
-                    "variants": {"active": 10, "control_1": 10, "control_2": 10},
-                },
-            }
-        }
+                    "owner": "test_owner",
+                    "type": "r2",
+                    "version": "1",
+                    "start_ts": time.time() - THIRTY_DAYS,
+                    "stop_ts": time.time() + THIRTY_DAYS,
+                    "experiment": {
+                        "id": 1,
+                        "name": "test",
+                        "variants": {"active": 10, "control_1": 10, "control_2": 10},
+                    },
+                }
+            },
+            True,
+        )
+        cfg_data, global_cache = self.mock_experiments_global_cache.get_cfg_and_global_cache()
         experiments = Experiments(
-            config_watcher=self.mock_filewatcher,
             server_span=self.mock_span,
             context_name="test",
+            cfg_data=cfg_data,
+            global_cache=global_cache,
             event_logger=self.event_logger,
         )
 
@@ -204,22 +226,27 @@ class TestExperiments(unittest.TestCase):
         self.assertEqual(getattr(event_fields["experiment"], "version"), "1")
 
     def test_that_override_true_has_no_effect(self):
-        self.mock_filewatcher.get_data.return_value = {
-            "test": {
-                "id": 1,
-                "name": "test",
-                "owner": "test",
-                "type": "r2",
-                "version": "1",
-                "start_ts": time.time() - THIRTY_DAYS,
-                "stop_ts": time.time() + THIRTY_DAYS,
-                "experiment": {"variants": {"active": 10, "control_1": 10, "control_2": 10}},
-            }
-        }
+        self._mock_filewatcher.get_data.return_value = (
+            {
+                "test": {
+                    "id": 1,
+                    "name": "test",
+                    "owner": "test",
+                    "type": "r2",
+                    "version": "1",
+                    "start_ts": time.time() - THIRTY_DAYS,
+                    "stop_ts": time.time() + THIRTY_DAYS,
+                    "experiment": {"variants": {"active": 10, "control_1": 10, "control_2": 10}},
+                }
+            },
+            True,
+        )
+        cfg_data, global_cache = self.mock_experiments_global_cache.get_cfg_and_global_cache()
         experiments = Experiments(
-            config_watcher=self.mock_filewatcher,
             server_span=self.mock_span,
             context_name="test",
+            cfg_data=cfg_data,
+            global_cache=global_cache,
             event_logger=self.event_logger,
         )
         with mock.patch("baseplate.lib.experiments.providers.r2.R2Experiment.variant") as p:
@@ -231,22 +258,27 @@ class TestExperiments(unittest.TestCase):
             self.assertEqual(self.event_logger.log.call_count, 1)
 
     def test_is_valid_experiment(self):
-        self.mock_filewatcher.get_data.return_value = {
-            "test": {
-                "id": 1,
-                "name": "test",
-                "owner": "test",
-                "type": "r2",
-                "version": "1",
-                "start_ts": time.time() - THIRTY_DAYS,
-                "stop_ts": time.time() + THIRTY_DAYS,
-                "experiment": {"variants": {"active": 10, "control_1": 10, "control_2": 10}},
-            }
-        }
+        self._mock_filewatcher.get_data.return_value = (
+            {
+                "test": {
+                    "id": 1,
+                    "name": "test",
+                    "owner": "test",
+                    "type": "r2",
+                    "version": "1",
+                    "start_ts": time.time() - THIRTY_DAYS,
+                    "stop_ts": time.time() + THIRTY_DAYS,
+                    "experiment": {"variants": {"active": 10, "control_1": 10, "control_2": 10}},
+                }
+            },
+            True,
+        )
+        cfg_data, global_cache = self.mock_experiments_global_cache.get_cfg_and_global_cache()
         experiments = Experiments(
-            config_watcher=self.mock_filewatcher,
             server_span=self.mock_span,
             context_name="test",
+            cfg_data=cfg_data,
+            global_cache=global_cache,
             event_logger=self.event_logger,
         )
         with mock.patch("baseplate.lib.experiments.providers.r2.R2Experiment.variant") as p:
@@ -258,32 +290,37 @@ class TestExperiments(unittest.TestCase):
             self.assertEqual(is_valid, False)
 
     def test_get_all_experiment_names(self):
-        self.mock_filewatcher.get_data.return_value = {
-            "test": {
-                "id": 1,
-                "name": "test",
-                "owner": "test",
-                "type": "r2",
-                "version": "1",
-                "start_ts": time.time() - THIRTY_DAYS,
-                "stop_ts": time.time() + THIRTY_DAYS,
-                "experiment": {"variants": {"active": 10, "control_1": 10, "control_2": 10}},
+        self._mock_filewatcher.get_data.return_value = (
+            {
+                "test": {
+                    "id": 1,
+                    "name": "test",
+                    "owner": "test",
+                    "type": "r2",
+                    "version": "1",
+                    "start_ts": time.time() - THIRTY_DAYS,
+                    "stop_ts": time.time() + THIRTY_DAYS,
+                    "experiment": {"variants": {"active": 10, "control_1": 10, "control_2": 10}},
+                },
+                "test2": {
+                    "id": 1,
+                    "name": "test",
+                    "owner": "test",
+                    "type": "r2",
+                    "version": "1",
+                    "start_ts": time.time() - THIRTY_DAYS,
+                    "stop_ts": time.time() + THIRTY_DAYS,
+                    "experiment": {"variants": {"active": 10, "control_1": 10, "control_2": 10}},
+                },
             },
-            "test2": {
-                "id": 1,
-                "name": "test",
-                "owner": "test",
-                "type": "r2",
-                "version": "1",
-                "start_ts": time.time() - THIRTY_DAYS,
-                "stop_ts": time.time() + THIRTY_DAYS,
-                "experiment": {"variants": {"active": 10, "control_1": 10, "control_2": 10}},
-            },
-        }
+            True,
+        )
+        cfg_data, global_cache = self.mock_experiments_global_cache.get_cfg_and_global_cache()
         experiments = Experiments(
-            config_watcher=self.mock_filewatcher,
             server_span=self.mock_span,
             context_name="test",
+            cfg_data=cfg_data,
+            global_cache=global_cache,
             event_logger=self.event_logger,
         )
         with mock.patch("baseplate.lib.experiments.providers.r2.R2Experiment.variant") as p:
@@ -295,22 +332,27 @@ class TestExperiments(unittest.TestCase):
 
     def test_that_bucketing_events_are_not_sent_with_override_false(self):
         """Don't send events when override is False."""
-        self.mock_filewatcher.get_data.return_value = {
-            "test": {
-                "id": 1,
-                "name": "test",
-                "owner": "test",
-                "type": "r2",
-                "version": "1",
-                "start_ts": time.time() - THIRTY_DAYS,
-                "stop_ts": time.time() + THIRTY_DAYS,
-                "experiment": {"variants": {"active": 10, "control_1": 10, "control_2": 10}},
-            }
-        }
+        self._mock_filewatcher.get_data.return_value = (
+            {
+                "test": {
+                    "id": 1,
+                    "name": "test",
+                    "owner": "test",
+                    "type": "r2",
+                    "version": "1",
+                    "start_ts": time.time() - THIRTY_DAYS,
+                    "stop_ts": time.time() + THIRTY_DAYS,
+                    "experiment": {"variants": {"active": 10, "control_1": 10, "control_2": 10}},
+                }
+            },
+            True,
+        )
+        cfg_data, global_cache = self.mock_experiments_global_cache.get_cfg_and_global_cache()
         experiments = Experiments(
-            config_watcher=self.mock_filewatcher,
             server_span=self.mock_span,
             context_name="test",
+            cfg_data=cfg_data,
+            global_cache=global_cache,
             event_logger=self.event_logger,
         )
         with mock.patch("baseplate.lib.experiments.providers.r2.R2Experiment.variant") as p:
@@ -325,22 +367,27 @@ class TestExperiments(unittest.TestCase):
             self.assertEqual(self.event_logger.log.call_count, 0)
 
     def test_that_bucketing_events_not_sent_if_no_variant(self):
-        self.mock_filewatcher.get_data.return_value = {
-            "test": {
-                "id": 1,
-                "name": "test",
-                "owner": "test",
-                "type": "r2",
-                "version": "1",
-                "start_ts": time.time() - THIRTY_DAYS,
-                "stop_ts": time.time() + THIRTY_DAYS,
-                "experiment": {"variants": {"active": 10, "control_1": 10, "control_2": 10}},
-            }
-        }
+        self._mock_filewatcher.get_data.return_value = (
+            {
+                "test": {
+                    "id": 1,
+                    "name": "test",
+                    "owner": "test",
+                    "type": "r2",
+                    "version": "1",
+                    "start_ts": time.time() - THIRTY_DAYS,
+                    "stop_ts": time.time() + THIRTY_DAYS,
+                    "experiment": {"variants": {"active": 10, "control_1": 10, "control_2": 10}},
+                }
+            },
+            True,
+        )
+        cfg_data, global_cache = self.mock_experiments_global_cache.get_cfg_and_global_cache()
         experiments = Experiments(
-            config_watcher=self.mock_filewatcher,
             server_span=self.mock_span,
             context_name="test",
+            cfg_data=cfg_data,
+            global_cache=global_cache,
             event_logger=self.event_logger,
         )
 
@@ -354,22 +401,27 @@ class TestExperiments(unittest.TestCase):
             self.assertEqual(self.event_logger.log.call_count, 0)
 
     def test_that_bucketing_events_not_sent_if_experiment_disables(self):
-        self.mock_filewatcher.get_data.return_value = {
-            "test": {
-                "id": 1,
-                "name": "test",
-                "owner": "test",
-                "type": "r2",
-                "version": "1",
-                "start_ts": time.time() - THIRTY_DAYS,
-                "stop_ts": time.time() + THIRTY_DAYS,
-                "experiment": {"variants": {"active": 10, "control_1": 10, "control_2": 10}},
-            }
-        }
+        self._mock_filewatcher.get_data.return_value = (
+            {
+                "test": {
+                    "id": 1,
+                    "name": "test",
+                    "owner": "test",
+                    "type": "r2",
+                    "version": "1",
+                    "start_ts": time.time() - THIRTY_DAYS,
+                    "stop_ts": time.time() + THIRTY_DAYS,
+                    "experiment": {"variants": {"active": 10, "control_1": 10, "control_2": 10}},
+                }
+            },
+            True,
+        )
+        cfg_data, global_cache = self.mock_experiments_global_cache.get_cfg_and_global_cache()
         experiments = Experiments(
-            config_watcher=self.mock_filewatcher,
             server_span=self.mock_span,
             context_name="test",
+            cfg_data=cfg_data,
+            global_cache=global_cache,
             event_logger=self.event_logger,
         )
 
@@ -388,13 +440,15 @@ class TestExperiments(unittest.TestCase):
             self.assertEqual(self.event_logger.log.call_count, 0)
 
     def test_that_bucketing_events_not_sent_if_cant_load_config(self):
-        self.mock_filewatcher.get_data.side_effect = WatchedFileNotAvailableError(
+        self._mock_filewatcher.get_data.side_effect = WatchedFileNotAvailableError(
             "path", None
         )  # noqa
+        cfg_data, global_cache = self.mock_experiments_global_cache.get_cfg_and_global_cache()
         experiments = Experiments(
-            config_watcher=self.mock_filewatcher,
             server_span=self.mock_span,
             context_name="test",
+            cfg_data=cfg_data,
+            global_cache=global_cache,
             event_logger=self.event_logger,
         )
         self.assertEqual(self.event_logger.log.call_count, 0)
@@ -404,11 +458,13 @@ class TestExperiments(unittest.TestCase):
         self.assertEqual(self.event_logger.log.call_count, 0)
 
     def test_that_bucketing_events_not_sent_if_cant_parse_config(self):
-        self.mock_filewatcher.get_data.side_effect = TypeError()
+        self._mock_filewatcher.get_data.side_effect = TypeError()
+        cfg_data, global_cache = self.mock_experiments_global_cache.get_cfg_and_global_cache()
         experiments = Experiments(
-            config_watcher=self.mock_filewatcher,
             server_span=self.mock_span,
             context_name="test",
+            cfg_data=cfg_data,
+            global_cache=global_cache,
             event_logger=self.event_logger,
         )
         self.assertEqual(self.event_logger.log.call_count, 0)
@@ -418,22 +474,27 @@ class TestExperiments(unittest.TestCase):
         self.assertEqual(self.event_logger.log.call_count, 0)
 
     def test_that_bucketing_events_not_sent_if_cant_find_experiment(self):
-        self.mock_filewatcher.get_data.return_value = {
-            "other_test": {
-                "id": 1,
-                "name": "test",
-                "owner": "test",
-                "type": "r2",
-                "version": "1",
-                "start_ts": time.time() - THIRTY_DAYS,
-                "stop_ts": time.time() + THIRTY_DAYS,
-                "experiment": {"variants": {"active": 10, "control_1": 10, "control_2": 10}},
-            }
-        }
+        self._mock_filewatcher.get_data.return_value = (
+            {
+                "other_test": {
+                    "id": 1,
+                    "name": "test",
+                    "owner": "test",
+                    "type": "r2",
+                    "version": "1",
+                    "start_ts": time.time() - THIRTY_DAYS,
+                    "stop_ts": time.time() + THIRTY_DAYS,
+                    "experiment": {"variants": {"active": 10, "control_1": 10, "control_2": 10}},
+                }
+            },
+            True,
+        )
+        cfg_data, global_cache = self.mock_experiments_global_cache.get_cfg_and_global_cache()
         experiments = Experiments(
-            config_watcher=self.mock_filewatcher,
             server_span=self.mock_span,
             context_name="test",
+            cfg_data=cfg_data,
+            global_cache=global_cache,
             event_logger=self.event_logger,
         )
         self.assertEqual(self.event_logger.log.call_count, 0)
@@ -443,26 +504,31 @@ class TestExperiments(unittest.TestCase):
         self.assertEqual(self.event_logger.log.call_count, 0)
 
     def test_none_returned_on_variant_call_with_bad_id(self):
-        self.mock_filewatcher.get_data.return_value = {
-            "test": {
-                "id": "1",
-                "name": "test",
-                "owner": "test_owner",
-                "type": "r2",
-                "version": "1",
-                "start_ts": time.time() - THIRTY_DAYS,
-                "stop_ts": time.time() + THIRTY_DAYS,
-                "experiment": {
-                    "id": 1,
+        self._mock_filewatcher.get_data.return_value = (
+            {
+                "test": {
+                    "id": "1",
                     "name": "test",
-                    "variants": {"active": 50, "control_1": 25, "control_2": 25},
-                },
-            }
-        }
+                    "owner": "test_owner",
+                    "type": "r2",
+                    "version": "1",
+                    "start_ts": time.time() - THIRTY_DAYS,
+                    "stop_ts": time.time() + THIRTY_DAYS,
+                    "experiment": {
+                        "id": 1,
+                        "name": "test",
+                        "variants": {"active": 50, "control_1": 25, "control_2": 25},
+                    },
+                }
+            },
+            True,
+        )
+        cfg_data, global_cache = self.mock_experiments_global_cache.get_cfg_and_global_cache()
         experiments = Experiments(
-            config_watcher=self.mock_filewatcher,
             server_span=self.mock_span,
             context_name="test",
+            cfg_data=cfg_data,
+            global_cache=global_cache,
             event_logger=self.event_logger,
         )
         self.assertEqual(self.event_logger.log.call_count, 0)
@@ -470,24 +536,29 @@ class TestExperiments(unittest.TestCase):
         self.assertEqual(variant, None)
 
     def test_none_returned_on_variant_call_with_no_times(self):
-        self.mock_filewatcher.get_data.return_value = {
-            "test": {
-                "id": 1,
-                "name": "test",
-                "owner": "test_owner",
-                "type": "r2",
-                "version": "1",
-                "experiment": {
+        self._mock_filewatcher.get_data.return_value = (
+            {
+                "test": {
                     "id": 1,
                     "name": "test",
-                    "variants": {"active": 50, "control_1": 25, "control_2": 25},
-                },
-            }
-        }
+                    "owner": "test_owner",
+                    "type": "r2",
+                    "version": "1",
+                    "experiment": {
+                        "id": 1,
+                        "name": "test",
+                        "variants": {"active": 50, "control_1": 25, "control_2": 25},
+                    },
+                }
+            },
+            True,
+        )
+        cfg_data, global_cache = self.mock_experiments_global_cache.get_cfg_and_global_cache()
         experiments = Experiments(
-            config_watcher=self.mock_filewatcher,
             server_span=self.mock_span,
             context_name="test",
+            cfg_data=cfg_data,
+            global_cache=global_cache,
             event_logger=self.event_logger,
         )
         self.assertEqual(self.event_logger.log.call_count, 0)
@@ -495,21 +566,26 @@ class TestExperiments(unittest.TestCase):
         self.assertEqual(variant, None)
 
     def test_none_returned_on_variant_call_with_no_experiment(self):
-        self.mock_filewatcher.get_data.return_value = {
-            "test": {
-                "id": 1,
-                "name": "test",
-                "owner": "test_owner",
-                "type": "r2",
-                "version": "1",
-                "start_ts": time.time() - THIRTY_DAYS,
-                "stop_ts": time.time() + THIRTY_DAYS,
-            }
-        }
+        self._mock_filewatcher.get_data.return_value = (
+            {
+                "test": {
+                    "id": 1,
+                    "name": "test",
+                    "owner": "test_owner",
+                    "type": "r2",
+                    "version": "1",
+                    "start_ts": time.time() - THIRTY_DAYS,
+                    "stop_ts": time.time() + THIRTY_DAYS,
+                }
+            },
+            True,
+        )
+        cfg_data, global_cache = self.mock_experiments_global_cache.get_cfg_and_global_cache()
         experiments = Experiments(
-            config_watcher=self.mock_filewatcher,
             server_span=self.mock_span,
             context_name="test",
+            cfg_data=cfg_data,
+            global_cache=global_cache,
             event_logger=self.event_logger,
         )
         self.assertEqual(self.event_logger.log.call_count, 0)
@@ -517,7 +593,7 @@ class TestExperiments(unittest.TestCase):
         self.assertEqual(variant, None)
 
 
-@mock.patch("baseplate.lib.experiments.FileWatcher")
+@mock.patch("baseplate.lib.experiments.FileWatcherWithUpdatedFlag")
 class ExperimentsClientFromConfigTests(unittest.TestCase):
     def test_make_clients(self, file_watcher_mock):
         event_logger = mock.Mock(spec=DebugLogger)
@@ -550,3 +626,267 @@ class ExperimentsClientFromConfigTests(unittest.TestCase):
         file_watcher_mock.assert_called_once_with(
             "/tmp/test", json.load, timeout=60.0, backoff=None
         )
+
+
+class ExperimentsGlobalCacheTests(unittest.TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.event_logger = mock.Mock(spec=DebugLogger)
+        self._mock_filewatcher = mock.Mock(spec=FileWatcherWithUpdatedFlag)
+        self.mock_experiments_global_cache = ExperimentsGlobalCache(self._mock_filewatcher)
+        self.mock_span = mock.MagicMock(spec=ServerSpan)
+
+    def test_global_cache_updated(self):
+        self._mock_filewatcher.get_data.return_value = (
+            {
+                "test": {
+                    "id": 1,
+                    "name": "test",
+                    "owner": "test",
+                    "type": "r2",
+                    "version": "1",
+                    "start_ts": time.time() - THIRTY_DAYS,
+                    "stop_ts": time.time() + THIRTY_DAYS,
+                    "experiment": {"variants": {"active": 10, "control_1": 10, "control_2": 10}},
+                }
+            },
+            True,
+        )
+        cfg_data, global_cache = self.mock_experiments_global_cache.get_cfg_and_global_cache()
+        experiments = Experiments(
+            server_span=self.mock_span,
+            context_name="test",
+            cfg_data=cfg_data,
+            global_cache=global_cache,
+            event_logger=self.event_logger,
+        )
+        exp_res = experiments._get_experiment("test")
+        self.assertTrue("test" in global_cache)
+        self.assertEqual(exp_res.name, "test")
+
+    @mock.patch("baseplate.lib.experiments.parse_experiment")
+    def test_experiments_with_same_name_stale_cache(self, m_parse_experiment):
+        cfg_data = {
+            "test": {
+                "id": 1,
+                "name": "test",
+                "owner": "test",
+                "type": "r2",
+                "version": "1",
+                "start_ts": time.time() - THIRTY_DAYS,
+                "stop_ts": time.time() + THIRTY_DAYS,
+                "experiment": {"variants": {"active": 10, "control_1": 10, "control_2": 10}},
+            }
+        }
+
+        # experiment_one add test to global cache
+        self._mock_filewatcher.get_data.return_value = cfg_data, True
+        cfg_data, global_cache = self.mock_experiments_global_cache.get_cfg_and_global_cache()
+        experiment_one = Experiments(
+            server_span=self.mock_span,
+            context_name="test",
+            cfg_data=cfg_data,
+            global_cache=global_cache,
+            event_logger=self.event_logger,
+        )
+        experiment_one._get_experiment("test")
+        self.assertTrue("test" in global_cache)
+        m_parse_experiment.assert_called_once()
+
+        # experiment_two just use the cache
+        self._mock_filewatcher.get_data.return_value = cfg_data, False
+        cfg_data, global_cache = self.mock_experiments_global_cache.get_cfg_and_global_cache()
+        experiment_two = Experiments(
+            server_span=self.mock_span,
+            context_name="test",
+            cfg_data=cfg_data,
+            global_cache=global_cache,
+            event_logger=self.event_logger,
+        )
+        experiment_two._get_experiment("test")
+        m_parse_experiment.assert_called_once()
+        self.assertTrue("test" in global_cache)
+
+    @mock.patch("baseplate.lib.experiments.parse_experiment")
+    def test_experiments_with_different_name_stale_cache(self, m_parse_experiment):
+        value1 = {
+            "id": 1,
+            "name": "test1",
+            "owner": "test",
+            "type": "r2",
+            "version": "1",
+            "start_ts": time.time() - THIRTY_DAYS,
+            "stop_ts": time.time() + THIRTY_DAYS,
+            "experiment": {"variants": {"active": 10, "control_1": 10, "control_2": 10}},
+        }
+        value2 = {
+            "id": 2,
+            "name": "test2",
+            "owner": "test",
+            "type": "r2",
+            "version": "1",
+            "start_ts": time.time() - THIRTY_DAYS,
+            "stop_ts": time.time() + THIRTY_DAYS,
+            "experiment": {"variants": {"active": 10, "control_1": 10, "control_2": 10}},
+        }
+        cfg_data = {"test1": value1, "test2": value2}
+
+        # experiment_one add test1 to global cache
+        self._mock_filewatcher.get_data.return_value = cfg_data, True
+        cfg_data, global_cache = self.mock_experiments_global_cache.get_cfg_and_global_cache()
+        experiment_one = Experiments(
+            server_span=self.mock_span,
+            context_name="test",
+            cfg_data=cfg_data,
+            global_cache=global_cache,
+            event_logger=self.event_logger,
+        )
+        experiment_one._get_experiment("test1")
+        self.assertTrue("test1" in global_cache)
+        self.assertFalse("test2" in global_cache)
+        m_parse_experiment.assert_called_once_with(value1)
+
+        # experiment_two add test2 to global cache
+        self._mock_filewatcher.get_data.return_value = cfg_data, False
+        cfg_data, global_cache = self.mock_experiments_global_cache.get_cfg_and_global_cache()
+        experiment_two = Experiments(
+            server_span=self.mock_span,
+            context_name="test",
+            cfg_data=cfg_data,
+            global_cache=global_cache,
+            event_logger=self.event_logger,
+        )
+        experiment_two._get_experiment("test2")
+        m_parse_experiment.assert_called_with(value2)
+        self.assertTrue("test1" in global_cache)
+        self.assertTrue("test2" in global_cache)
+
+    def test_experiments_with_same_name_updated_cache(self):
+        owner1 = "test1"
+        owner2 = "test2"
+        value1 = {
+            "id": 1,
+            "name": "test",
+            "owner": owner1,
+            "type": "r2",
+            "version": "1",
+            "start_ts": time.time() - THIRTY_DAYS,
+            "stop_ts": time.time() + THIRTY_DAYS,
+            "experiment": {"variants": {"active": 10, "control_1": 10, "control_2": 10}},
+        }
+        value2 = {
+            "id": 1,
+            "name": "test",
+            "owner": owner2,
+            "type": "r2",
+            "version": "1",
+            "start_ts": time.time() - THIRTY_DAYS,
+            "stop_ts": time.time() + THIRTY_DAYS,
+            "experiment": {"variants": {"active": 10, "control_1": 10, "control_2": 10}},
+        }
+
+        cfg_data = {"test": value1}
+
+        # experiment_one add value 1 in global cache
+        self._mock_filewatcher.get_data.return_value = cfg_data, True
+        cfg_data, global_cache = self.mock_experiments_global_cache.get_cfg_and_global_cache()
+        experiment_one = Experiments(
+            server_span=self.mock_span,
+            context_name="test",
+            cfg_data=cfg_data,
+            global_cache=global_cache,
+            event_logger=self.event_logger,
+        )
+        experiment_one._get_experiment("test")
+        self.assertTrue("test" in global_cache)
+        self.assertEqual(global_cache["test"].owner, owner1)
+
+        # updated test config file to value2
+        cfg_data = {"test": value2}
+        self._mock_filewatcher.get_data.return_value = cfg_data, True
+        cfg_data, global_cache = self.mock_experiments_global_cache.get_cfg_and_global_cache()
+        self.assertEqual(global_cache, {})
+        experiment_two = Experiments(
+            server_span=self.mock_span,
+            context_name="test",
+            cfg_data=cfg_data,
+            global_cache=global_cache,
+            event_logger=self.event_logger,
+        )
+        experiment_two._get_experiment("test")
+        self.assertTrue("test" in global_cache)
+        self.assertEqual(global_cache["test"].owner, owner2)
+
+        # experiment_one global cache still use old one
+        self.assertEqual(experiment_one._global_cache["test"].owner, owner1)
+
+        # global cache was updated by experiment_two
+        self._mock_filewatcher.get_data.return_value = cfg_data, False
+        global_cache = self.mock_experiments_global_cache.get_cfg_and_global_cache()[1]
+        self.assertEqual(global_cache["test"].owner, owner2)
+
+    def test_experiments_with_different_name_updated_cache(self):
+        value1 = {
+            "id": 1,
+            "name": "test1",
+            "owner": "test1",
+            "type": "r2",
+            "version": "1",
+            "start_ts": time.time() - THIRTY_DAYS,
+            "stop_ts": time.time() + THIRTY_DAYS,
+            "experiment": {"variants": {"active": 10, "control_1": 10, "control_2": 10}},
+        }
+        value2 = {
+            "id": 2,
+            "name": "test2",
+            "owner": "test2",
+            "type": "r2",
+            "version": "1",
+            "start_ts": time.time() - THIRTY_DAYS,
+            "stop_ts": time.time() + THIRTY_DAYS,
+            "experiment": {"variants": {"active": 10, "control_1": 10, "control_2": 10}},
+        }
+
+        cfg_data = {"test1": value1, "test2": value2}
+
+        # experiment_one add test1 into global cache
+        self._mock_filewatcher.get_data.return_value = cfg_data, True
+        cfg_data, global_cache = self.mock_experiments_global_cache.get_cfg_and_global_cache()
+        experiment_one = Experiments(
+            server_span=self.mock_span,
+            context_name="test",
+            cfg_data=cfg_data,
+            global_cache=global_cache,
+            event_logger=self.event_logger,
+        )
+        experiment_one._get_experiment("test1")
+        self.assertTrue("test1" in global_cache)
+        self.assertFalse("test2" in global_cache)
+        self.assertEqual(global_cache["test1"].owner, "test1")
+
+        # updated test config file
+        # experiment_two add test2 into global cache
+        self._mock_filewatcher.get_data.return_value = cfg_data, True
+        cfg_data, global_cache = self.mock_experiments_global_cache.get_cfg_and_global_cache()
+        self.assertEqual(global_cache, {})
+        experiment_two = Experiments(
+            server_span=self.mock_span,
+            context_name="test",
+            cfg_data=cfg_data,
+            global_cache=global_cache,
+            event_logger=self.event_logger,
+        )
+        experiment_two._get_experiment("test2")
+        self.assertTrue("test2" in global_cache)
+        self.assertFalse("test1" in global_cache)
+        self.assertEqual(global_cache["test2"].owner, "test2")
+
+        # experiment_one global cache still use old one
+        self.assertEqual(experiment_one._global_cache["test1"].owner, "test1")
+
+        # global cache only contains test2 experiment
+        self._mock_filewatcher.get_data.return_value = cfg_data, False
+        global_cache = self.mock_experiments_global_cache.get_cfg_and_global_cache()[1]
+        self.assertTrue("test2" in global_cache)
+        self.assertFalse("test1" in global_cache)
+        self.assertEqual(global_cache["test2"].owner, "test2")

--- a/tests/unit/lib/experiments/experiment_tests.py
+++ b/tests/unit/lib/experiments/experiment_tests.py
@@ -1,3 +1,4 @@
+import datetime
 import json
 import time
 import unittest
@@ -13,9 +14,7 @@ from baseplate.lib.experiments import EventType
 from baseplate.lib.experiments import Experiments
 from baseplate.lib.experiments import experiments_client_from_config
 from baseplate.lib.experiments import ExperimentsContextFactory
-from baseplate.lib.experiments import ExperimentsGlobalCache
-from baseplate.lib.file_watcher import FileWatcherWithUpdatedFlag
-from baseplate.lib.file_watcher import WatchedFileNotAvailableError
+from baseplate.lib.file_watcher import FileWatcher
 
 
 THIRTY_DAYS = timedelta(days=30).total_seconds()
@@ -25,8 +24,6 @@ class TestExperiments(unittest.TestCase):
     def setUp(self):
         super().setUp()
         self.event_logger = mock.Mock(spec=DebugLogger)
-        self._mock_filewatcher = mock.Mock(spec=FileWatcherWithUpdatedFlag)
-        self.mock_experiments_global_cache = ExperimentsGlobalCache(self._mock_filewatcher)
         self.mock_span = mock.MagicMock(spec=ServerSpan)
         self.mock_span.context = None
         self.mock_span.trace_id = "123456"
@@ -41,31 +38,27 @@ class TestExperiments(unittest.TestCase):
         )
 
     def test_bucketing_event_fields(self):
-        self._mock_filewatcher.get_data.return_value = (
-            {
-                "test": {
+        cfg_data = {
+            "test": {
+                "id": 1,
+                "name": "test",
+                "owner": "test_owner",
+                "type": "r2",
+                "version": "1",
+                "start_ts": time.time() - THIRTY_DAYS,
+                "stop_ts": time.time() + THIRTY_DAYS,
+                "experiment": {
                     "id": 1,
                     "name": "test",
-                    "owner": "test_owner",
-                    "type": "r2",
-                    "version": "1",
-                    "start_ts": time.time() - THIRTY_DAYS,
-                    "stop_ts": time.time() + THIRTY_DAYS,
-                    "experiment": {
-                        "id": 1,
-                        "name": "test",
-                        "variants": {"active": 10, "control_1": 10, "control_2": 10},
-                    },
-                }
-            },
-            True,
-        )
-        cfg_data, global_cache = self.mock_experiments_global_cache.get_cfg_and_global_cache()
+                    "variants": {"active": 10, "control_1": 10, "control_2": 10},
+                },
+            }
+        }
         experiments = Experiments(
             server_span=self.mock_span,
             context_name="test",
             cfg_data=cfg_data,
-            global_cache=global_cache,
+            global_cache={},
             event_logger=self.event_logger,
         )
 
@@ -91,31 +84,27 @@ class TestExperiments(unittest.TestCase):
         self.assertEqual(getattr(event_fields["experiment"], "version"), "1")
 
     def test_bucketing_event_fields_without_baseplate_user(self):
-        self._mock_filewatcher.get_data.return_value = (
-            {
-                "test": {
+        cfg_data = {
+            "test": {
+                "id": 1,
+                "name": "test",
+                "owner": "test_owner",
+                "type": "r2",
+                "version": "1",
+                "start_ts": time.time() - THIRTY_DAYS,
+                "stop_ts": time.time() + THIRTY_DAYS,
+                "experiment": {
                     "id": 1,
                     "name": "test",
-                    "owner": "test_owner",
-                    "type": "r2",
-                    "version": "1",
-                    "start_ts": time.time() - THIRTY_DAYS,
-                    "stop_ts": time.time() + THIRTY_DAYS,
-                    "experiment": {
-                        "id": 1,
-                        "name": "test",
-                        "variants": {"active": 10, "control_1": 10, "control_2": 10},
-                    },
-                }
-            },
-            True,
-        )
-        cfg_data, global_cache = self.mock_experiments_global_cache.get_cfg_and_global_cache()
+                    "variants": {"active": 10, "control_1": 10, "control_2": 10},
+                },
+            }
+        }
         experiments = Experiments(
             server_span=self.mock_span,
             context_name="test",
             cfg_data=cfg_data,
-            global_cache=global_cache,
+            global_cache={},
             event_logger=self.event_logger,
         )
 
@@ -140,31 +129,27 @@ class TestExperiments(unittest.TestCase):
         self.assertEqual(getattr(event_fields["experiment"], "version"), "1")
 
     def test_that_we_only_send_bucketing_event_once(self):
-        self._mock_filewatcher.get_data.return_value = (
-            {
-                "test": {
+        cfg_data = {
+            "test": {
+                "id": 1,
+                "name": "test",
+                "owner": "test",
+                "type": "r2",
+                "version": "1",
+                "start_ts": time.time() - THIRTY_DAYS,
+                "stop_ts": time.time() + THIRTY_DAYS,
+                "experiment": {
                     "id": 1,
                     "name": "test",
-                    "owner": "test",
-                    "type": "r2",
-                    "version": "1",
-                    "start_ts": time.time() - THIRTY_DAYS,
-                    "stop_ts": time.time() + THIRTY_DAYS,
-                    "experiment": {
-                        "id": 1,
-                        "name": "test",
-                        "variants": {"active": 10, "control_1": 10, "control_2": 10},
-                    },
-                }
-            },
-            True,
-        )
-        cfg_data, global_cache = self.mock_experiments_global_cache.get_cfg_and_global_cache()
+                    "variants": {"active": 10, "control_1": 10, "control_2": 10},
+                },
+            }
+        }
         experiments = Experiments(
             server_span=self.mock_span,
             context_name="test",
             cfg_data=cfg_data,
-            global_cache=global_cache,
+            global_cache={},
             event_logger=self.event_logger,
         )
 
@@ -178,31 +163,27 @@ class TestExperiments(unittest.TestCase):
             self.assertEqual(self.event_logger.log.call_count, 1)
 
     def test_exposure_event_fields(self):
-        self._mock_filewatcher.get_data.return_value = (
-            {
-                "test": {
+        cfg_data = {
+            "test": {
+                "id": 1,
+                "name": "test",
+                "owner": "test_owner",
+                "type": "r2",
+                "version": "1",
+                "start_ts": time.time() - THIRTY_DAYS,
+                "stop_ts": time.time() + THIRTY_DAYS,
+                "experiment": {
                     "id": 1,
                     "name": "test",
-                    "owner": "test_owner",
-                    "type": "r2",
-                    "version": "1",
-                    "start_ts": time.time() - THIRTY_DAYS,
-                    "stop_ts": time.time() + THIRTY_DAYS,
-                    "experiment": {
-                        "id": 1,
-                        "name": "test",
-                        "variants": {"active": 10, "control_1": 10, "control_2": 10},
-                    },
-                }
-            },
-            True,
-        )
-        cfg_data, global_cache = self.mock_experiments_global_cache.get_cfg_and_global_cache()
+                    "variants": {"active": 10, "control_1": 10, "control_2": 10},
+                },
+            }
+        }
         experiments = Experiments(
             server_span=self.mock_span,
             context_name="test",
             cfg_data=cfg_data,
-            global_cache=global_cache,
+            global_cache={},
             event_logger=self.event_logger,
         )
 
@@ -226,29 +207,26 @@ class TestExperiments(unittest.TestCase):
         self.assertEqual(getattr(event_fields["experiment"], "version"), "1")
 
     def test_that_override_true_has_no_effect(self):
-        self._mock_filewatcher.get_data.return_value = (
-            {
-                "test": {
-                    "id": 1,
-                    "name": "test",
-                    "owner": "test",
-                    "type": "r2",
-                    "version": "1",
-                    "start_ts": time.time() - THIRTY_DAYS,
-                    "stop_ts": time.time() + THIRTY_DAYS,
-                    "experiment": {"variants": {"active": 10, "control_1": 10, "control_2": 10}},
-                }
-            },
-            True,
-        )
-        cfg_data, global_cache = self.mock_experiments_global_cache.get_cfg_and_global_cache()
+        cfg_data = {
+            "test": {
+                "id": 1,
+                "name": "test",
+                "owner": "test",
+                "type": "r2",
+                "version": "1",
+                "start_ts": time.time() - THIRTY_DAYS,
+                "stop_ts": time.time() + THIRTY_DAYS,
+                "experiment": {"variants": {"active": 10, "control_1": 10, "control_2": 10}},
+            }
+        }
         experiments = Experiments(
             server_span=self.mock_span,
             context_name="test",
             cfg_data=cfg_data,
-            global_cache=global_cache,
+            global_cache={},
             event_logger=self.event_logger,
         )
+
         with mock.patch("baseplate.lib.experiments.providers.r2.R2Experiment.variant") as p:
             p.return_value = "active"
             self.assertEqual(self.event_logger.log.call_count, 0)
@@ -258,29 +236,26 @@ class TestExperiments(unittest.TestCase):
             self.assertEqual(self.event_logger.log.call_count, 1)
 
     def test_is_valid_experiment(self):
-        self._mock_filewatcher.get_data.return_value = (
-            {
-                "test": {
-                    "id": 1,
-                    "name": "test",
-                    "owner": "test",
-                    "type": "r2",
-                    "version": "1",
-                    "start_ts": time.time() - THIRTY_DAYS,
-                    "stop_ts": time.time() + THIRTY_DAYS,
-                    "experiment": {"variants": {"active": 10, "control_1": 10, "control_2": 10}},
-                }
-            },
-            True,
-        )
-        cfg_data, global_cache = self.mock_experiments_global_cache.get_cfg_and_global_cache()
+        cfg_data = {
+            "test": {
+                "id": 1,
+                "name": "test",
+                "owner": "test",
+                "type": "r2",
+                "version": "1",
+                "start_ts": time.time() - THIRTY_DAYS,
+                "stop_ts": time.time() + THIRTY_DAYS,
+                "experiment": {"variants": {"active": 10, "control_1": 10, "control_2": 10}},
+            }
+        }
         experiments = Experiments(
             server_span=self.mock_span,
             context_name="test",
             cfg_data=cfg_data,
-            global_cache=global_cache,
+            global_cache={},
             event_logger=self.event_logger,
         )
+
         with mock.patch("baseplate.lib.experiments.providers.r2.R2Experiment.variant") as p:
             p.return_value = "active"
             is_valid = experiments.is_valid_experiment("test")
@@ -290,39 +265,36 @@ class TestExperiments(unittest.TestCase):
             self.assertEqual(is_valid, False)
 
     def test_get_all_experiment_names(self):
-        self._mock_filewatcher.get_data.return_value = (
-            {
-                "test": {
-                    "id": 1,
-                    "name": "test",
-                    "owner": "test",
-                    "type": "r2",
-                    "version": "1",
-                    "start_ts": time.time() - THIRTY_DAYS,
-                    "stop_ts": time.time() + THIRTY_DAYS,
-                    "experiment": {"variants": {"active": 10, "control_1": 10, "control_2": 10}},
-                },
-                "test2": {
-                    "id": 1,
-                    "name": "test",
-                    "owner": "test",
-                    "type": "r2",
-                    "version": "1",
-                    "start_ts": time.time() - THIRTY_DAYS,
-                    "stop_ts": time.time() + THIRTY_DAYS,
-                    "experiment": {"variants": {"active": 10, "control_1": 10, "control_2": 10}},
-                },
+        cfg_data = {
+            "test": {
+                "id": 1,
+                "name": "test",
+                "owner": "test",
+                "type": "r2",
+                "version": "1",
+                "start_ts": time.time() - THIRTY_DAYS,
+                "stop_ts": time.time() + THIRTY_DAYS,
+                "experiment": {"variants": {"active": 10, "control_1": 10, "control_2": 10}},
             },
-            True,
-        )
-        cfg_data, global_cache = self.mock_experiments_global_cache.get_cfg_and_global_cache()
+            "test2": {
+                "id": 1,
+                "name": "test",
+                "owner": "test",
+                "type": "r2",
+                "version": "1",
+                "start_ts": time.time() - THIRTY_DAYS,
+                "stop_ts": time.time() + THIRTY_DAYS,
+                "experiment": {"variants": {"active": 10, "control_1": 10, "control_2": 10}},
+            },
+        }
         experiments = Experiments(
             server_span=self.mock_span,
             context_name="test",
             cfg_data=cfg_data,
-            global_cache=global_cache,
+            global_cache={},
             event_logger=self.event_logger,
         )
+
         with mock.patch("baseplate.lib.experiments.providers.r2.R2Experiment.variant") as p:
             p.return_value = "active"
             experiment_names = experiments.get_all_experiment_names()
@@ -332,29 +304,26 @@ class TestExperiments(unittest.TestCase):
 
     def test_that_bucketing_events_are_not_sent_with_override_false(self):
         """Don't send events when override is False."""
-        self._mock_filewatcher.get_data.return_value = (
-            {
-                "test": {
-                    "id": 1,
-                    "name": "test",
-                    "owner": "test",
-                    "type": "r2",
-                    "version": "1",
-                    "start_ts": time.time() - THIRTY_DAYS,
-                    "stop_ts": time.time() + THIRTY_DAYS,
-                    "experiment": {"variants": {"active": 10, "control_1": 10, "control_2": 10}},
-                }
-            },
-            True,
-        )
-        cfg_data, global_cache = self.mock_experiments_global_cache.get_cfg_and_global_cache()
+        cfg_data = {
+            "test": {
+                "id": 1,
+                "name": "test",
+                "owner": "test",
+                "type": "r2",
+                "version": "1",
+                "start_ts": time.time() - THIRTY_DAYS,
+                "stop_ts": time.time() + THIRTY_DAYS,
+                "experiment": {"variants": {"active": 10, "control_1": 10, "control_2": 10}},
+            }
+        }
         experiments = Experiments(
             server_span=self.mock_span,
             context_name="test",
             cfg_data=cfg_data,
-            global_cache=global_cache,
+            global_cache={},
             event_logger=self.event_logger,
         )
+
         with mock.patch("baseplate.lib.experiments.providers.r2.R2Experiment.variant") as p:
             p.return_value = "active"
             self.assertEqual(self.event_logger.log.call_count, 0)
@@ -367,27 +336,23 @@ class TestExperiments(unittest.TestCase):
             self.assertEqual(self.event_logger.log.call_count, 0)
 
     def test_that_bucketing_events_not_sent_if_no_variant(self):
-        self._mock_filewatcher.get_data.return_value = (
-            {
-                "test": {
-                    "id": 1,
-                    "name": "test",
-                    "owner": "test",
-                    "type": "r2",
-                    "version": "1",
-                    "start_ts": time.time() - THIRTY_DAYS,
-                    "stop_ts": time.time() + THIRTY_DAYS,
-                    "experiment": {"variants": {"active": 10, "control_1": 10, "control_2": 10}},
-                }
-            },
-            True,
-        )
-        cfg_data, global_cache = self.mock_experiments_global_cache.get_cfg_and_global_cache()
+        cfg_data = {
+            "test": {
+                "id": 1,
+                "name": "test",
+                "owner": "test",
+                "type": "r2",
+                "version": "1",
+                "start_ts": time.time() - THIRTY_DAYS,
+                "stop_ts": time.time() + THIRTY_DAYS,
+                "experiment": {"variants": {"active": 10, "control_1": 10, "control_2": 10}},
+            }
+        }
         experiments = Experiments(
             server_span=self.mock_span,
             context_name="test",
             cfg_data=cfg_data,
-            global_cache=global_cache,
+            global_cache={},
             event_logger=self.event_logger,
         )
 
@@ -401,27 +366,23 @@ class TestExperiments(unittest.TestCase):
             self.assertEqual(self.event_logger.log.call_count, 0)
 
     def test_that_bucketing_events_not_sent_if_experiment_disables(self):
-        self._mock_filewatcher.get_data.return_value = (
-            {
-                "test": {
-                    "id": 1,
-                    "name": "test",
-                    "owner": "test",
-                    "type": "r2",
-                    "version": "1",
-                    "start_ts": time.time() - THIRTY_DAYS,
-                    "stop_ts": time.time() + THIRTY_DAYS,
-                    "experiment": {"variants": {"active": 10, "control_1": 10, "control_2": 10}},
-                }
-            },
-            True,
-        )
-        cfg_data, global_cache = self.mock_experiments_global_cache.get_cfg_and_global_cache()
+        cfg_data = {
+            "test": {
+                "id": 1,
+                "name": "test",
+                "owner": "test",
+                "type": "r2",
+                "version": "1",
+                "start_ts": time.time() - THIRTY_DAYS,
+                "stop_ts": time.time() + THIRTY_DAYS,
+                "experiment": {"variants": {"active": 10, "control_1": 10, "control_2": 10}},
+            }
+        }
         experiments = Experiments(
             server_span=self.mock_span,
             context_name="test",
             cfg_data=cfg_data,
-            global_cache=global_cache,
+            global_cache={},
             event_logger=self.event_logger,
         )
 
@@ -439,32 +400,12 @@ class TestExperiments(unittest.TestCase):
             experiments.variant("test", user=self.user, bucketing_event_override=True)
             self.assertEqual(self.event_logger.log.call_count, 0)
 
-    def test_that_bucketing_events_not_sent_if_cant_load_config(self):
-        self._mock_filewatcher.get_data.side_effect = WatchedFileNotAvailableError(
-            "path", None
-        )  # noqa
-        cfg_data, global_cache = self.mock_experiments_global_cache.get_cfg_and_global_cache()
+    def test_that_bucketing_events_not_sent_if_config_is_empty(self):
         experiments = Experiments(
             server_span=self.mock_span,
             context_name="test",
-            cfg_data=cfg_data,
-            global_cache=global_cache,
-            event_logger=self.event_logger,
-        )
-        self.assertEqual(self.event_logger.log.call_count, 0)
-        experiments.variant("test", user=self.user)
-        self.assertEqual(self.event_logger.log.call_count, 0)
-        experiments.variant("test", user=self.user)
-        self.assertEqual(self.event_logger.log.call_count, 0)
-
-    def test_that_bucketing_events_not_sent_if_cant_parse_config(self):
-        self._mock_filewatcher.get_data.side_effect = TypeError()
-        cfg_data, global_cache = self.mock_experiments_global_cache.get_cfg_and_global_cache()
-        experiments = Experiments(
-            server_span=self.mock_span,
-            context_name="test",
-            cfg_data=cfg_data,
-            global_cache=global_cache,
+            cfg_data={},
+            global_cache={},
             event_logger=self.event_logger,
         )
         self.assertEqual(self.event_logger.log.call_count, 0)
@@ -474,27 +415,23 @@ class TestExperiments(unittest.TestCase):
         self.assertEqual(self.event_logger.log.call_count, 0)
 
     def test_that_bucketing_events_not_sent_if_cant_find_experiment(self):
-        self._mock_filewatcher.get_data.return_value = (
-            {
-                "other_test": {
-                    "id": 1,
-                    "name": "test",
-                    "owner": "test",
-                    "type": "r2",
-                    "version": "1",
-                    "start_ts": time.time() - THIRTY_DAYS,
-                    "stop_ts": time.time() + THIRTY_DAYS,
-                    "experiment": {"variants": {"active": 10, "control_1": 10, "control_2": 10}},
-                }
-            },
-            True,
-        )
-        cfg_data, global_cache = self.mock_experiments_global_cache.get_cfg_and_global_cache()
+        cfg_data = {
+            "other_test": {
+                "id": 1,
+                "name": "test",
+                "owner": "test",
+                "type": "r2",
+                "version": "1",
+                "start_ts": time.time() - THIRTY_DAYS,
+                "stop_ts": time.time() + THIRTY_DAYS,
+                "experiment": {"variants": {"active": 10, "control_1": 10, "control_2": 10}},
+            }
+        }
         experiments = Experiments(
             server_span=self.mock_span,
             context_name="test",
             cfg_data=cfg_data,
-            global_cache=global_cache,
+            global_cache={},
             event_logger=self.event_logger,
         )
         self.assertEqual(self.event_logger.log.call_count, 0)
@@ -504,31 +441,27 @@ class TestExperiments(unittest.TestCase):
         self.assertEqual(self.event_logger.log.call_count, 0)
 
     def test_none_returned_on_variant_call_with_bad_id(self):
-        self._mock_filewatcher.get_data.return_value = (
-            {
-                "test": {
-                    "id": "1",
+        cfg_data = {
+            "test": {
+                "id": "1",
+                "name": "test",
+                "owner": "test_owner",
+                "type": "r2",
+                "version": "1",
+                "start_ts": time.time() - THIRTY_DAYS,
+                "stop_ts": time.time() + THIRTY_DAYS,
+                "experiment": {
+                    "id": 1,
                     "name": "test",
-                    "owner": "test_owner",
-                    "type": "r2",
-                    "version": "1",
-                    "start_ts": time.time() - THIRTY_DAYS,
-                    "stop_ts": time.time() + THIRTY_DAYS,
-                    "experiment": {
-                        "id": 1,
-                        "name": "test",
-                        "variants": {"active": 50, "control_1": 25, "control_2": 25},
-                    },
-                }
-            },
-            True,
-        )
-        cfg_data, global_cache = self.mock_experiments_global_cache.get_cfg_and_global_cache()
+                    "variants": {"active": 50, "control_1": 25, "control_2": 25},
+                },
+            }
+        }
         experiments = Experiments(
             server_span=self.mock_span,
             context_name="test",
             cfg_data=cfg_data,
-            global_cache=global_cache,
+            global_cache={},
             event_logger=self.event_logger,
         )
         self.assertEqual(self.event_logger.log.call_count, 0)
@@ -536,29 +469,25 @@ class TestExperiments(unittest.TestCase):
         self.assertEqual(variant, None)
 
     def test_none_returned_on_variant_call_with_no_times(self):
-        self._mock_filewatcher.get_data.return_value = (
-            {
-                "test": {
+        cfg_data = {
+            "test": {
+                "id": 1,
+                "name": "test",
+                "owner": "test_owner",
+                "type": "r2",
+                "version": "1",
+                "experiment": {
                     "id": 1,
                     "name": "test",
-                    "owner": "test_owner",
-                    "type": "r2",
-                    "version": "1",
-                    "experiment": {
-                        "id": 1,
-                        "name": "test",
-                        "variants": {"active": 50, "control_1": 25, "control_2": 25},
-                    },
-                }
-            },
-            True,
-        )
-        cfg_data, global_cache = self.mock_experiments_global_cache.get_cfg_and_global_cache()
+                    "variants": {"active": 50, "control_1": 25, "control_2": 25},
+                },
+            }
+        }
         experiments = Experiments(
             server_span=self.mock_span,
             context_name="test",
             cfg_data=cfg_data,
-            global_cache=global_cache,
+            global_cache={},
             event_logger=self.event_logger,
         )
         self.assertEqual(self.event_logger.log.call_count, 0)
@@ -566,26 +495,22 @@ class TestExperiments(unittest.TestCase):
         self.assertEqual(variant, None)
 
     def test_none_returned_on_variant_call_with_no_experiment(self):
-        self._mock_filewatcher.get_data.return_value = (
-            {
-                "test": {
-                    "id": 1,
-                    "name": "test",
-                    "owner": "test_owner",
-                    "type": "r2",
-                    "version": "1",
-                    "start_ts": time.time() - THIRTY_DAYS,
-                    "stop_ts": time.time() + THIRTY_DAYS,
-                }
-            },
-            True,
-        )
-        cfg_data, global_cache = self.mock_experiments_global_cache.get_cfg_and_global_cache()
+        cfg_data = {
+            "test": {
+                "id": 1,
+                "name": "test",
+                "owner": "test_owner",
+                "type": "r2",
+                "version": "1",
+                "start_ts": time.time() - THIRTY_DAYS,
+                "stop_ts": time.time() + THIRTY_DAYS,
+            }
+        }
         experiments = Experiments(
             server_span=self.mock_span,
             context_name="test",
             cfg_data=cfg_data,
-            global_cache=global_cache,
+            global_cache={},
             event_logger=self.event_logger,
         )
         self.assertEqual(self.event_logger.log.call_count, 0)
@@ -593,7 +518,7 @@ class TestExperiments(unittest.TestCase):
         self.assertEqual(variant, None)
 
 
-@mock.patch("baseplate.lib.experiments.FileWatcherWithUpdatedFlag")
+@mock.patch("baseplate.lib.experiments.FileWatcher")
 class ExperimentsClientFromConfigTests(unittest.TestCase):
     def test_make_clients(self, file_watcher_mock):
         event_logger = mock.Mock(spec=DebugLogger)
@@ -632,12 +557,23 @@ class ExperimentsGlobalCacheTests(unittest.TestCase):
     def setUp(self) -> None:
         super().setUp()
         self.event_logger = mock.Mock(spec=DebugLogger)
-        self._mock_filewatcher = mock.Mock(spec=FileWatcherWithUpdatedFlag)
-        self.mock_experiments_global_cache = ExperimentsGlobalCache(self._mock_filewatcher)
+        self._mock_filewatcher = mock.Mock(spec=FileWatcher)
         self.mock_span = mock.MagicMock(spec=ServerSpan)
+        self.experiments_factory = ExperimentsContextFactory("test", self.event_logger)
+        self.experiments_factory._filewatcher = self._mock_filewatcher
+        self.one_hour_ago = time.time() - datetime.timedelta(hours=1).total_seconds()
+        self.two_hour_ago = time.time() - datetime.timedelta(hours=2).total_seconds()
+
+    def test_config_can_not_load(self):
+        self._mock_filewatcher.get_data_and_mtime.side_effect = TypeError()
+        experiments = self.experiments_factory.make_object_for_context("test", self.mock_span)
+        self.assertEqual(experiments._cfg_data, {})
+
+        exp_res = experiments._get_experiment("test")
+        self.assertIsNone(exp_res)
 
     def test_global_cache_updated(self):
-        self._mock_filewatcher.get_data.return_value = (
+        self._mock_filewatcher.get_data_and_mtime.return_value = (
             {
                 "test": {
                     "id": 1,
@@ -650,22 +586,17 @@ class ExperimentsGlobalCacheTests(unittest.TestCase):
                     "experiment": {"variants": {"active": 10, "control_1": 10, "control_2": 10}},
                 }
             },
-            True,
+            self.one_hour_ago,
         )
-        cfg_data, global_cache = self.mock_experiments_global_cache.get_cfg_and_global_cache()
-        experiments = Experiments(
-            server_span=self.mock_span,
-            context_name="test",
-            cfg_data=cfg_data,
-            global_cache=global_cache,
-            event_logger=self.event_logger,
-        )
+        experiments = self.experiments_factory.make_object_for_context("test", self.mock_span)
+
         exp_res = experiments._get_experiment("test")
-        self.assertTrue("test" in global_cache)
+        self.assertTrue("test" in self.experiments_factory._global_cache)
         self.assertEqual(exp_res.name, "test")
 
     @mock.patch("baseplate.lib.experiments.parse_experiment")
-    def test_experiments_with_same_name_stale_cache(self, m_parse_experiment):
+    def test_experiments_with_same_name_same_cache(self, m_parse_experiment):
+        self.experiments_factory.cfg_mtime = 0.0
         cfg_data = {
             "test": {
                 "id": 1,
@@ -678,37 +609,25 @@ class ExperimentsGlobalCacheTests(unittest.TestCase):
                 "experiment": {"variants": {"active": 10, "control_1": 10, "control_2": 10}},
             }
         }
+        self._mock_filewatcher.get_data_and_mtime.return_value = cfg_data, self.one_hour_ago
 
         # experiment_one add test to global cache
-        self._mock_filewatcher.get_data.return_value = cfg_data, True
-        cfg_data, global_cache = self.mock_experiments_global_cache.get_cfg_and_global_cache()
-        experiment_one = Experiments(
-            server_span=self.mock_span,
-            context_name="test",
-            cfg_data=cfg_data,
-            global_cache=global_cache,
-            event_logger=self.event_logger,
-        )
+        experiment_one = self.experiments_factory.make_object_for_context("test", self.mock_span)
         experiment_one._get_experiment("test")
-        self.assertTrue("test" in global_cache)
+
+        self.assertTrue("test" in self.experiments_factory._global_cache)
         m_parse_experiment.assert_called_once()
 
         # experiment_two just use the cache
-        self._mock_filewatcher.get_data.return_value = cfg_data, False
-        cfg_data, global_cache = self.mock_experiments_global_cache.get_cfg_and_global_cache()
-        experiment_two = Experiments(
-            server_span=self.mock_span,
-            context_name="test",
-            cfg_data=cfg_data,
-            global_cache=global_cache,
-            event_logger=self.event_logger,
-        )
+        experiment_two = self.experiments_factory.make_object_for_context("test", self.mock_span)
         experiment_two._get_experiment("test")
+
         m_parse_experiment.assert_called_once()
-        self.assertTrue("test" in global_cache)
+        self.assertTrue("test" in self.experiments_factory._global_cache)
 
     @mock.patch("baseplate.lib.experiments.parse_experiment")
-    def test_experiments_with_different_name_stale_cache(self, m_parse_experiment):
+    def test_experiments_with_different_name_same_cache(self, m_parse_experiment):
+        self.experiments_factory.cfg_mtime = 0.0
         value1 = {
             "id": 1,
             "name": "test1",
@@ -730,38 +649,26 @@ class ExperimentsGlobalCacheTests(unittest.TestCase):
             "experiment": {"variants": {"active": 10, "control_1": 10, "control_2": 10}},
         }
         cfg_data = {"test1": value1, "test2": value2}
+        self._mock_filewatcher.get_data_and_mtime.return_value = cfg_data, self.one_hour_ago
 
         # experiment_one add test1 to global cache
-        self._mock_filewatcher.get_data.return_value = cfg_data, True
-        cfg_data, global_cache = self.mock_experiments_global_cache.get_cfg_and_global_cache()
-        experiment_one = Experiments(
-            server_span=self.mock_span,
-            context_name="test",
-            cfg_data=cfg_data,
-            global_cache=global_cache,
-            event_logger=self.event_logger,
-        )
+        experiment_one = self.experiments_factory.make_object_for_context("test", self.mock_span)
         experiment_one._get_experiment("test1")
-        self.assertTrue("test1" in global_cache)
-        self.assertFalse("test2" in global_cache)
+
+        self.assertTrue("test1" in self.experiments_factory._global_cache)
+        self.assertFalse("test2" in self.experiments_factory._global_cache)
         m_parse_experiment.assert_called_once_with(value1)
 
         # experiment_two add test2 to global cache
-        self._mock_filewatcher.get_data.return_value = cfg_data, False
-        cfg_data, global_cache = self.mock_experiments_global_cache.get_cfg_and_global_cache()
-        experiment_two = Experiments(
-            server_span=self.mock_span,
-            context_name="test",
-            cfg_data=cfg_data,
-            global_cache=global_cache,
-            event_logger=self.event_logger,
-        )
+        experiment_two = self.experiments_factory.make_object_for_context("test", self.mock_span)
         experiment_two._get_experiment("test2")
+
         m_parse_experiment.assert_called_with(value2)
-        self.assertTrue("test1" in global_cache)
-        self.assertTrue("test2" in global_cache)
+        self.assertTrue("test1" in self.experiments_factory._global_cache)
+        self.assertTrue("test2" in self.experiments_factory._global_cache)
 
     def test_experiments_with_same_name_updated_cache(self):
+        self.experiments_factory.cfg_mtime = 0.0
         owner1 = "test1"
         owner2 = "test2"
         value1 = {
@@ -788,44 +695,32 @@ class ExperimentsGlobalCacheTests(unittest.TestCase):
         cfg_data = {"test": value1}
 
         # experiment_one add value 1 in global cache
-        self._mock_filewatcher.get_data.return_value = cfg_data, True
-        cfg_data, global_cache = self.mock_experiments_global_cache.get_cfg_and_global_cache()
-        experiment_one = Experiments(
-            server_span=self.mock_span,
-            context_name="test",
-            cfg_data=cfg_data,
-            global_cache=global_cache,
-            event_logger=self.event_logger,
-        )
+        self._mock_filewatcher.get_data_and_mtime.return_value = cfg_data, self.two_hour_ago
+        experiment_one = self.experiments_factory.make_object_for_context("test", self.mock_span)
         experiment_one._get_experiment("test")
-        self.assertTrue("test" in global_cache)
-        self.assertEqual(global_cache["test"].owner, owner1)
+
+        self.assertTrue("test" in self.experiments_factory._global_cache)
+        self.assertEqual(experiment_one._global_cache["test"].owner, owner1)
+        self.assertEqual(self.experiments_factory._global_cache["test"].owner, owner1)
 
         # updated test config file to value2
         cfg_data = {"test": value2}
-        self._mock_filewatcher.get_data.return_value = cfg_data, True
-        cfg_data, global_cache = self.mock_experiments_global_cache.get_cfg_and_global_cache()
-        self.assertEqual(global_cache, {})
-        experiment_two = Experiments(
-            server_span=self.mock_span,
-            context_name="test",
-            cfg_data=cfg_data,
-            global_cache=global_cache,
-            event_logger=self.event_logger,
-        )
+        self._mock_filewatcher.get_data_and_mtime.return_value = cfg_data, self.one_hour_ago
+        experiment_two = self.experiments_factory.make_object_for_context("test", self.mock_span)
+        self.assertEqual(self.experiments_factory._global_cache, {})
+
         experiment_two._get_experiment("test")
-        self.assertTrue("test" in global_cache)
-        self.assertEqual(global_cache["test"].owner, owner2)
+        self.assertTrue("test" in self.experiments_factory._global_cache)
+        self.assertEqual(experiment_two._global_cache["test"].owner, owner2)
 
         # experiment_one global cache still use old one
         self.assertEqual(experiment_one._global_cache["test"].owner, owner1)
 
         # global cache was updated by experiment_two
-        self._mock_filewatcher.get_data.return_value = cfg_data, False
-        global_cache = self.mock_experiments_global_cache.get_cfg_and_global_cache()[1]
-        self.assertEqual(global_cache["test"].owner, owner2)
+        self.assertEqual(self.experiments_factory._global_cache["test"].owner, owner2)
 
     def test_experiments_with_different_name_updated_cache(self):
+        self.experiments_factory.cfg_mtime = 0.0
         value1 = {
             "id": 1,
             "name": "test1",
@@ -850,43 +745,29 @@ class ExperimentsGlobalCacheTests(unittest.TestCase):
         cfg_data = {"test1": value1, "test2": value2}
 
         # experiment_one add test1 into global cache
-        self._mock_filewatcher.get_data.return_value = cfg_data, True
-        cfg_data, global_cache = self.mock_experiments_global_cache.get_cfg_and_global_cache()
-        experiment_one = Experiments(
-            server_span=self.mock_span,
-            context_name="test",
-            cfg_data=cfg_data,
-            global_cache=global_cache,
-            event_logger=self.event_logger,
-        )
+        self._mock_filewatcher.get_data_and_mtime.return_value = cfg_data, self.two_hour_ago
+        experiment_one = self.experiments_factory.make_object_for_context("test", self.mock_span)
         experiment_one._get_experiment("test1")
-        self.assertTrue("test1" in global_cache)
-        self.assertFalse("test2" in global_cache)
-        self.assertEqual(global_cache["test1"].owner, "test1")
+
+        self.assertTrue("test1" in self.experiments_factory._global_cache)
+        self.assertFalse("test2" in self.experiments_factory._global_cache)
+        self.assertEqual(self.experiments_factory._global_cache["test1"].owner, "test1")
 
         # updated test config file
         # experiment_two add test2 into global cache
-        self._mock_filewatcher.get_data.return_value = cfg_data, True
-        cfg_data, global_cache = self.mock_experiments_global_cache.get_cfg_and_global_cache()
-        self.assertEqual(global_cache, {})
-        experiment_two = Experiments(
-            server_span=self.mock_span,
-            context_name="test",
-            cfg_data=cfg_data,
-            global_cache=global_cache,
-            event_logger=self.event_logger,
-        )
+        self._mock_filewatcher.get_data_and_mtime.return_value = cfg_data, self.one_hour_ago
+        experiment_two = self.experiments_factory.make_object_for_context("test", self.mock_span)
+        self.assertEqual(self.experiments_factory._global_cache, {})
+
         experiment_two._get_experiment("test2")
-        self.assertTrue("test2" in global_cache)
-        self.assertFalse("test1" in global_cache)
-        self.assertEqual(global_cache["test2"].owner, "test2")
+        self.assertTrue("test2" in experiment_two._global_cache)
+        self.assertFalse("test1" in experiment_two._global_cache)
+        self.assertEqual(experiment_two._global_cache["test2"].owner, "test2")
 
         # experiment_one global cache still use old one
         self.assertEqual(experiment_one._global_cache["test1"].owner, "test1")
 
         # global cache only contains test2 experiment
-        self._mock_filewatcher.get_data.return_value = cfg_data, False
-        global_cache = self.mock_experiments_global_cache.get_cfg_and_global_cache()[1]
-        self.assertTrue("test2" in global_cache)
-        self.assertFalse("test1" in global_cache)
-        self.assertEqual(global_cache["test2"].owner, "test2")
+        self.assertTrue("test2" in self.experiments_factory._global_cache)
+        self.assertFalse("test1" in self.experiments_factory._global_cache)
+        self.assertEqual(self.experiments_factory._global_cache["test2"].owner, "test2")

--- a/tests/unit/lib/experiments/providers/feature_flag_tests.py
+++ b/tests/unit/lib/experiments/providers/feature_flag_tests.py
@@ -9,8 +9,9 @@ from unittest import mock
 from baseplate import ServerSpan
 from baseplate.lib.events import EventQueue
 from baseplate.lib.experiments import Experiments
+from baseplate.lib.experiments import ExperimentsGlobalCache
 from baseplate.lib.experiments.providers import parse_experiment
-from baseplate.lib.file_watcher import FileWatcher
+from baseplate.lib.file_watcher import FileWatcherWithUpdatedFlag
 
 logger = logging.getLogger(__name__)
 
@@ -34,23 +35,30 @@ class TestFeatureFlag(unittest.TestCase):
 
     def test_does_not_log_bucketing_event(self):
         event_queue = mock.Mock(spec=EventQueue)
-        filewatcher = mock.Mock(spec=FileWatcher)
+        filewatcher = mock.Mock(spec=FileWatcherWithUpdatedFlag)
+        experiments_global_cache = ExperimentsGlobalCache(filewatcher)
         span = mock.MagicMock(spec=ServerSpan)
-        filewatcher.get_data.return_value = {
-            "test": {
-                "id": 1,
-                "name": "test",
-                "type": "feature_flag",
-                "version": "1",
-                "start_ts": time.time() - THIRTY_DAYS,
-                "stop_ts": time.time() + THIRTY_DAYS,
-                "experiment": {
-                    "targeting": {"logged_in": [True, False]},
-                    "variants": {"active": 100},
-                },
-            }
-        }
-        experiments = Experiments(config_watcher=filewatcher, server_span=span, context_name="test")
+        filewatcher.get_data.return_value = (
+            {
+                "test": {
+                    "id": 1,
+                    "name": "test",
+                    "type": "feature_flag",
+                    "version": "1",
+                    "start_ts": time.time() - THIRTY_DAYS,
+                    "stop_ts": time.time() + THIRTY_DAYS,
+                    "experiment": {
+                        "targeting": {"logged_in": [True, False]},
+                        "variants": {"active": 100},
+                    },
+                }
+            },
+            True,
+        )
+        cfg_data, global_cache = experiments_global_cache.get_cfg_and_global_cache()
+        experiments = Experiments(
+            server_span=span, context_name="test", cfg_data=cfg_data, global_cache=global_cache
+        )
         self.assertEqual(event_queue.put.call_count, 0)
         variant = experiments.variant("test", user_id=self.user_id, logged_in=True)
         self.assertEqual(variant, "active")

--- a/tests/unit/lib/experiments/providers/r2_tests.py
+++ b/tests/unit/lib/experiments/providers/r2_tests.py
@@ -10,10 +10,9 @@ from unittest import mock
 from baseplate import ServerSpan
 from baseplate.lib.events import EventLogger
 from baseplate.lib.experiments import ExperimentsContextFactory
-from baseplate.lib.experiments import ExperimentsGlobalCache
 from baseplate.lib.experiments.providers import parse_experiment
 from baseplate.lib.experiments.providers.r2 import R2Experiment
-from baseplate.lib.file_watcher import FileWatcherWithUpdatedFlag
+from baseplate.lib.file_watcher import FileWatcher
 
 THIRTY_DAYS = timedelta(days=30).total_seconds()
 
@@ -370,9 +369,10 @@ class TestSimulatedR2Experiments(unittest.TestCase):
     def setUp(self):
         super().setUp()
         self.event_logger = mock.Mock(spec=EventLogger)
-        self.mock_filewatcher = mock.Mock(spec=FileWatcherWithUpdatedFlag)
+        self.mock_filewatcher = mock.Mock(spec=FileWatcher)
         self.factory = ExperimentsContextFactory("path", self.event_logger)
-        self.factory._experiments_global_cache = ExperimentsGlobalCache(self.mock_filewatcher)
+        self.factory._filewatcher = self.mock_filewatcher
+        self.now = time.time()
 
     def get_experiment_client(self, name):
         span = mock.MagicMock(spec=ServerSpan)
@@ -383,7 +383,7 @@ class TestSimulatedR2Experiments(unittest.TestCase):
     def _simulate_experiment(self, config, static_vars, target_var, targets):
         num_experiments = len(targets)
         counter = collections.Counter()
-        self.mock_filewatcher.get_data.return_value = {config["name"]: config}, True
+        self.mock_filewatcher.get_data_and_mtime.return_value = {config["name"]: config}, self.now
         for target in targets:
             experiment_vars = {target_var: target}
             experiment_vars.update(static_vars)
@@ -428,7 +428,7 @@ class TestSimulatedR2Experiments(unittest.TestCase):
 
     def assert_no_user_experiment(self, users, config, content=None):
         content = content or dict(id=None, type=None)
-        self.mock_filewatcher.get_data.return_value = {config["name"]: config}, True
+        self.mock_filewatcher.get_data_and_mtime.return_value = {config["name"]: config}, self.now
         for user in users:
             experiments = self.get_experiment_client("test")
             self.assertIs(
@@ -444,7 +444,7 @@ class TestSimulatedR2Experiments(unittest.TestCase):
             )
 
     def assert_no_page_experiment(self, user, pages, config):
-        self.mock_filewatcher.get_data.return_value = {config["name"]: config}, True
+        self.mock_filewatcher.get_data_and_mtime.return_value = {config["name"]: config}, self.now
         for page in pages:
             experiments = self.get_experiment_client("test")
             self.assertIs(
@@ -460,7 +460,7 @@ class TestSimulatedR2Experiments(unittest.TestCase):
             )
 
     def assert_same_variant(self, users, config, expected, content=None, **kwargs):
-        self.mock_filewatcher.get_data.return_value = {config["name"]: config}, True
+        self.mock_filewatcher.get_data_and_mtime.return_value = {config["name"]: config}, self.now
         content = content or dict(id=None, type=None)
         for user in users:
             experiments = self.get_experiment_client("test")

--- a/tests/unit/lib/experiments/providers/r2_tests.py
+++ b/tests/unit/lib/experiments/providers/r2_tests.py
@@ -10,10 +10,10 @@ from unittest import mock
 from baseplate import ServerSpan
 from baseplate.lib.events import EventLogger
 from baseplate.lib.experiments import ExperimentsContextFactory
+from baseplate.lib.experiments import ExperimentsGlobalCache
 from baseplate.lib.experiments.providers import parse_experiment
 from baseplate.lib.experiments.providers.r2 import R2Experiment
-from baseplate.lib.file_watcher import FileWatcher
-
+from baseplate.lib.file_watcher import FileWatcherWithUpdatedFlag
 
 THIRTY_DAYS = timedelta(days=30).total_seconds()
 
@@ -370,9 +370,9 @@ class TestSimulatedR2Experiments(unittest.TestCase):
     def setUp(self):
         super().setUp()
         self.event_logger = mock.Mock(spec=EventLogger)
-        self.mock_filewatcher = mock.Mock(spec=FileWatcher)
+        self.mock_filewatcher = mock.Mock(spec=FileWatcherWithUpdatedFlag)
         self.factory = ExperimentsContextFactory("path", self.event_logger)
-        self.factory._filewatcher = self.mock_filewatcher
+        self.factory._experiments_global_cache = ExperimentsGlobalCache(self.mock_filewatcher)
 
     def get_experiment_client(self, name):
         span = mock.MagicMock(spec=ServerSpan)
@@ -383,7 +383,7 @@ class TestSimulatedR2Experiments(unittest.TestCase):
     def _simulate_experiment(self, config, static_vars, target_var, targets):
         num_experiments = len(targets)
         counter = collections.Counter()
-        self.mock_filewatcher.get_data.return_value = {config["name"]: config}
+        self.mock_filewatcher.get_data.return_value = {config["name"]: config}, True
         for target in targets:
             experiment_vars = {target_var: target}
             experiment_vars.update(static_vars)
@@ -428,7 +428,7 @@ class TestSimulatedR2Experiments(unittest.TestCase):
 
     def assert_no_user_experiment(self, users, config, content=None):
         content = content or dict(id=None, type=None)
-        self.mock_filewatcher.get_data.return_value = {config["name"]: config}
+        self.mock_filewatcher.get_data.return_value = {config["name"]: config}, True
         for user in users:
             experiments = self.get_experiment_client("test")
             self.assertIs(
@@ -444,7 +444,7 @@ class TestSimulatedR2Experiments(unittest.TestCase):
             )
 
     def assert_no_page_experiment(self, user, pages, config):
-        self.mock_filewatcher.get_data.return_value = {config["name"]: config}
+        self.mock_filewatcher.get_data.return_value = {config["name"]: config}, True
         for page in pages:
             experiments = self.get_experiment_client("test")
             self.assertIs(
@@ -460,7 +460,7 @@ class TestSimulatedR2Experiments(unittest.TestCase):
             )
 
     def assert_same_variant(self, users, config, expected, content=None, **kwargs):
-        self.mock_filewatcher.get_data.return_value = {config["name"]: config}
+        self.mock_filewatcher.get_data.return_value = {config["name"]: config}, True
         content = content or dict(id=None, type=None)
         for user in users:
             experiments = self.get_experiment_client("test")


### PR DESCRIPTION
## Description
This is for adding global cache for experiment. Requests could be given a reference to the current global cache and hold onto that for their whole life. when the global cache is invalidated,  when file been updated,  the global cache would be a new {}. so in-flight requests keep pointing at the old one 
## side effect:
    when initial each experiment it has to read the config file first,  and clear the global cache when filewatcher reads from file. this will cause 

- in same request, the config file data will be the same as when its initialized, won't update when request in flight.
- time latency increased when initialize each experiment object.

## Note:
will update the comments later

@pacejackson @spladug 