### PR TITLE
PyPI Updates

### DIFF
--- a/.github/workflows/python-publish.yaml
+++ b/.github/workflows/python-publish.yaml
@@ -1,0 +1,32 @@
+name: Upload Python Package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  deploy:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.8'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install setuptools==47.3.0 wheel==0.34.2 twine==3.1.1
+
+    - name: Build and publish
+      env:
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+      run: |
+        python setup.py sdist bdist_wheel
+        twine upload dist/*
+

--- a/setup.py
+++ b/setup.py
@@ -3,12 +3,15 @@ from setuptools import setup
 
 setup(
     name="baseplate",
-    description="A library to build services on",
+    description="reddit's python service framework",
     long_description=open("README.rst").read(),
     long_description_content_type="text/x-rst",
     author="reddit",
     license="BSD",
-    url="https://baseplate.readthedocs.io/en/stable/",
+    url="https://github.com/reddit/baseplate.py",
+    project_urls={
+        "Documentation": "https://baseplate.readthedocs.io/en/stable/",
+    },
     use_scm_version=True,
     packages=find_packages(exclude=["tests", "tests.*"]),
     python_requires=">=3.7",


### PR DESCRIPTION
This updates the project URLs so PyPI can show the right stuff for us. Shown below is current [baseplate.py on PyPI](https://pypi.org/project/baseplate/) and on the right is [the new edgecontext library on PyPI](https://pypi.org/project/reddit-edgecontext/). Baseplate.py should look more like edgecontext once this is merged.

![Screenshot from 2021-02-01 15-48-25](https://user-images.githubusercontent.com/338853/106532418-028b5800-64a5-11eb-9235-0938f8c1446d.png) ![Screenshot from 2021-02-01 15-48-50](https://user-images.githubusercontent.com/338853/106532435-0919cf80-64a5-11eb-98b8-43a015e28880.png)

Additionally, this setups a github action for automatic publishing to PyPI so all we have to do in the future is create a github release and we're done.
