### PR TITLE
tagged metrics: Fix tagging on multi-part client names

### DIFF
--- a/baseplate/observers/metrics_tagged.py
+++ b/baseplate/observers/metrics_tagged.py
@@ -191,8 +191,7 @@ class TaggedMetricsClientSpanObserver(SpanObserver):
 
     def on_start(self) -> None:
         self.timer.start(self.sample_rate)
-        self.tags["client"] = self.span.name.split(".")[0]
-        self.tags["endpoint"] = self.span.name.split(".")[1]
+        self.tags["client"], _, self.tags["endpoint"] = self.span.name.rpartition(".")
 
     def on_incr_tag(self, key: str, delta: float) -> None:
         self.counters[key] = delta


### PR DESCRIPTION
```python
baseplate.configure_context({
    "foo": {
        "bar": ThriftClient(...),
    },
})
```

would generate span names like `foo.bar.is_healthy` which we'd want to turn into tags as `client=foo.bar` + `endpoint=is_healthy` but instead we're doing it as `client=foo` + `endpoint=bar` which is not great!
