### PR TITLE
Sidecar stability improvements

### DIFF
--- a/baseplate/lib/metrics.py
+++ b/baseplate/lib/metrics.py
@@ -112,7 +112,10 @@ class NullTransport(Transport):
 class RawTransport(Transport):
     """A transport which sends messages on a socket."""
 
-    def __init__(self, endpoint: config.EndpointConfiguration):
+    def __init__(
+        self, endpoint: config.EndpointConfiguration, swallow_network_errors: bool = False,
+    ):
+        self.swallow_network_errors = swallow_network_errors
         self.socket = socket.socket(endpoint.family, socket.SOCK_DGRAM)
         self.socket.connect(endpoint.address)
 
@@ -120,6 +123,9 @@ class RawTransport(Transport):
         try:
             self.socket.sendall(serialized_metric)
         except socket.error as exc:
+            if self.swallow_network_errors:
+                logger.exception("Failed to send to metrics collector")
+                return
             if exc.errno == errno.EMSGSIZE:
                 raise MessageTooBigTransportError(len(serialized_metric))
             raise TransportError(exc)
@@ -517,13 +523,18 @@ class Gauge:
 
 
 def make_client(
-    namespace: str, endpoint: config.EndpointConfiguration, log_if_unconfigured: bool
+    namespace: str,
+    endpoint: config.EndpointConfiguration,
+    log_if_unconfigured: bool,
+    swallow_network_errors: bool = False,
 ) -> Client:
     """Return a configured client.
 
     :param namespace: The root key to prefix all metrics with.
     :param endpoint: The endpoint to send metrics to or :py:data:`None`.  If
         :py:data:`None`, the returned client will discard all metrics.
+    :param swallow_network_errors: Swallow (log) network errors during sending
+        to metrics collector.
     :return: A configured client.
 
     .. seealso:: :py:func:`baseplate.lib.metrics.metrics_client_from_config`.
@@ -532,7 +543,7 @@ def make_client(
     transport: Transport
 
     if endpoint:
-        transport = RawTransport(endpoint)
+        transport = RawTransport(endpoint, swallow_network_errors=swallow_network_errors)
     else:
         transport = NullTransport(log_if_unconfigured)
     return Client(transport, namespace)
@@ -551,6 +562,11 @@ def metrics_client_from_config(raw_config: config.RawConfig) -> Client:
     `metrics.log_if_unconfigured``
         Whether to log metrics when there is no unconfigured endpoint.
         Defaults to false.
+    `metrics.swallow_network_errors``
+        When false, network errors during sending to metrics collector will
+        cause an exception to be thrown. When true, those exceptions are logged
+        and swallowed instead.
+        Defaults to false.
 
     :param raw_config: The application configuration which should have
         settings for the metrics client.
@@ -564,6 +580,7 @@ def metrics_client_from_config(raw_config: config.RawConfig) -> Client:
                 "namespace": config.Optional(config.String, default=""),
                 "endpoint": config.Optional(config.Endpoint),
                 "log_if_unconfigured": config.Optional(config.Boolean, default=False),
+                "swallow_network_errors": config.Optional(config.Boolean, default=False),
             }
         },
     )

--- a/baseplate/sidecars/trace_publisher.py
+++ b/baseplate/sidecars/trace_publisher.py
@@ -99,9 +99,10 @@ class ZipkinPublisher:
                 response = getattr(exc, "response", None)
                 if response is not None:
                     logger.exception("HTTP Request failed. Error: %s", response.text)
-                    # If client error, crash
+                    # If client error, skip retries
                     if response.status_code < 500:
-                        raise
+                        self.metrics.counter("error.http.client").increment()
+                        return
                 else:
                     logger.exception("HTTP Request failed. Response not available")
             except OSError:

--- a/tests/unit/observers/tracing/publisher_tests.py
+++ b/tests/unit/observers/tracing/publisher_tests.py
@@ -32,14 +32,3 @@ class ZipkinPublisherTest(unittest.TestCase):
         spans = b"[]"
         self.publisher.publish(SerializedBatch(item_count=1, serialized=spans))
         self.assertEqual(self.session.post.call_count, 3)
-
-    def test_client_error(self):
-        self.session.post.side_effect = [
-            requests.HTTPError(400, response=mock.Mock(status_code=400))
-        ]
-        spans = b"[]"
-
-        with self.assertRaises(requests.HTTPError):
-            self.publisher.publish(SerializedBatch(item_count=1, serialized=spans))
-
-        self.assertEqual(self.session.post.call_count, 1)


### PR DESCRIPTION
When the sidecar crashes (unhandled exceptions) it will cause the whole
service to be restarted by k8s, so this change improves sidecar
stability to reduce crashes:

1. In metrics client, add swallow_network_errors option to log and
   swallow the network errors instead of raising them.
2. In trace publishing sidecar, do not raise client errors, but also
   skip retries for those errors.