### PR TITLE
Don't emit JSON logs to TTYs

### DIFF
--- a/baseplate/server/__init__.py
+++ b/baseplate/server/__init__.py
@@ -120,7 +120,7 @@ def configure_logging(config: Configuration, debug: bool) -> None:
         logging_level = logging.INFO
 
     formatter: logging.Formatter
-    if not sys.stdout.isatty():
+    if not sys.stdin.isatty():
         formatter = CustomJsonFormatter(
             "%(levelname)s %(message)s %(funcName)s %(lineno)d %(module)s %(name)s %(pathname)s %(process)d %(processName)s %(thread)d %(threadName)s"
         )

--- a/baseplate/server/__init__.py
+++ b/baseplate/server/__init__.py
@@ -119,9 +119,13 @@ def configure_logging(config: Configuration, debug: bool) -> None:
     else:
         logging_level = logging.INFO
 
-    formatter = CustomJsonFormatter(
-        "%(levelname)s %(message)s %(funcName)s %(lineno)d %(module)s %(name)s %(pathname)s %(process)d %(processName)s %(thread)d %(threadName)s"
-    )
+    formatter: logging.Formatter
+    if not sys.stdout.isatty():
+        formatter = CustomJsonFormatter(
+            "%(levelname)s %(message)s %(funcName)s %(lineno)d %(module)s %(name)s %(pathname)s %(process)d %(processName)s %(thread)d %(threadName)s"
+        )
+    else:
+        formatter = logging.Formatter("%(levelname)-8s %(message)s")
 
     handler = logging.StreamHandler()
     handler.setFormatter(formatter)

--- a/docs/api/baseplate/observers/logging.rst
+++ b/docs/api/baseplate/observers/logging.rst
@@ -20,9 +20,15 @@ controlled with :ref:`Python's standard logging configuration
 Outputs
 -------
 
-When used with :program:`baseplate-serve`, log entries are formatted as JSON
-objects that can be parsed automatically by log analysis systems. Log entry
-objects contain the following keys:
+The :program:`baseplate-serve` command will automatically set up log
+formatting.
+
+When directly used from a TTY, a simplified human-readable message format is
+emitted. Only the level and message are included.
+
+In production usage, log entries are formatted as JSON objects that can be
+parsed automatically by log analysis systems. Log entry objects contain the
+following keys:
 
 ``message``
    The message.


### PR DESCRIPTION
It's super annoying to try and read the JSON and we can reasonably
assume it's a human watching when stdout is a TTY.