### PR TITLE
Make trace IDs strings for flexibility

### DIFF
--- a/baseplate/__init__.py
+++ b/baseplate/__init__.py
@@ -102,13 +102,13 @@ class TraceInfo(NamedTuple):
     """
 
     #: The ID of the whole trace. This will be the same for all downstream requests.
-    trace_id: int
+    trace_id: str
 
     #: The ID of the parent span, or None if this is the root span.
-    parent_id: Optional[int]
+    parent_id: Optional[str]
 
     #: The ID of the current span. Should be unique within a trace.
-    span_id: int
+    span_id: str
 
     #: True if this trace was selected for sampling. Will be propagated to child spans.
     sampled: Optional[bool]
@@ -124,15 +124,15 @@ class TraceInfo(NamedTuple):
         with any upstream requests.
 
         """
-        trace_id = random.getrandbits(64)
+        trace_id = str(random.getrandbits(64))
         return cls(trace_id=trace_id, parent_id=None, span_id=trace_id, sampled=None, flags=None)
 
     @classmethod
     def from_upstream(
         cls,
-        trace_id: Optional[int],
-        parent_id: Optional[int],
-        span_id: Optional[int],
+        trace_id: Optional[str],
+        parent_id: Optional[str],
+        span_id: Optional[str],
         sampled: Optional[bool],
         flags: Optional[int],
     ) -> "TraceInfo":
