### PR TITLE
Display Trace IDs as UUID

### DIFF
--- a/baseplate/__init__.py
+++ b/baseplate/__init__.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import random
+import uuid
 
 from contextlib import contextmanager
 from types import TracebackType
@@ -654,6 +655,10 @@ class Span:
     ) -> "Span":
         """Return a child Span whose parent is this Span."""
         raise NotImplementedError
+
+    @property
+    def trace_uuid(self) -> uuid.UUID:
+        return uuid.UUID(int=self.trace_id)
 
 
 class ParentSpanAlreadyFinishedError(Exception):

--- a/baseplate/observers/logging.py
+++ b/baseplate/observers/logging.py
@@ -15,4 +15,4 @@ class LoggingBaseplateObserver(BaseplateObserver):
     """
 
     def on_server_span_created(self, context: RequestContext, server_span: Span) -> None:
-        threading.current_thread().name = str(server_span.trace_id)
+        threading.current_thread().name = str(server_span.trace_uuid)

--- a/baseplate/observers/sentry.py
+++ b/baseplate/observers/sentry.py
@@ -114,7 +114,7 @@ class _SentryServerSpanObserver(ServerSpanObserver):
         self.server_span = server_span
 
     def on_start(self) -> None:
-        self.scope.set_tag("trace_id", self.server_span.trace_id)
+        self.scope.set_tag("trace_id", str(self.server_span.trace_uuid))
 
     def on_set_tag(self, key: str, value: Any) -> None:
         self.scope.set_tag(key, value)


### PR DESCRIPTION
Since Wavefront formats trace IDs this way, we should standardize to make it clearer how they mesh.