### PR TITLE
Rework tagged metrics to ensure proper aggregations

### DIFF
--- a/baseplate/observers/metrics_tagged.py
+++ b/baseplate/observers/metrics_tagged.py
@@ -45,9 +45,7 @@ class TaggedMetricsBaseplateObserver(BaseplateObserver):
             raw_config,
             {
                 "metrics": {
-                    "allowlist": config.Optional(
-                        config.TupleOf(config.String), default=[],
-                    ),
+                    "allowlist": config.Optional(config.TupleOf(config.String), default=[]),
                 },
                 "metrics_observer": {"sample_rate": config.Optional(config.Percent, default=1.0)},
             },

--- a/baseplate/observers/metrics_tagged.py
+++ b/baseplate/observers/metrics_tagged.py
@@ -46,7 +46,7 @@ class TaggedMetricsBaseplateObserver(BaseplateObserver):
             {
                 "metrics": {
                     "allowlist": config.Optional(
-                        config.TupleOf(config.String), default=["client", "endpoint"],
+                        config.TupleOf(config.String), default=[],
                     ),
                 },
                 "metrics_observer": {"sample_rate": config.Optional(config.Percent, default=1.0)},
@@ -54,7 +54,7 @@ class TaggedMetricsBaseplateObserver(BaseplateObserver):
         )
         return cls(
             client,
-            allowlist=set(cfg.metrics.allowlist),
+            allowlist=set(cfg.metrics.allowlist) | {"client", "endpoint"},
             sample_rate=cfg.metrics_observer.sample_rate,
         )
 

--- a/docs/api/baseplate/observers/tagged_statsd.rst
+++ b/docs/api/baseplate/observers/tagged_statsd.rst
@@ -1,10 +1,11 @@
 StatsD Tagged Metrics
 =====================
 
-The tagged metrics observer emits `StatsD`_-compatible time-series metrics about the
-performance of your application with tags in the InfluxStatsD format. The tags added to 
-the metrics are configurable: any tags that pass through the span.set_tag() 
-function are filtered through a user-supplied whitelist in the configuration file.
+The tagged metrics observer emits `StatsD`_-compatible time-series metrics
+about the performance of your application with tags in the InfluxStatsD format.
+The tags added to the metrics are configurable: any tags that pass through the
+:py:meth:`~baseplate.Span.set_tag` function are filtered through a
+user-supplied whitelist in the configuration file.
 
 .. _`StatsD`: https://github.com/statsd/statsd
 
@@ -15,9 +16,6 @@ Make sure your service calls
 :py:meth:`~baseplate.Baseplate.configure_observers` during application startup
 and then add the following to your configuration file to enable and configure
 the StatsD tagged metrics observer.
-
-Do not include a metrics.namespace parameter in the configuration file, as it incompatible with 
-the service.
 
 .. code-block:: ini
 
@@ -41,13 +39,17 @@ the service.
 
 Whitelist Options
 -----------------
-Wavefront supports a maximum of 20 tags per cluster and 1000 distinct time series per 
-metric. Baseplate integrations of frameworks come out of the box with some default tags set via span.set_tag(), 
-but to append them to the metrics they must be present in the configuration file via metrics.whitelist. 
 
-In order to find these tags to put in the whitelist, look through the code base for calls to span.set_tag()
-or check a zipkin trace in Wavefront to see all the tags on a span. 
-   
+Wavefront supports a maximum of 20 tags per cluster and 1000 distinct time
+series per metric. Baseplate integrations of frameworks come out of the box
+with some default tags set via :py:meth:`~baseplate.Span.set_tag()`, but to
+append them to the metrics they must be present in the configuration file via
+``metrics.whitelist``.
+
+In order to find these tags to put in the whitelist, look through the code base
+for calls to :py:meth:`~baseplate.Span.set_tag()` or check a zipkin trace in
+Wavefront to see all the tags on a span.
+
 Outputs
 -------
 
@@ -62,15 +64,14 @@ in Telegraf via the ``name_prefix`` input plugin configuration.
 
 For the :py:class:`~baseplate.ServerSpan` representing the request the server
 is handling, the timer has a name like
