### PR TITLE
Rename context.trace -> context.span

### DIFF
--- a/baseplate/__init__.py
+++ b/baseplate/__init__.py
@@ -715,7 +715,7 @@ class ServerSpan(LocalSpan):
     """A server span represents a request this server is handling.
 
     The server span is available on the :py:class:`~baseplate.RequestContext`
-    during requests as the ``trace`` attribute.
+    during requests as the ``span`` attribute.
 
     """
 

--- a/baseplate/__init__.py
+++ b/baseplate/__init__.py
@@ -199,7 +199,7 @@ class RequestContext:
         # reference. so we fake it here and say "trust us".
         #
         # this would be much cleaner with a different API but this is where we are.
-        self.trace: "Span" = span  # type: ignore
+        self.span: "Span" = span  # type: ignore
 
     def __getattr__(self, name: str) -> Any:
         try:
@@ -218,9 +218,9 @@ class RequestContext:
             full_name = name
 
         if isinstance(config_item, dict):
-            obj = RequestContext(context_config=config_item, prefix=full_name, span=self.trace)
+            obj = RequestContext(context_config=config_item, prefix=full_name, span=self.span)
         elif hasattr(config_item, "make_object_for_context"):
-            obj = config_item.make_object_for_context(full_name, self.trace)
+            obj = config_item.make_object_for_context(full_name, self.span)
         else:
             obj = config_item
 
@@ -236,7 +236,7 @@ class RequestContext:
         return RequestContext(
             context_config=self.__context_config,
             prefix=self.__prefix,
-            span=self.trace,
+            span=self.span,
             wrapped=self,
         )
 
@@ -479,7 +479,7 @@ class Baseplate:
             context,
             baseplate=self,
         )
-        context.trace = server_span
+        context.span = server_span
 
         for observer in self.observers:
             observer.on_server_span_created(context, server_span)
@@ -704,7 +704,7 @@ class LocalSpan(Span):
                 context_copy,
                 self.baseplate,
             )
-        context_copy.trace = span
+        context_copy.span = span
 
         for observer in self.observers:
             observer.on_child_span_created(span)

--- a/baseplate/frameworks/pyramid/__init__.py
+++ b/baseplate/frameworks/pyramid/__init__.py
@@ -75,13 +75,13 @@ def _make_baseplate_tween(
         try:
             response = handler(request)
         except:  # noqa: E722
-            if hasattr(request, "trace") and request.trace:
-                request.trace.finish(exc_info=sys.exc_info())
+            if hasattr(request, "span") and request.span:
+                request.span.finish(exc_info=sys.exc_info())
             raise
         else:
-            if request.trace:
-                request.trace.set_tag("http.status_code", response.status_code)
-                response.app_iter = SpanFinishingAppIterWrapper(request.trace, response.app_iter)
+            if request.span:
+                request.span.set_tag("http.status_code", response.status_code)
+                response.app_iter = SpanFinishingAppIterWrapper(request.span, response.app_iter)
         finally:
             # avoid a reference cycle
             request.start_server_span = None

--- a/baseplate/frameworks/queue_consumer/kafka.py
+++ b/baseplate/frameworks/queue_consumer/kafka.py
@@ -135,7 +135,7 @@ class KafkaMessageHandler(MessageHandler):
                     data = self.message_unpack_fn(blob)
                 except Exception:
                     logger.error("skipping invalid message")
-                    context.trace.incr_tag(f"{self.name}.{topic}.invalid_message")
+                    context.span.incr_tag(f"{self.name}.{topic}.invalid_message")
                     return
 
                 try:
@@ -391,7 +391,7 @@ class InOrderConsumerFactory(_BaseKafkaQueueConsumerFactory):
                 message.partition(),
                 message.offset(),
             )
-            with context.trace.make_child("kafka.commit"):
+            with context.span.make_child("kafka.commit"):
                 self.consumer.commit(message=message, asynchronous=False)
 
         return KafkaMessageHandler(

--- a/baseplate/frameworks/thrift/__init__.py
+++ b/baseplate/frameworks/thrift/__init__.py
@@ -32,7 +32,7 @@ class _ContextAwareHandler:
 
             handler_fn = getattr(self.handler, fn_name)
 
-            span = self.context.trace
+            span = self.context.span
             try:
                 span.start()
                 result = handler_fn(self.context, *args, **kwargs)

--- a/tests/integration/pyramid_tests.py
+++ b/tests/integration/pyramid_tests.py
@@ -69,7 +69,7 @@ def render_bad_exception_view(request):
 
 
 def local_tracing_within_context(request):
-    with request.trace.make_child("local-req", local=True, component_name="in-context"):
+    with request.span.make_child("local-req", local=True, component_name="in-context"):
         pass
     return {"trace": "success"}
 

--- a/tests/integration/requests_tests.py
+++ b/tests/integration/requests_tests.py
@@ -133,9 +133,9 @@ def test_internal_client_sends_headers(http_server):
         assert response.status_code == 204
         assert response.text == ""
         assert http_server.requests[0].method == "GET"
-        assert http_server.requests[0].trace.trace_id == context.trace.trace_id
-        assert http_server.requests[0].trace.parent_id == context.trace.id
-        assert http_server.requests[0].trace.id != context.trace.id
+        assert http_server.requests[0].span.trace_id == context.span.trace_id
+        assert http_server.requests[0].span.parent_id == context.span.id
+        assert http_server.requests[0].span.id != context.span.id
         assert http_server.requests[0].raw_edge_context == b"test payload"
 
 

--- a/tests/integration/thrift_tests.py
+++ b/tests/integration/thrift_tests.py
@@ -143,7 +143,7 @@ class ThriftTraceHeaderTests(GeventPatchedTestCase):
                 self.server_span = None
 
             def example(self, context):
-                self.server_span = context.trace
+                self.server_span = context.span
                 return True
 
         handler = Handler()
@@ -169,7 +169,7 @@ class ThriftTraceHeaderTests(GeventPatchedTestCase):
                 self.server_span = None
 
             def example(self, context):
-                self.server_span = context.trace
+                self.server_span = context.span
                 return True
 
         handler = Handler()
@@ -203,7 +203,7 @@ class ThriftTraceHeaderTests(GeventPatchedTestCase):
                 self.server_span = None
 
             def example(self, context):
-                self.server_span = context.trace
+                self.server_span = context.span
                 return True
 
         handler = Handler()

--- a/tests/integration/tracing_tests.py
+++ b/tests/integration/tracing_tests.py
@@ -33,7 +33,7 @@ def example_application(request):
 def local_parent_trace_within_context(request):
     # For testing embedded tracing contexts
     #  See `TracingTests.test_local_tracing_embedded`
-    with request.trace.make_child("local-req", local=True, component_name="in-context") as span:
+    with request.span.make_child("local-req", local=True, component_name="in-context") as span:
         with span.make_child("local-req", local=True, component_name="in-context"):
             pass
 

--- a/tests/unit/frameworks/queue_consumer/kafka_tests.py
+++ b/tests/unit/frameworks/queue_consumer/kafka_tests.py
@@ -171,7 +171,7 @@ class TestKafkaMessageHandler:
         message_unpack_fn = mock.Mock(side_effect=ValueError("something bad happened"))
         on_success_fn = mock.Mock()
 
-        context.trace = span
+        context.span = span
 
         handler = KafkaMessageHandler(baseplate, name, handler_fn, message_unpack_fn, on_success_fn)
         handler.handle(message)


### PR DESCRIPTION
The span is for the whole observer system, not just for tracing. Even
though the span concept comes from tracing.

Fixes #544