### PR TITLE
Switch from raven to sentry-sdk

### DIFF
--- a/baseplate/observers/sentry.py
+++ b/baseplate/observers/sentry.py
@@ -1,14 +1,16 @@
+from __future__ import annotations
+
 import logging
-import os
-import sys
 
 from types import TracebackType
 from typing import Any
+from typing import List
 from typing import Optional
 from typing import Type
 from typing import TYPE_CHECKING
+from typing import Union
 
-import raven
+import sentry_sdk
 
 from baseplate import _ExcInfo
 from baseplate import BaseplateObserver
@@ -19,54 +21,46 @@ from baseplate.lib import config
 from baseplate.observers.timeout import ServerTimeout
 
 if TYPE_CHECKING:
-    from gevent.hub import Hub
+    from gevent.hub import Hub as GeventHub
 
 
-ALWAYS_IGNORE_EXCEPTIONS = (
+ALWAYS_IGNORE_ERRORS = (
+    "baseplate.observers.timeout.ServerTimeout",
     "ConnectionError",
     "ConnectionRefusedError",
     "ConnectionResetError",
-    "HTTPError",
-    "TApplicationException",
-    "TProtocolException",
-    "TTransportException",
-    "MemcacheServerError",
+    "pymemcache.exceptions.MemcacheServerError",
+    "requests.exceptions.HTTPError",
+    "thrift.Thrift.TApplicationException",
+    "thrift.Thrift.TProtocolException",
+    "thrift.Thrift.TTransportException",
 )
 
 
-def error_reporter_from_config(raw_config: config.RawConfig, module_name: str) -> raven.Client:
-    """Configure and return a error reporter.
+def init_sentry_client_from_config(raw_config: config.RawConfig, **kwargs: Any) -> None:
+    """Configure the Sentry client.
 
     This expects one configuration option and can take many optional ones:
 
     ``sentry.dsn``
         The DSN provided by Sentry. If blank, the reporter will discard events.
-    ``sentry.site`` (optional)
-        An arbitrary string to identify this client installation.
     ``sentry.environment`` (optional)
         The environment your application is running in.
-    ``sentry.exclude_paths`` (optional)
-        Comma-delimited list of module prefixes to ignore when discovering
-        where an error came from.
-    ``sentry.include_paths`` (optional)
-        Comma-delimited list of paths to include for consideration when
-        drilling down to an exception.
-    ``sentry.ignore_exceptions`` (optional)
-        Comma-delimited list of fully qualified names of exception classes
-        (potentially with * globs) to not report.
     ``sentry.sample_rate`` (optional)
         Percentage of errors to report. (e.g. "37%")
-    ``sentry.processors`` (optional)
-        Comma-delimited list of fully qualified names of processor classes
-        to apply to events before sending to Sentry.
+    ``sentry.ignore_errors`` (optional)
+        A comma-delimited list of exception names, unqualified (e.g.
+        ServerTimeout) or fully qualified (e.g.
+        baseplate.observers.timeout.ServerTimeout) to not notify sentry about.
+        Note: a minimal list of common exceptions is hard-coded in Baseplate,
+        this option only extends that list.
 
     Example usage::
 
-        error_reporter_from_config(app_config, __name__)
+        init_sentry_client_from_config(app_config)
 
     :param raw_config: The application configuration which should have
         settings for the error reporter.
-    :param module_name: ``__name__`` of the root module of the application.
 
     """
     cfg = config.parse_config(
@@ -74,53 +68,28 @@ def error_reporter_from_config(raw_config: config.RawConfig, module_name: str) -
         {
             "sentry": {
                 "dsn": config.Optional(config.String, default=None),
-                "site": config.Optional(config.String, default=None),
                 "environment": config.Optional(config.String, default=None),
-                "include_paths": config.Optional(config.String, default=None),
-                "exclude_paths": config.Optional(config.String, default=None),
-                "additional_ignore_exceptions": config.Optional(
-                    config.TupleOf(config.String), default=[]
-                ),
                 "sample_rate": config.Optional(config.Percent, default=1),
-                "processors": config.Optional(
-                    config.TupleOf(config.String),
-                    default=["raven.processors.SanitizePasswordsProcessor"],
-                ),
+                "ignore_errors": config.Optional(config.TupleOf(config.String), default=()),
             }
         },
     )
 
-    application_module = sys.modules[module_name]
-    module_path = os.path.abspath(application_module.__file__)
-    directory = os.path.dirname(module_path)
-    release = None
-    while directory != "/":
-        try:
-            release = raven.fetch_git_sha(directory)
-        except raven.exceptions.InvalidGitRepository:
-            directory = os.path.dirname(directory)
-        else:
-            break
+    if cfg.sentry.dsn:
+        kwargs.setdefault("dsn", cfg.sentry.dsn)
 
-    all_ignore_exceptions = list(ALWAYS_IGNORE_EXCEPTIONS)
-    if cfg.sentry.additional_ignore_exceptions:
-        all_ignore_exceptions.extend(cfg.sentry.additional_ignore_exceptions)
+    if cfg.sentry.environment:
+        kwargs.setdefault("environment", cfg.sentry.environment)
 
-    # pylint: disable=maybe-no-member
-    client = raven.Client(
-        dsn=cfg.sentry.dsn,
-        site=cfg.sentry.site,
-        release=release,
-        environment=cfg.sentry.environment,
-        include_paths=cfg.sentry.include_paths,
-        exclude_paths=cfg.sentry.exclude_paths,
-        ignore_exceptions=all_ignore_exceptions,
-        sample_rate=cfg.sentry.sample_rate,
-        processors=cfg.sentry.processors,
-    )
+    kwargs.setdefault("sample_rate", cfg.sentry.sample_rate)
 
-    client.ignore_exceptions.add("ServerTimeout")
-    return client
+    ignore_errors: List[Union[type, str]] = []
+    ignore_errors.extend(ALWAYS_IGNORE_ERRORS)
+    ignore_errors.extend(cfg.sentry.ignore_errors)
+    kwargs.setdefault("ignore_errors", ignore_errors)
+
+    client = sentry_sdk.Client(**kwargs)
+    sentry_sdk.Hub.current.bind_client(client)
 
 
 class SentryBaseplateObserver(BaseplateObserver):
@@ -128,55 +97,57 @@ class SentryBaseplateObserver(BaseplateObserver):
 
     This observer reports unexpected exceptions to Sentry.
 
-    The raven client is accessible to your application during requests as the
-    ``sentry`` attribute on the :py:class:`~baseplate.RequestContext`.
-
-    :param raven.Client client: A configured raven client.
-
     """
 
-    def __init__(self, client: raven.Client):
-        self.raven = client
-
     def on_server_span_created(self, context: RequestContext, server_span: Span) -> None:
-        observer = SentryServerSpanObserver(self.raven, server_span)
+        sentry_hub = sentry_sdk.Hub.current
+        observer = _SentryServerSpanObserver(sentry_hub, server_span)
         server_span.register(observer)
-        context.sentry = self.raven
+        context.sentry = sentry_hub
 
 
-class SentryServerSpanObserver(ServerSpanObserver):
-    def __init__(self, client: raven.Client, server_span: Span):
-        self.raven = client
+class _SentryServerSpanObserver(ServerSpanObserver):
+    def __init__(self, sentry_hub: sentry_sdk.Hub, server_span: Span):
+        self.sentry_hub = sentry_hub
+        self.scope_manager = self.sentry_hub.push_scope()
+        self.scope = self.scope_manager.__enter__()
         self.server_span = server_span
 
     def on_start(self) -> None:
-        self.raven.context.activate()
-
-        # for now, this is just a tag for us humans to use
-        # https://github.com/getsentry/sentry/issues/716
-        self.raven.tags_context({"trace_id": self.server_span.trace_id})
+        self.scope.set_tag("trace_id", self.server_span.trace_id)
 
     def on_set_tag(self, key: str, value: Any) -> None:
-        if key.startswith("http"):
-            self.raven.http_context({key[len("http.") :]: value})
-        else:
-            self.raven.tags_context({key: value})
+        self.scope.set_tag(key, value)
 
     def on_log(self, name: str, payload: Any) -> None:
-        self.raven.captureBreadcrumb(category=name, data=payload)
+        self.sentry_hub.add_breadcrumb({"category": name, "message": str(payload)})
 
     def on_finish(self, exc_info: Optional[_ExcInfo] = None) -> None:
         if exc_info is not None:
-            self.raven.captureException(exc_info=exc_info)
-        self.raven.context.clear(deactivate=True)
+            self.sentry_hub.capture_exception(error=exc_info)
+        self.scope_manager.__exit__(None, None, None)
 
 
-class SentryUnhandledErrorReporter:
+class _SentryUnhandledErrorReporter:
     """Hook into the Gevent hub and report errors outside request context."""
 
-    def __init__(self, hub: "Hub", client: raven.Client):
+    @classmethod
+    def install(cls) -> None:
+        from gevent import get_hub
+
+        gevent_hub = get_hub()
+        gevent_hub.print_exception = cls(gevent_hub)
+
+    @classmethod
+    def uninstall(cls) -> None:
+        from gevent import get_hub
+
+        gevent_hub = get_hub()
+        assert isinstance(gevent_hub.print_exception, cls)
+        gevent_hub.print_exception = gevent_hub.print_exception.original_print_exception
+
+    def __init__(self, hub: GeventHub):
         self.original_print_exception = getattr(hub, "print_exception")
-        self.raven = client
         self.logger = logging.getLogger(__name__)
 
     def __call__(
@@ -186,7 +157,7 @@ class SentryUnhandledErrorReporter:
         value: Optional[BaseException],
         tb: Optional[TracebackType],
     ) -> None:
-        self.raven.captureException((exc_type, value, tb))
+        sentry_sdk.capture_exception((exc_type, value, tb))
 
         if value and isinstance(value, ServerTimeout):
             self.logger.warning(

--- a/baseplate/server/__init__.py
+++ b/baseplate/server/__init__.py
@@ -130,9 +130,6 @@ def configure_logging(config: Configuration, debug: bool) -> None:
     root_logger.setLevel(logging_level)
     root_logger.addHandler(handler)
 
-    sentry_logger = logging.getLogger("raven.base.Client")
-    sentry_logger.setLevel(logging.WARNING)
-
     if config.has_logging_options:
         logging.config.fileConfig(config.filename)
 

--- a/docs/api/baseplate/observers/sentry.rst
+++ b/docs/api/baseplate/observers/sentry.rst
@@ -1,10 +1,10 @@
 Sentry (Crash Reporting)
 ========================
 
-The Sentry observer integrates `Raven`_ with your application to record
+The Sentry observer integrates `sentry-sdk`_ with your application to record
 tracebacks for crashes to `Sentry`_.
 
-.. _Raven: https://docs.sentry.io/clients/python/
+.. _sentry-sdk: https://docs.sentry.io/platforms/python/
 .. _Sentry: https://sentry.io/welcome/
 
 Configuration
@@ -25,32 +25,16 @@ the Sentry observer.
    # the DSN provided by Sentry for your project
    sentry.dsn = https://decaf:face@sentry.local/123
 
-   # optional: string to identify this client installation
-   sentry.site = my site
-
    # optional: the environment this application is running in
    sentry.environment = staging
-
-   # optional: comma-delimited list of module prefixes to ignore when
-   # determining where an error came from
-   sentry.exclude_paths = foo, bar
-
-   # optional: comma-delimited list of module prefixes to include for
-   # consideration when drilling down into an exception
-   sentry.include_paths = foo, bar
-
-   # optional: comma-delimited list of fully qualified names of exception
-   # classes (potentially with * globs) to not report.
-   sentry.ignore_exceptions = my_service.UninterestingException
 
    # optional: percent chance that a given error will be reported
    # (defaults to 100%)
    sentry.sample_rate = 37%
 
-   # optional: comma-delimited list of fully qualified names of processor
-   # classes to apply to events before sending to Sentry. defaults to
-   # raven.processors.SanitizePasswordsProcessor
-   sentry.processors = my_service.SanitizeTokenProcessor
+   # optional: comma-delimited list of fully qualified names of exception
+   # classes to not report.
+   sentry.ignore_errors = my_service.UninterestingException
 
    ...
 
@@ -65,7 +49,7 @@ request will be included in the context reported to Sentry.
 Direct Use
 ----------
 
-When enabled, the error reporting observer also adds a :py:class:`raven.Client`
+When enabled, the error reporting observer also adds a :py:class:`sentry_sdk.Hub`
 object as an attribute named ``sentry`` to the
 :py:class:`~baseplate.RequestContext`::
 
@@ -73,4 +57,4 @@ object as an attribute named ``sentry`` to the
        try:
            ...
        except Exception:
-           request.sentry.captureException()
+           request.sentry.capture_exception()

--- a/docs/api/baseplate/observers/sentry.rst
+++ b/docs/api/baseplate/observers/sentry.rst
@@ -4,6 +4,11 @@ Sentry (Crash Reporting)
 The Sentry observer integrates `sentry-sdk`_ with your application to record
 tracebacks for crashes to `Sentry`_.
 
+.. versionchanged:: 2.0
+
+   The underlying library for communicating with sentry was changed from Raven
+   to sentry-sdk.
+
 .. _sentry-sdk: https://docs.sentry.io/platforms/python/
 .. _Sentry: https://sentry.io/welcome/
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -37,6 +37,7 @@ intersphinx_mapping = {
     "redis": ("https://redis-py.readthedocs.io/en/latest/", None),
     "sqlalchemy": ("https://docs.sqlalchemy.org/en/13/", None),
     "requests": ("https://requests.readthedocs.io/en/stable/", None),
+    "sentry_sdk": ("https://getsentry.github.io/sentry-python/", None),
 }
 
 # The suffix of source filenames.

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -18,9 +18,9 @@ confluent-kafka==1.3
 coverage==4.5.2
 cqlmapper==0.1.0
 cryptography==3.2
-gevent==1.4.0
+gevent==21.1.1
 graphviz==0.11.1
-greenlet==0.4.15
+greenlet==1.0.0
 hupper==1.0
 idna==2.8
 importlib-metadata==0.23
@@ -50,10 +50,10 @@ pytest==4.6.3
 pytest-cov==2.6.1
 python-json-logger==0.1.11
 pytz==2018.9
-raven==6.10.0
 redis==3.3.8
 repoze.lru==0.7
 requests==2.21.0
+sentry-sdk==0.19.5
 six==1.12.0
 SQLAlchemy==1.3.0
 thrift==0.13.0
@@ -69,4 +69,5 @@ WebTest==2.0.32
 wrapt==1.11.1
 zipp==0.6.0
 zope.deprecation==4.4.0
+zope.event==4.5.0
 zope.interface==4.4.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,8 @@ exclude_lines =
     pass
     # module-import stuff should be minimal
     if __name__ == .__main__.:
+    # mypy-only branches aren't live code
+    if TYPE_CHECKING:
 
 [flake8]
 max-line-length = 100
@@ -102,9 +104,6 @@ ignore_missing_imports = True
 ignore_missing_imports = True
 
 [mypy-pythonjsonlogger.*]
-ignore_missing_imports = True
-
-[mypy-raven.*]
 ignore_missing_imports = True
 
 [mypy-sqlalchemy.*]

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
         "python-json-logger~=0.1",
         "requests>=2.21.0",
         "thrift>=0.12.0",
-        "gevent>=1.3",
+        "gevent>=20.5.0",
     ],
     extras_require={
         "amqp": ["kombu>=4.0.0"],

--- a/tests/unit/observers/sentry_tests.py
+++ b/tests/unit/observers/sentry_tests.py
@@ -60,7 +60,7 @@ def test_event_when_exception(baseplate_app, sentry_transport):
 def test_tags(baseplate_app, sentry_transport):
     with pytest.raises(ValueError):
         with baseplate_app.server_context("test") as context:
-            context.trace.set_tag("foo", "bar")
+            context.span.set_tag("foo", "bar")
             raise ValueError("oops")
 
     assert len(sentry_transport.events) == 1
@@ -70,7 +70,7 @@ def test_tags(baseplate_app, sentry_transport):
 
     with pytest.raises(ValueError):
         with baseplate_app.server_context("test") as context:
-            context.trace.set_tag("different-tag", "foo")
+            context.span.set_tag("different-tag", "foo")
             raise ValueError("oops")
 
     assert len(sentry_transport.events) == 2
@@ -83,7 +83,7 @@ def test_tags(baseplate_app, sentry_transport):
 def test_logs(baseplate_app, sentry_transport):
     with pytest.raises(ValueError):
         with baseplate_app.server_context("test") as context:
-            context.trace.log("foo-category", "bar-log-entry")
+            context.span.log("foo-category", "bar-log-entry")
             raise ValueError("oops")
 
     assert len(sentry_transport.events) == 1

--- a/tests/unit/observers/sentry_tests.py
+++ b/tests/unit/observers/sentry_tests.py
@@ -1,78 +1,137 @@
-import unittest
+from typing import Any
+from typing import Dict
 
-from unittest import mock
+import gevent
+import pytest
+import sentry_sdk
 
-import raven
-
-from pymemcache.exceptions import MemcacheServerError
-from requests.exceptions import HTTPError
-from thrift.protocol.TProtocol import TProtocolException
-from thrift.Thrift import TApplicationException
-from thrift.transport.TTransport import TTransportException
-
-from baseplate.observers import sentry
+from baseplate import Baseplate
+from baseplate.observers.sentry import _SentryUnhandledErrorReporter
+from baseplate.observers.sentry import init_sentry_client_from_config
+from baseplate.observers.sentry import SentryBaseplateObserver
 
 
-class StubRavenClient(raven.Client):
-    def __init__(self, **kwargs):
-        self.stub_events_sent = 0
-        return super().__init__(**kwargs)
+class FakeTransport:
+    def __init__(self):
+        self.events = []
 
-    def send(self, **kwargs):
-        self.stub_events_sent += 1
-        return None
-
-    def is_enabled(self):
-        return True
+    def __call__(self, event: Dict[str, Any]) -> None:
+        self.events.append(event)
 
 
-class TestException(Exception):
-    pass
+@pytest.fixture
+def sentry_transport():
+    return FakeTransport()
 
 
-@mock.patch("raven.Client", new=StubRavenClient)
-class SentryIgnoreExceptionsTest(unittest.TestCase):
-    def observe_and_raise(self, cli, exc):
-        @cli.capture_exceptions
-        def _raise_exception():
-            raise exc
+@pytest.fixture(autouse=True)
+def init_sentry_client(sentry_transport):
+    try:
+        init_sentry_client_from_config({"sentry.dsn": "foo"}, transport=sentry_transport)
+        yield
+    finally:
+        sentry_sdk.init()  # shut everything down
 
-        return _raise_exception
 
-    def observe_always_ignore(self, cli):
-        ignore = [
-            ConnectionError,
-            ConnectionRefusedError,
-            ConnectionResetError,
-            HTTPError,
-            TApplicationException,
-            TProtocolException,
-            TTransportException,
-            MemcacheServerError,
-        ]
-        for exc in ignore:
-            fn = self.observe_and_raise(cli, exc)
-            try:
-                fn()
-            except exc:
-                exc
+@pytest.fixture
+def baseplate_app():
+    baseplate = Baseplate()
+    baseplate.register(SentryBaseplateObserver())
+    return baseplate
 
-    def test_default_ignore_exceptions(self):
-        cli = sentry.error_reporter_from_config(dict(), __name__)
-        self.observe_always_ignore(cli)
-        self.assertEqual(cli.stub_events_sent, 0)
 
-    def test_report_exception(self):
-        cli = sentry.error_reporter_from_config(dict(), __name__)
-        self.assertRaises(TestException, self.observe_and_raise(cli, TestException))
-        self.assertEqual(cli.stub_events_sent, 1)
+def test_no_event_when_nothing_wrong(baseplate_app, sentry_transport):
+    with baseplate_app.server_context("test"):
+        pass
 
-    def test_additional_ignored_exceptions(self):
-        cli = sentry.error_reporter_from_config(
-            {"sentry.additional_ignore_exceptions": TestException.__name__}, __name__,
-        )
-        self.assertRaises(TestException, self.observe_and_raise(cli, TestException))
-        self.assertEqual(cli.stub_events_sent, 0)
+    assert not sentry_transport.events
 
-        self.observe_always_ignore(cli)
-        self.assertEqual(cli.stub_events_sent, 0)
+
+def test_event_when_exception(baseplate_app, sentry_transport):
+    with pytest.raises(ValueError):
+        with baseplate_app.server_context("test"):
+            raise ValueError("oops")
+
+    assert len(sentry_transport.events) == 1
+    event = sentry_transport.events[0]
+    assert event["exception"]["values"][0]["type"] == "ValueError"
+
+
+def test_tags(baseplate_app, sentry_transport):
+    with pytest.raises(ValueError):
+        with baseplate_app.server_context("test") as context:
+            context.trace.set_tag("foo", "bar")
+            raise ValueError("oops")
+
+    assert len(sentry_transport.events) == 1
+    event = sentry_transport.events[0]
+    assert event["exception"]["values"][0]["type"] == "ValueError"
+    assert event["tags"]["foo"] == "bar"
+
+    with pytest.raises(ValueError):
+        with baseplate_app.server_context("test") as context:
+            context.trace.set_tag("different-tag", "foo")
+            raise ValueError("oops")
+
+    assert len(sentry_transport.events) == 2
+    event = sentry_transport.events[1]
+    assert event["exception"]["values"][0]["type"] == "ValueError"
+    assert event["tags"]["different-tag"] == "foo"
+    assert "foo" not in event["tags"]
+
+
+def test_logs(baseplate_app, sentry_transport):
+    with pytest.raises(ValueError):
+        with baseplate_app.server_context("test") as context:
+            context.trace.log("foo-category", "bar-log-entry")
+            raise ValueError("oops")
+
+    assert len(sentry_transport.events) == 1
+    event = sentry_transport.events[0]
+    assert event["exception"]["values"][0]["type"] == "ValueError"
+
+    last_breadcrumb = event["breadcrumbs"]["values"][-1]
+    assert last_breadcrumb["category"] == "foo-category"
+    assert last_breadcrumb["message"] == "bar-log-entry"
+
+
+def test_ignored_exception_ignored(baseplate_app, sentry_transport):
+    with pytest.raises(ConnectionError):
+        with baseplate_app.server_context("test"):
+            raise ConnectionError("oops")
+
+    assert not sentry_transport.events
+
+
+def test_unhandled_error_reporter(sentry_transport):
+    def raise_unhandled_error():
+        raise KeyError("foo")
+
+    try:
+        _SentryUnhandledErrorReporter.install()
+
+        greenlet = gevent.spawn(raise_unhandled_error)
+        greenlet.join()
+    finally:
+        _SentryUnhandledErrorReporter.uninstall()
+
+    assert len(sentry_transport.events) == 1
+    event = sentry_transport.events[0]
+    assert event["exception"]["values"][0]["type"] == "KeyError"
+
+
+def test_unhandled_error_reporter_server_timeout(sentry_transport):
+    def raise_unhandled_error():
+        from baseplate.observers.timeout import ServerTimeout
+
+        raise ServerTimeout("blah", 1.0, debug=False)
+
+    try:
+        _SentryUnhandledErrorReporter.install()
+
+        greenlet = gevent.spawn(raise_unhandled_error)
+        greenlet.join()
+    finally:
+        _SentryUnhandledErrorReporter.uninstall()
+
+    assert not sentry_transport.events


### PR DESCRIPTION
Raven has been deprecated for a while.

gevent gets a minimum version bump because of
https://docs.sentry.io/platforms/python/troubleshooting/#context-variables-vs-geventeventlet

Fixes #247 