### PR TITLE
Add User-Agent to HTTP requests made by sidecars

### DIFF
--- a/baseplate/__init__.py
+++ b/baseplate/__init__.py
@@ -37,7 +37,7 @@ try:
     __version__ = get_distribution(__name__).version
 except DistributionNotFound:
     # package is not installed
-    __version__ = 'unknown'
+    __version__ = "unknown"
 
 
 logger = logging.getLogger(__name__)

--- a/baseplate/__init__.py
+++ b/baseplate/__init__.py
@@ -1,8 +1,6 @@
 import logging
 import random
 
-from pkg_resources import get_distribution, DistributionNotFound
-
 from contextlib import contextmanager
 from types import TracebackType
 from typing import Any
@@ -18,6 +16,9 @@ from typing import Type
 from typing import TYPE_CHECKING
 
 import gevent.monkey
+
+from pkg_resources import DistributionNotFound
+from pkg_resources import get_distribution
 
 from baseplate.lib import config
 from baseplate.lib import get_calling_module_name

--- a/baseplate/__init__.py
+++ b/baseplate/__init__.py
@@ -1,6 +1,8 @@
 import logging
 import random
 
+from pkg_resources import get_distribution, DistributionNotFound
+
 from contextlib import contextmanager
 from types import TracebackType
 from typing import Any
@@ -28,6 +30,13 @@ if TYPE_CHECKING:
     import baseplate.clients
     import baseplate.observers.tracing
     import raven
+
+
+try:
+    __version__ = get_distribution(__name__).version
+except DistributionNotFound:
+    # package is not installed
+    __version__ = 'unknown'
 
 
 logger = logging.getLogger(__name__)

--- a/baseplate/sidecars/event_publisher.py
+++ b/baseplate/sidecars/event_publisher.py
@@ -12,6 +12,7 @@ from typing import Optional
 
 import requests
 
+from baseplate import __version__ as baseplate_version
 from baseplate.lib import config
 from baseplate.lib import metrics
 from baseplate.lib.events import MAX_EVENT_SIZE
@@ -92,6 +93,7 @@ class BatchPublisher:
         self.key_name = cfg.key.name
         self.key_secret = cfg.key.secret
         self.session = requests.Session()
+        self.session.headers.update({"User-Agent": f"baseplate-{self.__class__.__name__}/{baseplate_version}"})
 
     def _sign_payload(self, payload: bytes) -> str:
         digest = hmac.new(self.key_secret, payload, hashlib.sha256).hexdigest()

--- a/baseplate/sidecars/event_publisher.py
+++ b/baseplate/sidecars/event_publisher.py
@@ -93,9 +93,9 @@ class BatchPublisher:
         self.key_name = cfg.key.name
         self.key_secret = cfg.key.secret
         self.session = requests.Session()
-        self.session.headers.update(
-            {"User-Agent": f"baseplate-{self.__class__.__name__}/{baseplate_version}"}
-        )
+        self.session.headers[
+            "User-Agent"
+        ] = f"baseplate.py-{self.__class__.__name__}/{baseplate_version}"
 
     def _sign_payload(self, payload: bytes) -> str:
         digest = hmac.new(self.key_secret, payload, hashlib.sha256).hexdigest()

--- a/baseplate/sidecars/event_publisher.py
+++ b/baseplate/sidecars/event_publisher.py
@@ -93,7 +93,9 @@ class BatchPublisher:
         self.key_name = cfg.key.name
         self.key_secret = cfg.key.secret
         self.session = requests.Session()
-        self.session.headers.update({"User-Agent": f"baseplate-{self.__class__.__name__}/{baseplate_version}"})
+        self.session.headers.update(
+            {"User-Agent": f"baseplate-{self.__class__.__name__}/{baseplate_version}"}
+        )
 
     def _sign_payload(self, payload: bytes) -> str:
         digest = hmac.new(self.key_secret, payload, hashlib.sha256).hexdigest()

--- a/baseplate/sidecars/secrets_fetcher.py
+++ b/baseplate/sidecars/secrets_fetcher.py
@@ -154,7 +154,9 @@ class VaultClientFactory:
         self.auth_type = auth_type
         self.mount_point = mount_point
         self.session = requests.Session()
-        self.session.headers.update({"User-Agent": f"baseplate-{self.__class__.__name__}/{baseplate_version}"})
+        self.session.headers.update(
+            {"User-Agent": f"baseplate-{self.__class__.__name__}/{baseplate_version}"}
+        )
         self.client: Optional["VaultClient"] = None
 
     def _make_client(self) -> "VaultClient":

--- a/baseplate/sidecars/secrets_fetcher.py
+++ b/baseplate/sidecars/secrets_fetcher.py
@@ -80,6 +80,7 @@ from typing import Tuple
 
 import requests
 
+from baseplate import __version__ as baseplate_version
 from baseplate.lib import config
 
 
@@ -153,6 +154,7 @@ class VaultClientFactory:
         self.auth_type = auth_type
         self.mount_point = mount_point
         self.session = requests.Session()
