### PR TITLE
do not disable existing loggers when reading log config with fileConfig

### DIFF
--- a/baseplate/server/__init__.py
+++ b/baseplate/server/__init__.py
@@ -134,7 +134,7 @@ def configure_logging(config: Configuration, debug: bool) -> None:
     sentry_logger.setLevel(logging.WARNING)
 
     if config.has_logging_options:
-        logging.config.fileConfig(config.filename)
+        logging.config.fileConfig(config.filename, disable_existing_loggers=False)
 
 
 def make_listener(endpoint: EndpointConfiguration) -> socket.socket:


### PR DESCRIPTION
When logging options are read from configuration using `logging.config.fileConfig`, we should pass the `disable_existing_loggers=False` option to prevent it from interfering with loggers created by users.