### PR TITLE
Add list of exceptions for raven to always filter out

### DIFF
--- a/baseplate/observers/sentry.py
+++ b/baseplate/observers/sentry.py
@@ -10,11 +10,6 @@ from typing import TYPE_CHECKING
 
 import raven
 
-from pymemcache.exceptions import MemcacheError
-from requests import HTTPError
-from requests import Timeout
-from thrift.Thrift import TException
-
 from baseplate import _ExcInfo
 from baseplate import BaseplateObserver
 from baseplate import RequestContext
@@ -28,18 +23,21 @@ if TYPE_CHECKING:
 
 
 ALWAYS_IGNORE_EXCEPTIONS = (
-    ConnectionError,
-    HTTPError,
-    Timeout,
-    TException,
-    MemcacheError,
+    "ConnectionError",
+    "ConnectionRefusedError",
+    "ConnectionResetError",
+    "HTTPError",
+    "TApplicationException",
+    "TProtocolException",
+    "TTransportException",
+    "MemcacheServerError",
 )
 
 
 def error_reporter_from_config(raw_config: config.RawConfig, module_name: str) -> raven.Client:
     """Configure and return a error reporter.
 
-    This expects one configuration option and can take many optional ones:
+    This expects one uration option and can take many optional ones:
 
     ``sentry.dsn``
         The DSN provided by Sentry. If blank, the reporter will discard events.

--- a/baseplate/observers/sentry.py
+++ b/baseplate/observers/sentry.py
@@ -112,7 +112,7 @@ def error_reporter_from_config(raw_config: config.RawConfig, module_name: str) -
     if cfg_ignore_exceptions:
         warn_deprecated(
             "'ignore_exceptions' configuration varible is depricated."
-            + "Please use 'additional_ignore_exceptions' instead.",
+            "Please use 'sentry.additional_ignore_exceptions' instead.",
         )
 
     if cfg_additional_ignore_exceptions and cfg_ignore_exceptions:

--- a/baseplate/observers/sentry.py
+++ b/baseplate/observers/sentry.py
@@ -111,7 +111,7 @@ def error_reporter_from_config(raw_config: config.RawConfig, module_name: str) -
 
     if cfg_ignore_exceptions:
         warn_deprecated(
-            "'ignore_exceptions' configuration varible is depricated."
+            "'sentry.ignore_exceptions' is deprecated. "
             "Please use 'sentry.additional_ignore_exceptions' instead.",
         )
 

--- a/baseplate/observers/sentry.py
+++ b/baseplate/observers/sentry.py
@@ -16,6 +16,7 @@ from baseplate import RequestContext
 from baseplate import ServerSpanObserver
 from baseplate import Span
 from baseplate.lib import config
+from baseplate.lib import warn_deprecated
 from baseplate.observers.timeout import ServerTimeout
 
 if TYPE_CHECKING:
@@ -80,7 +81,7 @@ def error_reporter_from_config(raw_config: config.RawConfig, module_name: str) -
                 "exclude_paths": config.Optional(config.String, default=None),
                 "ignore_exceptions": config.Optional(
                     config.TupleOf(config.String), default=[]
-                ),  # Depricated in favor of `additional_ignore_exception
+                ),  # Deprecated in favor of `additional_ignore_exception
                 "additional_ignore_exceptions": config.Optional(
                     config.TupleOf(config.String), default=[]
                 ),
@@ -107,6 +108,12 @@ def error_reporter_from_config(raw_config: config.RawConfig, module_name: str) -
 
     cfg_ignore_exceptions = cfg.sentry.ignore_exceptions
     cfg_additional_ignore_exceptions = cfg.sentry.additional_ignore_exceptions
+
+    if cfg_ignore_exceptions != None:
+        warn_deprecated(
+            "'ignore_exceptions' configuration varible is depricated."
+            + "Please use 'additional_ignore_exceptions' instead.",
+        )
 
     if cfg_additional_ignore_exceptions and cfg_ignore_exceptions:
         raise config.ConfigurationError(

--- a/baseplate/observers/sentry.py
+++ b/baseplate/observers/sentry.py
@@ -38,7 +38,7 @@ ALWAYS_IGNORE_EXCEPTIONS = (
 def error_reporter_from_config(raw_config: config.RawConfig, module_name: str) -> raven.Client:
     """Configure and return a error reporter.
 
-    This expects one uration option and can take many optional ones:
+    This expects one configuration option and can take many optional ones:
 
     ``sentry.dsn``
         The DSN provided by Sentry. If blank, the reporter will discard events.

--- a/baseplate/observers/sentry.py
+++ b/baseplate/observers/sentry.py
@@ -109,7 +109,7 @@ def error_reporter_from_config(raw_config: config.RawConfig, module_name: str) -
     cfg_ignore_exceptions = cfg.sentry.ignore_exceptions
     cfg_additional_ignore_exceptions = cfg.sentry.additional_ignore_exceptions
 
