### PR TITLE
Add deadline-budget to thrift servers

### DIFF
--- a/baseplate/frameworks/thrift/__init__.py
+++ b/baseplate/frameworks/thrift/__init__.py
@@ -103,10 +103,11 @@ def baseplateify_processor(
             if edge_context_factory:
                 context.edge_context = edge_context_factory.from_upstream(edge_payload)
 
-            deadline_budget = headers.get(b"Deadline-Budget", None)
-            context.deadline_budget = (
-                float(deadline_budget.decode()) / 1000 if deadline_budget else None
-            )
+            try:
+                raw_deadline_budget = headers[b"Deadline-Budget"].decode()
+                context.deadline_budget = float(raw_deadline_budget) / 1000
+            except (KeyError, ValueError):
+                context.deadline_budget = None
 
             span = baseplate.make_server_span(context, name=fn_name, trace_info=trace_info)
 

--- a/baseplate/frameworks/thrift/__init__.py
+++ b/baseplate/frameworks/thrift/__init__.py
@@ -103,6 +103,11 @@ def baseplateify_processor(
             if edge_context_factory:
                 context.edge_context = edge_context_factory.from_upstream(edge_payload)
 
+            deadline_budget = headers.get(b"Deadline-Budget", None)
+            context.deadline_budget = (
+                float(deadline_budget.decode()) / 1000 if deadline_budget else None
+            )
+
             span = baseplate.make_server_span(context, name=fn_name, trace_info=trace_info)
 
             try:

--- a/baseplate/observers/timeout.py
+++ b/baseplate/observers/timeout.py
@@ -47,10 +47,11 @@ class TimeoutBaseplateObserver(BaseplateObserver):
         min_timeout = None
         if timeout is not config.InfiniteTimespan:
             min_timeout = timeout.total_seconds()
+
         try:
             deadline_budget = context.deadline_budget
             if deadline_budget:
-                if not min_timeout or deadline_budget < timeout.total_seconds():
+                if not min_timeout or deadline_budget < min_timeout:
                     min_timeout = deadline_budget
         except AttributeError:
             # no deadline budget in request header

--- a/baseplate/observers/timeout.py
+++ b/baseplate/observers/timeout.py
@@ -43,10 +43,6 @@ class TimeoutBaseplateObserver(BaseplateObserver):
 
     def on_server_span_created(self, context: RequestContext, server_span: ServerSpan) -> None:
         timeout = self.config.by_endpoint.get(server_span.name, self.config.default)
-        try:
-            deadline_budget = context.deadline_budget
-        except AttributeError:
-            deadline_budget = None
 
         min_timeout = None
         if timeout is not config.InfiniteTimespan:

--- a/baseplate/observers/timeout.py
+++ b/baseplate/observers/timeout.py
@@ -43,10 +43,25 @@ class TimeoutBaseplateObserver(BaseplateObserver):
 
     def on_server_span_created(self, context: RequestContext, server_span: ServerSpan) -> None:
         timeout = self.config.by_endpoint.get(server_span.name, self.config.default)
+        try:
+            deadline_budget = context.deadline_budget
+        except AttributeError:
+            deadline_budget = None
+
+        min_timeout = None
         if timeout is not config.InfiniteTimespan:
-            observer = TimeoutServerSpanObserver(
-                server_span, timeout.total_seconds(), self.config.debug
-            )
+            min_timeout = timeout.total_seconds()
+        try:
+            deadline_budget = context.deadline_budget
+            if deadline_budget:
+                if not min_timeout or deadline_budget < timeout.total_seconds():
+                    min_timeout = deadline_budget
+        except AttributeError:
+            # no deadline budget in request header
+            pass
+
+        if min_timeout:
+            observer = TimeoutServerSpanObserver(server_span, min_timeout, self.config.debug)
             server_span.register(observer)
 
 

--- a/tests/integration/thrift_tests.py
+++ b/tests/integration/thrift_tests.py
@@ -6,6 +6,7 @@ from importlib import reload
 from unittest import mock
 
 import gevent.monkey
+import pytest
 
 from thrift.Thrift import TApplicationException
 
@@ -18,6 +19,8 @@ from baseplate.clients.thrift import ThriftClient
 from baseplate.frameworks.thrift import baseplateify_processor
 from baseplate.lib import config
 from baseplate.lib.thrift_pool import ThriftConnectionPool
+from baseplate.observers.timeout import ServerTimeout
+from baseplate.observers.timeout import TimeoutBaseplateObserver
 from baseplate.server import make_listener
 from baseplate.server.thrift import make_server
 from baseplate.thrift import BaseplateService
@@ -30,9 +33,10 @@ from .test_thrift import TestService
 
 
 @contextlib.contextmanager
-def serve_thrift(handler, server_spec, server_span_observer=None):
+def serve_thrift(handler, server_spec, server_span_observer=None, baseplate_observer=None):
     # create baseplate root
     baseplate = Baseplate()
+
     if server_span_observer:
 
         class TestBaseplateObserver(BaseplateObserver):
@@ -40,6 +44,9 @@ def serve_thrift(handler, server_spec, server_span_observer=None):
                 server_span.register(server_span_observer)
 
         baseplate.register(TestBaseplateObserver())
+
+    if baseplate_observer:
+        baseplate.register(baseplate_observer)
 
     # set up the server's processor
     logger = mock.Mock(spec=logging.Logger)
@@ -455,7 +462,7 @@ class ThriftEndToEndTests(GeventPatchedTestCase):
                     svc.example()
 
         # this should be 1 second (1000 ms)
-        assert handler.context.headers.get(b"Deadline-Budget").decode() == str(1000)
+        assert handler.context.deadline_budget == 1.0  # pool timeout seconds
 
     def test_budget_header_retry_timeout(self):
         """Test that the budget header is set in the headers with the retry timeout."""
@@ -478,9 +485,7 @@ class ThriftEndToEndTests(GeventPatchedTestCase):
                 ) as svc:
                     svc.example()
 
-        assert handler.context.headers.get(b"Deadline-Budget").decode() == str(
-            int(retry_timeout_seconds * 1000)
-        )
+        assert handler.context.deadline_budget == retry_timeout_seconds
 
     def test_budget_header_budget_and_backoff(self):
         """Test that the budget header is set in the headers with the backoff timeout."""
@@ -504,9 +509,35 @@ class ThriftEndToEndTests(GeventPatchedTestCase):
                 ) as svc:
                     svc.example()
 