+        self.session.headers.update({"User-Agent": f"baseplate-{self.__class__.__name__}/{baseplate_version}"})
         self.client: Optional["VaultClient"] = None
 
     def _make_client(self) -> "VaultClient":

--- a/baseplate/sidecars/secrets_fetcher.py
+++ b/baseplate/sidecars/secrets_fetcher.py
@@ -154,9 +154,9 @@ class VaultClientFactory:
         self.auth_type = auth_type
         self.mount_point = mount_point
         self.session = requests.Session()
-        self.session.headers.update(
-            {"User-Agent": f"baseplate-{self.__class__.__name__}/{baseplate_version}"}
-        )
+        self.session.headers[
+            "User-Agent"
+        ] = f"baseplate.py-{self.__class__.__name__}/{baseplate_version}"
         self.client: Optional["VaultClient"] = None
 
     def _make_client(self) -> "VaultClient":

--- a/baseplate/sidecars/trace_publisher.py
+++ b/baseplate/sidecars/trace_publisher.py
@@ -7,6 +7,7 @@ from typing import Optional
 
 import requests
 
+from baseplate import __version__ as baseplate_version
 from baseplate.lib import config
 from baseplate.lib import metrics
 from baseplate.lib.message_queue import MessageQueue
@@ -60,6 +61,7 @@ class ZipkinPublisher:
         adapter = requests.adapters.HTTPAdapter(pool_connections=num_conns, pool_maxsize=num_conns)
         parsed_url = urllib.parse.urlparse(zipkin_api_url)
         self.session = requests.Session()
+        self.session.headers.update({"User-Agent": f"baseplate-{self.__class__.__name__}/{baseplate_version}"})
         self.session.mount(f"{parsed_url.scheme}://", adapter)
         self.endpoint = f"{zipkin_api_url}/spans"
         self.metrics = metrics_client

--- a/baseplate/sidecars/trace_publisher.py
+++ b/baseplate/sidecars/trace_publisher.py
@@ -61,7 +61,9 @@ class ZipkinPublisher:
         adapter = requests.adapters.HTTPAdapter(pool_connections=num_conns, pool_maxsize=num_conns)
         parsed_url = urllib.parse.urlparse(zipkin_api_url)
         self.session = requests.Session()
-        self.session.headers.update({"User-Agent": f"baseplate-{self.__class__.__name__}/{baseplate_version}"})
+        self.session.headers.update(
+            {"User-Agent": f"baseplate-{self.__class__.__name__}/{baseplate_version}"}
+        )
         self.session.mount(f"{parsed_url.scheme}://", adapter)
         self.endpoint = f"{zipkin_api_url}/spans"
         self.metrics = metrics_client

--- a/baseplate/sidecars/trace_publisher.py
+++ b/baseplate/sidecars/trace_publisher.py
@@ -61,9 +61,9 @@ class ZipkinPublisher:
         adapter = requests.adapters.HTTPAdapter(pool_connections=num_conns, pool_maxsize=num_conns)
         parsed_url = urllib.parse.urlparse(zipkin_api_url)
         self.session = requests.Session()
-        self.session.headers.update(
-            {"User-Agent": f"baseplate-{self.__class__.__name__}/{baseplate_version}"}
-        )
+        self.session.headers[
+            "User-Agent"
+        ] = f"baseplate.py-{self.__class__.__name__}/{baseplate_version}"
         self.session.mount(f"{parsed_url.scheme}://", adapter)
         self.endpoint = f"{zipkin_api_url}/spans"
         self.metrics = metrics_client

--- a/tests/unit/lib/events/publisher_tests.py
+++ b/tests/unit/lib/events/publisher_tests.py
@@ -68,6 +68,7 @@ class PublisherTests(unittest.TestCase):
         self.config.key.secret = b"hunter2"
 
         self.session = Session.return_value
+        self.session.headers = {}
 
         self.metrics_client = mock.MagicMock(autospec=metrics.Client)
 

--- a/tests/unit/observers/tracing/publisher_tests.py
+++ b/tests/unit/observers/tracing/publisher_tests.py
@@ -13,6 +13,7 @@ class ZipkinPublisherTest(unittest.TestCase):
     @mock.patch("requests.Session", autospec=True)
     def setUp(self, mock_Session):
         self.session = mock_Session.return_value
+        self.session.headers = {}
         self.metrics_client = mock.MagicMock(autospec=metrics.Client)
         self.zipkin_api_url = "http://test.local/api/v2"
         self.publisher = trace_publisher.ZipkinPublisher(self.zipkin_api_url, self.metrics_client)


### PR DESCRIPTION
This adds a `User-Agent` HTTP header to outbound requests made by the sidecars. An example looks like looks like `baseplate.py-ZipkinPublisher/1.4.1.dev22+gea38896.d20201112`. 

Addresses #396 (Add user-agent headers to requests from sidecars)

👓 @spladug 