-    if cfg_ignore_exceptions != None:
+    if cfg_ignore_exceptions:
         warn_deprecated(
             "'ignore_exceptions' configuration varible is depricated."
             + "Please use 'additional_ignore_exceptions' instead.",

--- a/baseplate/sidecars/live_data_watcher.py
+++ b/baseplate/sidecars/live_data_watcher.py
@@ -9,12 +9,11 @@ import time
 from typing import Any
 from typing import NoReturn
 
-from kazoo.client import KazooClient
-from kazoo.protocol.states import ZnodeStat
-
 from baseplate.lib import config
 from baseplate.lib.live_data.zookeeper import zookeeper_client_from_config
 from baseplate.lib.secrets import secrets_store_from_config
+from kazoo.client import KazooClient
+from kazoo.protocol.states import ZnodeStat
 
 
 logger = logging.getLogger(__name__)

--- a/baseplate/sidecars/live_data_watcher.py
+++ b/baseplate/sidecars/live_data_watcher.py
@@ -9,11 +9,12 @@ import time
 from typing import Any
 from typing import NoReturn
 
+from kazoo.client import KazooClient
+from kazoo.protocol.states import ZnodeStat
+
 from baseplate.lib import config
 from baseplate.lib.live_data.zookeeper import zookeeper_client_from_config
 from baseplate.lib.secrets import secrets_store_from_config
-from kazoo.client import KazooClient
-from kazoo.protocol.states import ZnodeStat
 
 
 logger = logging.getLogger(__name__)

--- a/tests/unit/observers/sentry_tests.py
+++ b/tests/unit/observers/sentry_tests.py
@@ -6,9 +6,9 @@ import raven
 
 from pymemcache.exceptions import MemcacheServerError
 from requests.exceptions import HTTPError
+from thrift.protocol.TProtocol import TProtocolException
 from thrift.Thrift import TApplicationException
 from thrift.transport.TTransport import TTransportException
-from thrift.protocol.TProtocol import TProtocolException
 
 from baseplate import config
 from baseplate.observers import sentry

--- a/tests/unit/observers/sentry_tests.py
+++ b/tests/unit/observers/sentry_tests.py
@@ -1,0 +1,83 @@
+import unittest
+
+from unittest import mock
+
+import raven
+
+from baseplate import config
+from baseplate.observers import sentry
+
+
+class StubRavenClient(raven.Client):
+    def __init__(self, **kwargs):
+        self.stub_events_sent = 0
+        return super().__init__(**kwargs)
+
+    def send(self, **kwargs):
+        self.stub_events_sent += 1
+        return None
+
+    def is_enabled(self):
+        return True
+
+
+class TestException(Exception):
+    pass
+
+
+@mock.patch("raven.Client", new=StubRavenClient)
+class SentryIgnoreExceptionsTest(unittest.TestCase):
+    def observe_and_raise(self, cli, exc):
+        @cli.capture_exceptions
+        def _raise_exception():
+            raise exc
+
+        return _raise_exception
+
+    def observe_all(self, cli, excs):
+        for exc in excs:
+            fn = self.observe_and_raise(cli, exc)
+            try:
+                fn()
+            except exc:
+                exc
+
+    def test_default_ignore_exceptions(self):
+        cli = sentry.error_reporter_from_config(dict(), __name__)
+        self.observe_all(cli, sentry.ALWAYS_IGNORE_EXCEPTIONS)
+        self.assertEqual(cli.stub_events_sent, 0)
+
+    def test_report_exception(self):
+        cli = sentry.error_reporter_from_config(dict(), __name__)
+        self.assertRaises(TestException, self.observe_and_raise(cli, TestException))
+        self.assertEqual(cli.stub_events_sent, 1)
+
+    def test_ignere_exception(self):
+        cli = sentry.error_reporter_from_config(
+            {"sentry.ignore_exceptions": TestException.__name__}, __name__,
+        )
+        self.assertRaises(TestException, self.observe_and_raise(cli, TestException))
+        self.assertEqual(cli.stub_events_sent, 0)
+
+        # If 'ignore_exceptions' is defined default filters aren't included.
+        self.observe_all(cli, sentry.ALWAYS_IGNORE_EXCEPTIONS)
+        self.assertEqual(cli.stub_events_sent, len(sentry.ALWAYS_IGNORE_EXCEPTIONS))
+
+    def test_additional_ignored_exceptions(self):
+        cli = sentry.error_reporter_from_config(
+            {"sentry.additional_ignore_exceptions": TestException.__name__}, __name__,
+        )
+        self.assertRaises(TestException, self.observe_and_raise(cli, TestException))
+        self.assertEqual(cli.stub_events_sent, 0)
+
+        self.observe_all(cli, sentry.ALWAYS_IGNORE_EXCEPTIONS)
+        self.assertEqual(cli.stub_events_sent, 0)
+
+    def test_both_ignored_exceptions(self):
+        conf = {
+            "sentry.ignore_exceptions": TestException.__name__,
+            "sentry.additional_ignore_exceptions": TestException.__name__,
+        }
+        self.assertRaises(
+            config.ConfigurationError, sentry.error_reporter_from_config, conf, __name__
+        )


### PR DESCRIPTION
Add a default list of exceptions to Baseplate Sentry error observer. This is outlined in [this design document](https://docs.google.com/document/d/1n9VCZZz0XhWXvZM2wWvsiR8oi1LNk7-AsShsrbt4B6Y/edit?usp=sharing). [This](https://github.snooguts.net/reddit/design-docs/pull/994#issuecomment-235670) outlines the list of errors that should be filtered out.

## ConnectionError / ConnectionRefusedError / ConnectionResetError
These errors I addressed by filtering out the generic `ConnectionError`

## HTTPError / HTTPRequestTimeout / HTTPServiceUnavailable
I set Sentry to filter out `requests.HTTPError`. These were the flavor of `HTTPError` which I could find in Sentry. Both `HTTPRequestTimeout` and 'HTTPServiceUnavailable` seem to be errors with stem from GraphQLs codebase. These are probably not ones we want to filter out.

## OperationalError
I couldn't find this error in Sentry to figure out where it comes from.

## TTransportException / TApplicationException / TProtocolException
I decided to filter out `TException` which includes all Thrift errors.

## MemcachedServerError
Same as above, I chose to filter out `MemcachedError`.

## RedisClusterException
This error seems to come from some the `reddit-py-cluster` library. Modern baseplate doesn't depend on this anymore.