-        assert handler.context.headers.get(b"Deadline-Budget").decode() == str(
-            int(retry_timeout_seconds * 1000)
+        assert handler.context.deadline_budget == retry_timeout_seconds
+
+    def test_budget_timeout_from_client(self):
+        """Test that the server times out when passed a short timeout from the client."""
+        retry_timeout_seconds = 0.25
+
+        class Handler(TestService.Iface):
+            def example(self, context):
+                self.context = context
+                with pytest.raises(ServerTimeout):
+                    gevent.sleep(1)
+                return True
+
+        handler = Handler()
+
+        span_observer = mock.Mock(spec=SpanObserver)
+        timeout_observer = TimeoutBaseplateObserver.from_config(
+            {"server_timeout.default": "1 hour"}
         )
+        with serve_thrift(handler, TestService, baseplate_observer=timeout_observer) as server:
+            with baseplate_thrift_client(
+                server.endpoint, TestService, span_observer, timeout="1000 seconds"
+            ) as context:
+                with context.example_service.retrying(
+                    attempts=3, budget=retry_timeout_seconds
+                ) as svc:
+                    svc.example()
+
+        assert handler.context.deadline_budget == retry_timeout_seconds
 
 
 class ThriftHealthcheck(GeventPatchedTestCase):

--- a/tests/integration/thrift_tests.py
+++ b/tests/integration/thrift_tests.py
@@ -461,8 +461,8 @@ class ThriftEndToEndTests(GeventPatchedTestCase):
                 ) as svc:
                     svc.example()
 
-        # this should be 1 second (1000 ms)
-        assert handler.context.deadline_budget == 1.0  # pool timeout seconds
+        # this should be 1 second (1000 ms) for the pool timeout
+        self.assertAlmostEqual(handler.context.deadline_budget, 1.0)
 
     def test_budget_header_retry_timeout(self):
         """Test that the budget header is set in the headers with the retry timeout."""
@@ -485,7 +485,7 @@ class ThriftEndToEndTests(GeventPatchedTestCase):
                 ) as svc:
                     svc.example()
 
