### PR TITLE
Add pool_size and max_overflow to SQLAlchemy config parser

### DIFF
--- a/baseplate/clients/sqlalchemy.py
+++ b/baseplate/clients/sqlalchemy.py
@@ -55,6 +55,8 @@ def engine_from_config(
         checkout. When used, this obviates most of the reasons you might use
         pool_recycle, and as such they shouldn't normally be used
         simultaneously.  Requires SQLAlchemy 1.3.
+    * ``pool_size`` (optional) : The number of connections that can be saved in the pool.
+    * ``max_overflow`` (optional) : Max connections that can be opened beyond the pool size.
 
     """
     assert prefix.endswith(".")
@@ -64,6 +66,8 @@ def engine_from_config(
             "credentials_secret": config.Optional(config.String),
             "pool_recycle": config.Optional(config.Integer),
             "pool_pre_ping": config.Optional(config.Boolean),
+            "pool_size": config.Optional(config.Integer),
+            "max_overflow": config.Optional(config.Integer),
         }
     )
     options = parser.parse(prefix[:-1], app_config)
@@ -74,6 +78,12 @@ def engine_from_config(
 
     if options.pool_pre_ping is not None:
         kwargs.setdefault("pool_pre_ping", options.pool_pre_ping)
+
+    if options.pool_size is not None:
+        kwargs.setdefault("pool_size", options.pool_size)
+
+    if options.max_overflow is not None:
+        kwargs.setdefault("max_overflow", options.max_overflow)
 
     if options.credentials_secret:
         if not secrets:

--- a/tests/unit/clients/sqlalchemy_tests.py
+++ b/tests/unit/clients/sqlalchemy_tests.py
@@ -37,6 +37,8 @@ class EngineFromConfigTests(unittest.TestCase):
                 "database.url": "postgresql://fizz:buzz@localhost:9000/db",
                 "database.credentials_secret": "secret/sql/account",
                 "database.pool_recycle": "60",
+                "database.pool_size": "10",
+                "database.max_overflow": "5",
             },
             self.secrets,
         )
@@ -50,6 +52,8 @@ class EngineFromConfigTests(unittest.TestCase):
                 database="db",
             ),
             pool_recycle=60,
+            pool_size=10,
+            max_overflow=5,
         )
 
     @mock.patch("baseplate.clients.sqlalchemy.create_engine")


### PR DESCRIPTION
For context: in post service after adding graphs for the pool usage metrics we saw that we were hitting our max overflow often so we started increasing pool size.

I've seen usage of these in in other services too.