### PR TITLE
Configure metrics endpoint and namespace through env

### DIFF
--- a/baseplate/lib/config.py
+++ b/baseplate/lib/config.py
@@ -390,7 +390,28 @@ def TupleOf(item_parser: Callable[[str], T]) -> Callable[[str], Sequence[T]]:  #
 
 
 def DefaultFromEnv(
-    item_parser: Callable[[str], T], default_src: str, fallback: OptionalType[T] = None
+    item_parser: Callable[[str], T], default_src: str, fallback: OptionalType[T] = None,
+) -> Callable[[str], OptionalType[T]]:  # noqa: D401
+    """An option of type T or a default.
+
+    The default is sourced from an environment variable with the name specified in ``default_src``.
+    If the environment variable is not set, then the fallback will be used.
+    One of the following values must be provided: fallback, default_src, or the provided configuration
+    """
+    parser = OptionalDefaultFromEnv(item_parser, default_src, fallback)
+
+    def default_from_env(text: str) -> OptionalType[T]:
+        val = parser(text)
+        if val:
+            return val
+
+        raise ValueError("Value is required.")
+
+    return default_from_env
+
+
+def OptionalDefaultFromEnv(
+    item_parser: Callable[[str], T], default_src: str, fallback: OptionalType[T] = None,
 ) -> Callable[[str], OptionalType[T]]:  # noqa: D401
     """An option of type T or a default.
 
@@ -402,11 +423,7 @@ def DefaultFromEnv(
     default = Optional(item_parser, fallback)(env)
 
     def default_from_env(text: str) -> OptionalType[T]:
-        val = Optional(item_parser, default)(text)
-        if val:
-            return val
-
-        raise ValueError("no value provided")
+        return Optional(item_parser, default)(text)
 
     return default_from_env
 

--- a/baseplate/lib/config.py
+++ b/baseplate/lib/config.py
@@ -405,7 +405,7 @@ def DefaultFromEnv(
         if val:
             return val
 
-        raise ValueError("Value is required.")
+        raise ValueError("no value provided")
 
     return default_from_env
 

--- a/baseplate/lib/metrics.py
+++ b/baseplate/lib/metrics.py
@@ -563,7 +563,7 @@ def metrics_client_from_config(raw_config: config.RawConfig) -> Client:
         raw_config,
         {
             "metrics": {
-                "namespace": (config.Optional(config.String, default""),
+                "namespace": config.Optional(config.String, default=""),
                 "endpoint": config.OptionalDefaultFromEnv(
                     config.Endpoint, "BASEPLATE_METRICS_ENDPOINT",
                 ),

--- a/baseplate/lib/metrics.py
+++ b/baseplate/lib/metrics.py
@@ -563,9 +563,7 @@ def metrics_client_from_config(raw_config: config.RawConfig) -> Client:
         raw_config,
         {
             "metrics": {
-                "namespace": config.OptionalDefaultFromEnv(
-                    config.String, "BASEPLATE_METRICS_NAMESPACE",
-                ),
+                "namespace(config.Optional(config.String, default""),
                 "endpoint": config.OptionalDefaultFromEnv(
                     config.Endpoint, "BASEPLATE_METRICS_ENDPOINT",
                 ),

--- a/baseplate/lib/metrics.py
+++ b/baseplate/lib/metrics.py
@@ -563,7 +563,7 @@ def metrics_client_from_config(raw_config: config.RawConfig) -> Client:
         raw_config,
         {
             "metrics": {
-                "namespace(config.Optional(config.String, default""),
+                "namespace": (config.Optional(config.String, default""),
                 "endpoint": config.OptionalDefaultFromEnv(
                     config.Endpoint, "BASEPLATE_METRICS_ENDPOINT",
                 ),

--- a/baseplate/lib/metrics.py
+++ b/baseplate/lib/metrics.py
@@ -563,8 +563,12 @@ def metrics_client_from_config(raw_config: config.RawConfig) -> Client:
         raw_config,
         {
             "metrics": {
-                "namespace": config.Optional(config.String, default=""),
-                "endpoint": config.Optional(config.Endpoint),
+                "namespace": config.OptionalDefaultFromEnv(
+                    config.String, "BASEPLATE_METRICS_NAMESPACE",
+                ),
+                "endpoint": config.OptionalDefaultFromEnv(
+                    config.Endpoint, "BASEPLATE_METRICS_ENDPOINT",
+                ),
                 "log_if_unconfigured": config.Optional(config.Boolean, default=False),
             }
         },

--- a/tests/unit/lib/config_tests.py
+++ b/tests/unit/lib/config_tests.py
@@ -276,7 +276,7 @@ class OptionalDefaultFromEnvTests(unittest.TestCase):
         self.assertEqual(parser("foo"), "foo")
 
     def test_use_provided(self):
-        parser = config.DefaultFromEnv(config.String, "BASEPALTE_DEFAULT_VALUE")
+        parser = config.DefaultFromEnv(config.String, "BASEPLATE_DEFAULT_VALUE")
         self.assertEqual(parser("foo"), "foo")
 
     def test_fallback(self):

--- a/tests/unit/lib/config_tests.py
+++ b/tests/unit/lib/config_tests.py
@@ -265,6 +265,26 @@ class DefaultFromEnvTests(unittest.TestCase):
         self.assertEqual(parser(""), fallback_value)
 
 
+@patch.dict("os.environ", {"BASEPLATE_DEFAULT_VALUE": "default", "NOT_PROVIDED": ""})
+class OptionalDefaultFromEnvTests(unittest.TestCase):
+    def test_use_optional_default_from_env(self):
+        parser = config.OptionalDefaultFromEnv(config.String, "BASEPLATE_DEFAULT_VALUE")
+        self.assertEqual(parser(""), "default")
+
+    def test_empty_default(self):
+        parser = config.DefaultFromEnv(config.String, "NOT_PROVIDED")
+        self.assertEqual(parser("foo"), "foo")
+
+    def test_use_provided(self):
+        parser = config.DefaultFromEnv(config.String, "BASEPALTE_DEFAULT_VALUE")
+        self.assertEqual(parser("foo"), "foo")
+
+    def test_fallback(self):
+        fallback_value = 5
+        parser = config.DefaultFromEnv(config.Integer, "NOT_PROVIDED", fallback_value)
+        self.assertEqual(parser(""), fallback_value)
+
+
 class OptionalTests(unittest.TestCase):
     def test_optional_exists(self):
         parser = config.Optional(config.Integer)


### PR DESCRIPTION
This facilitates being able to configure the trace publisher through the environment. The metrics collector configuration is used by the trace publisher.