### PR TITLE
Make server_timeout.default optional again

### DIFF
--- a/baseplate/observers/timeout.py
+++ b/baseplate/observers/timeout.py
@@ -28,7 +28,9 @@ class TimeoutBaseplateObserver(BaseplateObserver):
             app_config,
             {
                 "server_timeout": {
-                    "default": config.TimespanOrInfinite,
+                    "default": config.Optional(
+                        config.TimespanOrInfinite, default=config.InfiniteTimespan,
+                    ),
                     "debug": config.Optional(config.Boolean, default=False),
                     "by_endpoint": config.DictOf(config.TimespanOrInfinite),
                 }


### PR DESCRIPTION
For consumers etc. it's just too annoying to have to set this
everywhere.