-        assert handler.context.deadline_budget == retry_timeout_seconds
+        self.assertAlmostEqual(handler.context.deadline_budget, retry_timeout_seconds)
 
     def test_budget_header_budget_and_backoff(self):
         """Test that the budget header is set in the headers with the backoff timeout."""
@@ -509,7 +509,7 @@ class ThriftEndToEndTests(GeventPatchedTestCase):
                 ) as svc:
                     svc.example()
 
-        assert handler.context.deadline_budget == retry_timeout_seconds
+        self.assertAlmostEqual(handler.context.deadline_budget, retry_timeout_seconds)
 
     def test_budget_timeout_from_client(self):
         """Test that the server times out when passed a short timeout from the client."""
@@ -537,7 +537,7 @@ class ThriftEndToEndTests(GeventPatchedTestCase):
                 ) as svc:
                     svc.example()
 
-        assert handler.context.deadline_budget == retry_timeout_seconds
+        self.assertAlmostEqual(handler.context.deadline_budget, retry_timeout_seconds)
 
 
 class ThriftHealthcheck(GeventPatchedTestCase):

--- a/tests/integration/timeout_tests.py
+++ b/tests/integration/timeout_tests.py
@@ -6,12 +6,16 @@ from baseplate.observers.timeout import ServerTimeout
 from baseplate.observers.timeout import TimeoutBaseplateObserver
 
 
-def test_default_timeout():
+def _create_baseplate_object(timeout: str):
     baseplate = Baseplate()
 
-    observer = TimeoutBaseplateObserver.from_config({"server_timeout.default": "50 milliseconds"})
+    observer = TimeoutBaseplateObserver.from_config({"server_timeout.default": timeout})
     baseplate.register(observer)
+    return baseplate
 
+
+def test_default_timeout():
+    baseplate = _create_baseplate_object("50 milliseconds")
     context = baseplate.make_context_object()
     with baseplate.make_server_span(context, "test"):
         with pytest.raises(ServerTimeout):
@@ -23,13 +27,7 @@ def test_default_timeout():
 
 
 def test_route_specific_timeout():
-    baseplate = Baseplate()
-
-    observer = TimeoutBaseplateObserver.from_config(
-        {"server_timeout.default": "1 hour", "server_timeout.by_endpoint.test": "5 milliseconds"}
-    )
-    baseplate.register(observer)
-
+    baseplate = _create_baseplate_object("5 milliseconds")
     context = baseplate.make_context_object()
     with baseplate.make_server_span(context, "test"):
         with pytest.raises(ServerTimeout):
@@ -37,4 +35,31 @@ def test_route_specific_timeout():
 
     context = baseplate.make_context_object()
     with baseplate.make_server_span(context, "test"):
-        gevent.sleep(0)  # shouldn't time out since it's so fast!
+        gevent.sleep(0)  #
+
+
+def test_timeout_from_context():
+    baseplate = _create_baseplate_object("1 hour")
+    baseplate.add_to_context("deadline_budget", 0.01)
+
+    # tests short deadline_budget causes timeout
+    context = baseplate.make_context_object()
+    with baseplate.make_server_span(context, "test"):
+        with pytest.raises(ServerTimeout):
+            gevent.sleep(1)
+
+    # tests long deadline_budget and server timeout doesn't timeout
+    context = baseplate.make_context_object()
+    baseplate.add_to_context("deadline_budget", 1000)
+    with baseplate.make_server_span(context, "test"):
+        gevent.sleep(0.01)  # shouldn't time out since timeouts are so long
+
+
+def test_pool_timeout_with_long_deadline_budget():
+    baseplate = _create_baseplate_object("5 milliseconds")
+    baseplate.add_to_context("deadline_budget", 1000)
+
+    context = baseplate.make_context_object()
+    with baseplate.make_server_span(context, "test"):
+        with pytest.raises(ServerTimeout):
+            gevent.sleep(0.01)

--- a/tests/integration/timeout_tests.py
+++ b/tests/integration/timeout_tests.py
@@ -35,7 +35,7 @@ def test_route_specific_timeout():
 
     context = baseplate.make_context_object()
     with baseplate.make_server_span(context, "test"):
-        gevent.sleep(0)  #
+        gevent.sleep(0)
 
 
 def test_timeout_from_context():


### PR DESCRIPTION
Following the changes from https://github.com/reddit/baseplate.py/pull/574, this adds `Deadline-Budget` server side so it can use the value that is passed from the client header.