@@ -147,13 +147,13 @@ class TraceInfo(NamedTuple):
         :raises: :py:exc:`ValueError` if any of the values are inappropriate.
 
         """
-        if trace_id is None or not 0 <= trace_id < 2 ** 64:
+        if trace_id is None:
             raise ValueError("invalid trace_id")
 
-        if span_id is None or not 0 <= span_id < 2 ** 64:
+        if span_id is None:
             raise ValueError("invalid span_id")
 
-        if parent_id is None or not 0 <= parent_id < 2 ** 64:
+        if parent_id is None:
             raise ValueError("invalid parent_id")
 
         if sampled is not None and not isinstance(sampled, bool):
@@ -535,9 +535,9 @@ class Span:
 
     def __init__(
         self,
-        trace_id: int,
-        parent_id: Optional[int],
-        span_id: int,
+        trace_id: str,
+        parent_id: Optional[str],
+        span_id: str,
         sampled: Optional[bool],
         flags: Optional[int],
         name: str,
@@ -688,7 +688,7 @@ class LocalSpan(Span):
         if not self.context:
             raise ParentSpanAlreadyFinishedError
 
-        span_id = random.getrandbits(64)
+        span_id = str(random.getrandbits(64))
         context_copy = self.context.clone()
         span: Span
         if local:

--- a/baseplate/frameworks/pyramid/__init__.py
+++ b/baseplate/frameworks/pyramid/__init__.py
@@ -246,9 +246,9 @@ class BaseplateConfigurator:
         sampled = bool(headers.get("X-Sampled") == "1")
         flags = headers.get("X-Flags", None)
         return TraceInfo.from_upstream(
-            int(headers["X-Trace"]),
-            int(headers["X-Parent"]),
-            int(headers["X-Span"]),
+            headers["X-Trace"],
+            headers["X-Parent"],
+            headers["X-Span"],
             sampled,
             int(flags) if flags is not None else None,
         )

--- a/baseplate/frameworks/thrift/__init__.py
+++ b/baseplate/frameworks/thrift/__init__.py
@@ -89,9 +89,9 @@ def baseplateify_processor(
                 sampled = bool(headers.get(b"Sampled") == b"1")
                 flags = headers.get(b"Flags", None)
                 trace_info = TraceInfo.from_upstream(
-                    int(headers[b"Trace"]),
-                    int(headers[b"Parent"]),
-                    int(headers[b"Span"]),
+                    headers[b"Trace"].decode(),
+                    headers[b"Parent"].decode(),
+                    headers[b"Span"].decode(),
                     sampled,
                     int(flags) if flags is not None else None,
                 )

--- a/baseplate/server/runtime_monitor.py
+++ b/baseplate/server/runtime_monitor.py
@@ -48,7 +48,7 @@ class _OpenConnectionsReporter(_Reporter):
 
 class _ActiveRequestsObserver(BaseplateObserver, _Reporter):
     def __init__(self) -> None:
-        self.live_requests: Dict[int, float] = {}
+        self.live_requests: Dict[str, float] = {}
 
     def on_server_span_created(self, context: RequestContext, server_span: ServerSpan) -> None:
         observer = _ActiveRequestsServerSpanObserver(self, server_span.trace_id)
@@ -68,7 +68,7 @@ class _ActiveRequestsObserver(BaseplateObserver, _Reporter):
 
 
 class _ActiveRequestsServerSpanObserver(ServerSpanObserver):
-    def __init__(self, reporter: _ActiveRequestsObserver, trace_id: int):
+    def __init__(self, reporter: _ActiveRequestsObserver, trace_id: str):
         self.reporter = reporter
         self.trace_id = trace_id
 

--- a/tests/integration/pyramid_tests.py
+++ b/tests/integration/pyramid_tests.py
@@ -121,9 +121,9 @@ class ConfiguratorTests(unittest.TestCase):
         self.assertEqual(self.observer.on_server_span_created.call_count, 1)
 
         context, server_span = self.observer.on_server_span_created.call_args[0]
-        self.assertEqual(server_span.trace_id, 1234)
+        self.assertEqual(server_span.trace_id, "1234")
         self.assertEqual(server_span.parent_id, None)
-        self.assertEqual(server_span.id, 1234)
+        self.assertEqual(server_span.id, "1234")
 
         self.assertTrue(self.server_observer.on_start.called)
         self.assertTrue(self.server_observer.on_finish.called)
@@ -145,9 +145,9 @@ class ConfiguratorTests(unittest.TestCase):
         self.assertEqual(self.observer.on_server_span_created.call_count, 1)
 
         context, server_span = self.observer.on_server_span_created.call_args[0]
-        self.assertEqual(server_span.trace_id, 1234)
-        self.assertEqual(server_span.parent_id, 2345)
-        self.assertEqual(server_span.id, 3456)
+        self.assertEqual(server_span.trace_id, "1234")
+        self.assertEqual(server_span.parent_id, "2345")
+        self.assertEqual(server_span.id, "3456")
         self.assertEqual(server_span.sampled, True)
         self.assertEqual(server_span.flags, 1)
 
@@ -222,7 +222,7 @@ class ConfiguratorTests(unittest.TestCase):
 
     @mock.patch("random.getrandbits")
     def test_distrust_headers(self, getrandbits):
-        getrandbits.return_value = 1234
+        getrandbits.return_value = 9999
         self.baseplate_configurator.header_trust_handler.trust_headers = False
 
         self.test_app.get(
@@ -230,9 +230,9 @@ class ConfiguratorTests(unittest.TestCase):
         )
 
         context, server_span = self.observer.on_server_span_created.call_args[0]
-        self.assertEqual(server_span.trace_id, getrandbits.return_value)
+        self.assertEqual(server_span.trace_id, str(getrandbits.return_value))
         self.assertEqual(server_span.parent_id, None)
-        self.assertEqual(server_span.id, getrandbits.return_value)
+        self.assertEqual(server_span.id, str(getrandbits.return_value))
 
     def test_local_trace_in_context(self):
         self.test_app.get("/trace_context")

--- a/tests/integration/thrift_tests.py
+++ b/tests/integration/thrift_tests.py
@@ -96,7 +96,7 @@ def baseplate_thrift_client(endpoint, client_spec, client_span_observer=None):
 
     context = baseplate.make_context_object()
     trace_info = TraceInfo.from_upstream(
-        trace_id=1234, parent_id=2345, span_id=3456, flags=4567, sampled=True
+        trace_id="1234", parent_id="2345", span_id="3456", flags=4567, sampled=True
     )
 
     baseplate.configure_context({"example_service": ThriftClient(client_spec.Client)})
@@ -153,14 +153,14 @@ class ThriftTraceHeaderTests(GeventPatchedTestCase):
                 client_result = client.example()
 
         self.assertIsNotNone(handler.server_span)
-        self.assertGreaterEqual(handler.server_span.id, 0)
+        self.assertGreaterEqual(len(handler.server_span.id), 0)
         self.assertTrue(client_result)
 
     def test_header_propagation(self):
         """If the client sends headers, we should set the trace up accordingly."""
-        trace_id = 1234
-        parent_id = 2345
-        span_id = 3456
+        trace_id = "1234"
+        parent_id = "2345"
+        span_id = "3456"
         flags = 4567
         sampled = 1
 
@@ -177,9 +177,9 @@ class ThriftTraceHeaderTests(GeventPatchedTestCase):
         with serve_thrift(handler, TestService) as server:
             with raw_thrift_client(server.endpoint, TestService) as client:
                 transport = client._oprot.trans
-                transport.set_header(b"Trace", str(trace_id).encode())
-                transport.set_header(b"Parent", str(parent_id).encode())
-                transport.set_header(b"Span", str(span_id).encode())
+                transport.set_header(b"Trace", trace_id.encode())
+                transport.set_header(b"Parent", parent_id.encode())
+                transport.set_header(b"Span", span_id.encode())
                 transport.set_header(b"Flags", str(flags).encode())
                 transport.set_header(b"Sampled", str(sampled).encode())
                 client_result = client.example()
@@ -194,9 +194,9 @@ class ThriftTraceHeaderTests(GeventPatchedTestCase):
 
     def test_optional_headers_optional(self):
         """Test that we accept traces from clients that don't include all headers."""
