### PR TITLE
requests: pass through verify in send() kwargs

### DIFF
--- a/baseplate/clients/requests.py
+++ b/baseplate/clients/requests.py
@@ -190,6 +190,7 @@ class BaseplateSession:
         send_kwargs = {
             "timeout": kwargs.pop("timeout", None),
             "allow_redirects": kwargs.pop("allow_redirects", None),
+            "verify": kwargs.pop("verify", True),
         }
         request = Request(method=method.upper(), url=url, **kwargs)
         prepared = self.prepare_request(request)


### PR DESCRIPTION
This allows development clients to make local certs work. Right now it looks like many services have verify turned off, in addition to using their own implementation a requests client. but this will at least let them turn it on when they migrate to the built in client.

Would it be ok to also just do the following?

```python
verify = os.environ.get('REQUESTS_CA_BUNDLE', True)
...
"verify": kwargs.pop("verify", verify),
```