### PR TITLE
Support SQLAlchemy 1.4

### DIFF
--- a/baseplate/clients/sqlalchemy.py
+++ b/baseplate/clients/sqlalchemy.py
@@ -91,8 +91,14 @@ def engine_from_config(
         if not secrets:
             raise TypeError("'secrets' is required if 'credentials_secret' is set")
         credentials = secrets.get_credentials(options.credentials_secret)
-        url.username = credentials.username
-        url.password = credentials.password
+
+        # support sqlalchemy 1.4+ where URL is immutable
+        # https://docs.sqlalchemy.org/en/14/changelog/migration_14.html#the-url-object-is-now-immutable
+        if hasattr(url, "set"):
+            url = url.set(username=credentials.username, password=credentials.password)
+        else:
+            url.username = credentials.username
+            url.password = credentials.password
 
     return create_engine(url, **kwargs)
 

--- a/requirements-transitive.txt
+++ b/requirements-transitive.txt
@@ -73,7 +73,7 @@ sphinxcontrib-htmlhelp==1.0.3
 sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.4
-SQLAlchemy==1.3.23
+SQLAlchemy==1.4.12
 thrift-unofficial==0.14.1
 toml==0.10.2
 translationstring==1.4


### PR DESCRIPTION
Note that users should read the SQLAlchemy migration docs before
upgrading as this is a significant change in preparation for their 2.0
release.

https://docs.sqlalchemy.org/en/14/changelog/migration_14.html