### PR TITLE
Issue 575 fix no content exceptions

### DIFF
--- a/baseplate/frameworks/pyramid/__init__.py
+++ b/baseplate/frameworks/pyramid/__init__.py
@@ -2,6 +2,7 @@ import base64
 import logging
 import sys
 
+from itertools import chain
 from typing import Any
 from typing import Callable
 from typing import Dict

--- a/baseplate/frameworks/pyramid/__init__.py
+++ b/baseplate/frameworks/pyramid/__init__.py
@@ -82,7 +82,13 @@ def _make_baseplate_tween(
             if request.span:
                 request.span.set_tag("http.status_code", response.status_code)
                 if hasattr(response, "explanation") and response.explanation:
-                    response.app_iter = SpanFinishingAppIterWrapper(request.span, chain(response.app_iter, [str.encode(response._status), str.encode(response.explanation)]))
+                    response.app_iter = SpanFinishingAppIterWrapper(
+                        request.span,
+                        chain(
+                            response.app_iter,
+                            [str.encode(response._status), str.encode(response.explanation)],
+                        ),
+                    )
                 else:
                     response.app_iter = SpanFinishingAppIterWrapper(request.span, response.app_iter)
         finally:

--- a/baseplate/frameworks/pyramid/__init__.py
+++ b/baseplate/frameworks/pyramid/__init__.py
@@ -81,7 +81,10 @@ def _make_baseplate_tween(
         else:
             if request.span:
                 request.span.set_tag("http.status_code", response.status_code)
-                response.app_iter = SpanFinishingAppIterWrapper(request.span, response.app_iter)
+                if hasattr(response, "explanation") and response.explanation:
+                    response.app_iter = SpanFinishingAppIterWrapper(request.span, chain(response.app_iter, [str.encode(response._status), str.encode(response.explanation)]))
+                else:
+                    response.app_iter = SpanFinishingAppIterWrapper(request.span, response.app_iter)
         finally:
             # avoid a reference cycle
             request.start_server_span = None

--- a/tests/integration/pyramid_tests.py
+++ b/tests/integration/pyramid_tests.py
@@ -19,6 +19,7 @@ try:
     from baseplate.frameworks.pyramid import ServerSpanInitialized
     from baseplate.frameworks.pyramid import StaticTrustHandler
     from pyramid.config import Configurator
+    from pyramid.httpexceptions import HTTPNotImplemented
 except ImportError:
     raise unittest.SkipTest("pyramid/webtest is not installed")
 
@@ -61,7 +62,7 @@ def example_application(request):
 
 
 def render_exception_view(request):
-    return
+    return HTTPNotImplemented(title="a fancy title", explanation="a fancy explanation")
 
 
 def render_bad_exception_view(request):
@@ -202,11 +203,12 @@ class ConfiguratorTests(unittest.TestCase):
         self.assertIsInstance(captured_exc, TestException)
 
     def test_control_flow_exception_not_caught(self):
-        self.test_app.get("/example?control_flow_exception")
+        response = self.test_app.get("/example?control_flow_exception", status=501)
 
         self.assertTrue(self.server_observer.on_start.called)
         self.assertTrue(self.server_observer.on_finish.called)
         self.assertTrue(self.context_init_event_subscriber.called)
+        self.assertIn(b"a fancy explanation", response.body)
         args, _ = self.server_observer.on_finish.call_args
         self.assertEqual(args[0], None)
 


### PR DESCRIPTION
This is a fairly hacky fix, but it does resolve the immediate issue.

AFAICT, the root issue is that the app_iter does not have the custom content in it so when it builds the response body it renders nothing. However, the default app_iter does is able to get that information somehow when it builds the response body from the app_iter.

A better solution might be to include the response object in the custom app_iter and checking for custom properties on the response once we're done iterating over the app_iter.