### PR TITLE
server/queue_consumer: Handle ServerTimeout to terminate the server

### DIFF
--- a/baseplate/server/queue_consumer.py
+++ b/baseplate/server/queue_consumer.py
@@ -23,6 +23,7 @@ from gevent.server import StreamServer
 import baseplate.lib.config
 
 from baseplate.lib.retry import RetryPolicy
+from baseplate.observers.timeout import ServerTimeout
 
 logger = logging.getLogger(__name__)
 
@@ -207,7 +208,7 @@ class QueueConsumerServer:
             def _run_and_terminate(*a: Any, **kw: Any) -> Any:
                 try:
                     return fn(*a, **kw)
-                except Exception:
+                except (Exception, ServerTimeout):
                     logger.exception("Unhandled error in pump or handler thread, terminating.")
                     self._terminate()
 

--- a/tests/unit/server/queue_consumer_tests.py
+++ b/tests/unit/server/queue_consumer_tests.py
@@ -14,6 +14,7 @@ import webtest
 
 from gevent.server import StreamServer
 
+from baseplate.observers.timeout import ServerTimeout
 from baseplate.server.queue_consumer import HealthcheckApp
 from baseplate.server.queue_consumer import MessageHandler
 from baseplate.server.queue_consumer import PumpWorker
@@ -225,6 +226,13 @@ class TestQueueConsumerServer:
 
     def test_handler_exception_terminates(self, build_server):
         server = build_server(max_concurrency=1, handler_raises=Exception())
+        server._terminate = mock.Mock()
+        server.start()
+        time.sleep(0.5)
+        server._terminate.assert_called_once()
+
+    def test_handler_timeout_terminates(self, build_server):
+        server = build_server(max_concurrency=1, handler_raises=ServerTimeout("", 10, False))
         server._terminate = mock.Mock()
         server.start()
         time.sleep(0.5)


### PR DESCRIPTION
Previously we were only handling `Exception`, but `ServerTimeout` inherits
from `BaseException` so it was not caught. This meant that a server timeout
would crash the pump or handler thread but not terminate the server, so the
crashed thread would never be restarted.

https://github.com/reddit/baseplate.py/issues/485

