### PR TITLE
Remove deprecated observer configuration functions

### DIFF
--- a/docs/api/baseplate/index.rst
+++ b/docs/api/baseplate/index.rst
@@ -127,12 +127,3 @@ StatsD :py:meth:`~!baseplate.SpanObserver.on_finish`.
 
 .. autoclass:: SpanObserver
    :members:
-
-Legacy Methods
---------------
-
-.. automethod:: Baseplate.configure_logging
-.. automethod:: Baseplate.configure_metrics
-.. automethod:: Baseplate.configure_tracing
-.. automethod:: Baseplate.configure_error_reporting
-

--- a/docs/cli/serve.rst
+++ b/docs/cli/serve.rst
@@ -148,7 +148,7 @@ Process-level metrics
 ---------------------
 
 If your application has registered a metrics client with
-:py:meth:`~baseplate.Baseplate.configure_metrics`, ``baseplate-serve``
+:py:meth:`~baseplate.Baseplate.configure_observers`, ``baseplate-serve``
 will automatically send process-level metrics every 10 seconds. Which metrics
 are sent depends on your server configuration, for example::
 

--- a/tests/integration/tracing_tests.py
+++ b/tests/integration/tracing_tests.py
@@ -108,12 +108,3 @@ class TracingTests(unittest.TestCase):
             self.assertEqual(span["name"], "local-req")
             self.assertEqual(len(span["annotations"]), 0)
             self.assertEqual(span["parentId"], self.local_span_ids[-2])
-
-    def test_configure_tracing_with_defaults_new_style(self):
-        baseplate = Baseplate()
-        self.assertEqual(0, len(baseplate.observers))
-        client = make_client("test")
-        baseplate.configure_tracing(client)
-        self.assertEqual(1, len(baseplate.observers))
-        tracing_observer = baseplate.observers[0]
-        self.assertEqual("test", tracing_observer.service_name)


### PR DESCRIPTION
configure_observers() is the one-stop-shop now! Since some observers like the server timeout mechanism only come through this method, it's best to force people to move away from the older methods when upgrading.