-        trace_id = 1234
-        parent_id = 2345
-        span_id = 3456
+        trace_id = "1234"
+        parent_id = "2345"
+        span_id = "3456"
 
         class Handler(TestService.Iface):
             def __init__(self):
@@ -211,9 +211,9 @@ class ThriftTraceHeaderTests(GeventPatchedTestCase):
         with serve_thrift(handler, TestService) as server:
             with raw_thrift_client(server.endpoint, TestService) as client:
                 transport = client._oprot.trans
-                transport.set_header(b"Trace", str(trace_id).encode())
-                transport.set_header(b"Parent", str(parent_id).encode())
-                transport.set_header(b"Span", str(span_id).encode())
+                transport.set_header(b"Trace", trace_id.encode())
+                transport.set_header(b"Parent", parent_id.encode())
+                transport.set_header(b"Span", span_id.encode())
                 client_result = client.example()
 
         self.assertIsNotNone(handler.server_span)

--- a/tests/unit/core_tests.py
+++ b/tests/unit/core_tests.py
@@ -184,7 +184,7 @@ class ServerSpanTests(unittest.TestCase):
         child_span = server_span.make_child("child_name")
 
         self.assertEqual(child_span.name, "child_name")
-        self.assertEqual(child_span.id, 0xCAFE)
+        self.assertEqual(child_span.id, "51966")
         self.assertEqual(child_span.trace_id, "trace")
         self.assertEqual(child_span.parent_id, "id")
         self.assertEqual(mock_observer.on_child_span_created.call_count, 1)
@@ -214,7 +214,7 @@ class ServerSpanTests(unittest.TestCase):
         local_span = server_span.make_child("test_op", local=True, component_name="test_component")
 
         self.assertEqual(local_span.name, "test_op")
-        self.assertEqual(local_span.id, 0xCAFE)
+        self.assertEqual(local_span.id, "51966")
         self.assertEqual(local_span.trace_id, "trace")
         self.assertEqual(local_span.parent_id, "id")
         self.assertEqual(mock_observer.on_child_span_created.call_count, 1)
@@ -267,7 +267,7 @@ class LocalSpanTests(unittest.TestCase):
         child_span = local_span.make_child("child_name")
 
         self.assertEqual(child_span.name, "child_name")
-        self.assertEqual(child_span.id, 0xCAFE)
+        self.assertEqual(child_span.id, "51966")
         self.assertEqual(child_span.trace_id, "trace")
         self.assertEqual(child_span.parent_id, "id")
         self.assertEqual(mock_observer.on_child_span_created.call_count, 1)


### PR DESCRIPTION
This will allow us, once fully rolled out, to upgrade to larger trace
IDs to avoid collisions and work better with other systems.