### PR TITLE
Add comment to requirements.txt to reduce confusion

### DIFF
--- a/requirements-transitive.txt
+++ b/requirements-transitive.txt
@@ -1,3 +1,8 @@
+# This file is just used to set up baseplate.py's test environment. It is not
+# indicative of the versions you must use in your applications.
+#
+# See install_requires and extras_require in setup.py for the range of versions
+# supported.
 advocate==1.0.0
 alabaster==0.7.12
 amqp==2.6.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,8 @@
+# This file is just used to set up baseplate.py's test environment. It is not
+# indicative of the versions you must use in your applications.
+#
+# See install_requires and extras_require in setup.py for the range of versions
+# supported.
 -r requirements-transitive.txt
 astroid==2.4.2
 black==19.10b0


### PR DESCRIPTION
We've had a few people think that these files tell them they must use those versions of given libraries. These files are just for the library's tests, not for its users. Hopefully this can help reduce confusion a bit.