-``baseplate.server,endpoint={route_or_method_name}`` and the counter looks like
-``baseplate.server,success={true,false},endpoint={route_or_method_name}``. If the request
-:doc:`timed out <timeout>` an additional tag will be added to make it 
-``baseplate.server,success={true,false},endpoint={route_or_method_name},timed_out={true,false}``
-assuming that success, endpoint, and timed_out are all present in the whitelist.
+``baseplate.server.latency,endpoint={route_or_method_name}`` and the counter
+looks like
+``baseplate.server.rate,success={True,False},endpoint={route_or_method_name}``.
 
 For each span representing a call to a remote service or database, the timer
-has a name like ``baseplate.clients,endpoint={method}`` and the counter
-``baseplate.clients,endpoint={method},success={true,false}``.
+has a name like ``baseplate.clients.latency,client={name},endpoint={method}``
+and the counter
+``baseplate.clients.rate,client={name},endpoint={method},success={True,False}``.
 
 When using :program:`baseplate-serve`, various process-level runtime metrics
 will also be emitted. These are not tied to individual requests but instead

--- a/docs/api/baseplate/observers/tagged_statsd.rst
+++ b/docs/api/baseplate/observers/tagged_statsd.rst
@@ -28,8 +28,8 @@ the StatsD tagged metrics observer.
 
    # optional: which span tags should be attached to metrics. see below.
    #
-   # defaults to [ endpoint, success ] if no value is provided
-   metrics.allowlist = endpoint, success, error
+   # `endpoint` and `client` are always allowed
+   metrics.allowlist = foo, bar, baz
 
    # optional: the percent of statsd metrics to sample.
    #

--- a/docs/api/baseplate/observers/tagged_statsd.rst
+++ b/docs/api/baseplate/observers/tagged_statsd.rst
@@ -5,7 +5,7 @@ The tagged metrics observer emits `StatsD`_-compatible time-series metrics
 about the performance of your application with tags in the InfluxStatsD format.
 The tags added to the metrics are configurable: any tags that pass through the
 :py:meth:`~baseplate.Span.set_tag` function are filtered through a
-user-supplied whitelist in the configuration file.
+user-supplied allowlist in the configuration file.
 
 .. _`StatsD`: https://github.com/statsd/statsd
 
@@ -26,27 +26,28 @@ the StatsD tagged metrics observer.
    # required to enable observer
    metrics.tagging = true
 
-   # optional: whitelist of tags to allow predefined tags from baseplate separated by commas
-   # defaults to [ endpoint, success, error ] if no value is provided
-   metrics.whitelist = endpoint, success, error
+   # optional: which span tags should be attached to metrics. see below.
+   #
+   # defaults to [ endpoint, success ] if no value is provided
+   metrics.allowlist = endpoint, success, error
 
-   # optional: the percent of statsd metrics to sample
+   # optional: the percent of statsd metrics to sample.
+   #
    # if not specified, it will default to 100% (all metrics sent)
-   # config must be passed to the `Baseplate` constructor to use this option
    metrics_observer.sample_rate = 100%
 
    ...
 
-Whitelist Options
------------------
+Tag Allowlist
+-------------
 
 Wavefront supports a maximum of 20 tags per cluster and 1000 distinct time
 series per metric. Baseplate integrations of frameworks come out of the box
 with some default tags set via :py:meth:`~baseplate.Span.set_tag()`, but to
 append them to the metrics they must be present in the configuration file via
-``metrics.whitelist``.
+``metrics.allowlist``.
 
-In order to find these tags to put in the whitelist, look through the code base
+In order to find these tags to put in the allowlist, look through the code base
 for calls to :py:meth:`~baseplate.Span.set_tag()` or check a zipkin trace in
 Wavefront to see all the tags on a span.
 


### PR DESCRIPTION
This is related to a recent discussion in #baseplate-spec. Unfortunately, tagging `success` on the timers meant that we can't get a complete view of the timers across successes and failures (since you can't just sum up percentiles). So this removes that tag from the timer, adds a counter back into the mix with that success tag, and renames both to give them some space.

The untagged metrics implementation emits counters for server timeouts and for each exception returned from a client. This was done with tags in the previous tagged metrics implementation, which can't continue for the same reasons as above. As a straw argument: I'm just not reimplementing them. How do we feel about this? Does anyone actually use those metrics?

Since we're gearing up for breaking 2.0 changes, I figured it's a good time to get rid of "whitelist" here too. 