### PR TITLE
Make the publisher sidecars' max queue size configurable

### DIFF
--- a/baseplate/sidecars/event_publisher.py
+++ b/baseplate/sidecars/event_publisher.py
@@ -184,13 +184,16 @@ def publish_events() -> None:
                 "version": config.Optional(config.Integer, default=1),
             },
             "key": {"name": config.String, "secret": config.Base64},
+            "max_queue_size": config.Optional(config.Integer, MAX_QUEUE_SIZE),
         },
     )
 
     metrics_client = metrics_client_from_config(raw_config)
 
     event_queue = MessageQueue(
-        "/events-" + args.queue_name, max_messages=MAX_QUEUE_SIZE, max_message_size=MAX_EVENT_SIZE
+        "/events-" + args.queue_name,
+        max_messages=cfg.max_queue_size,
+        max_message_size=MAX_EVENT_SIZE,
     )
 
     # pylint: disable=maybe-no-member

--- a/baseplate/sidecars/trace_publisher.py
+++ b/baseplate/sidecars/trace_publisher.py
@@ -154,11 +154,14 @@ def publish_traces() -> None:
             "post_timeout": config.Optional(config.Integer, POST_TIMEOUT_DEFAULT),
             "max_batch_size": config.Optional(config.Integer, MAX_BATCH_SIZE_DEFAULT),
             "retry_limit": config.Optional(config.Integer, RETRY_LIMIT_DEFAULT),
+            "max_queue_size": config.Optional(config.Integer, MAX_QUEUE_SIZE),
         },
     )
 
     trace_queue = MessageQueue(
-        "/traces-" + args.queue_name, max_messages=MAX_QUEUE_SIZE, max_message_size=MAX_SPAN_SIZE
+        "/traces-" + args.queue_name,
+        max_messages=publisher_cfg.max_queue_size,
+        max_message_size=MAX_SPAN_SIZE,
     )
 
     # pylint: disable=maybe-no-member


### PR DESCRIPTION
When the publisher sidecars cannot keep up with the service sending
messages to the mq and the mq starts to pile up, the piling up mq could
count towards containers' memory limit, and cause the containers to get
OOM killed.

Make the queue size configurable so the max memory used by the mq is
controllable, so that for services that would have low memory
limit/request could avoid being OOM killed because of mq.

See also https://github.com/reddit/baseplate.go/pull/336.