### PR TITLE
Make UnixUser/UnixGroup fall back to IDs if name isn't found

### DIFF
--- a/baseplate/lib/config.py
+++ b/baseplate/lib/config.py
@@ -316,7 +316,7 @@ def Percent(text: str) -> float:  # noqa: D401
 
 
 def UnixUser(text: str) -> int:  # noqa: D401
-    """A Unix user name.
+    """A Unix user name or decimal ID.
 
     The parsed value will be the integer user ID.
 
@@ -324,11 +324,14 @@ def UnixUser(text: str) -> int:  # noqa: D401
     try:
         return pwd.getpwnam(text).pw_uid
     except KeyError as exc:
-        raise ValueError(exc)
+        try:
+            return int(text)
+        except ValueError:
+            raise ValueError(exc) from None
 
 
 def UnixGroup(text: str) -> int:  # noqa: D401
-    """A Unix group name.
+    """A Unix group name or decimal ID.
 
     The parsed value will be the integer group ID.
 
@@ -336,7 +339,10 @@ def UnixGroup(text: str) -> int:  # noqa: D401
     try:
         return grp.getgrnam(text).gr_gid
     except KeyError as exc:
-        raise ValueError(exc)
+        try:
+            return int(text)
+        except ValueError:
+            raise ValueError(exc) from None
 
 
 T = TypeVar("T")

--- a/tests/unit/lib/config_tests.py
+++ b/tests/unit/lib/config_tests.py
@@ -199,6 +199,10 @@ class UnixUserTests(unittest.TestCase):
         with self.assertRaises(ValueError):
             config.UnixUser("fhqwhgads")
 
+    def test_uid_fallback(self):
+        result = config.UnixUser("1000")
+        self.assertEqual(result, 1000)
+
 
 class UnixGroupTests(unittest.TestCase):
     def test_valid_group(self):
@@ -208,6 +212,10 @@ class UnixGroupTests(unittest.TestCase):
     def test_invalid_group(self):
         with self.assertRaises(ValueError):
             config.UnixGroup("fhqwhgads")
+
+    def test_gid_fallback(self):
+        result = config.UnixGroup("1000")
+        self.assertEqual(result, 1000)
 
 
 class OneOfTests(unittest.TestCase):


### PR DESCRIPTION
This allows us to use numeric IDs in contexts that don't have proper /etc/passwd or /etc/group configuration, like docker containers. We look up by name first, and fall back to decimal UID/GID.