### PR TITLE
Add timeouts to HTTP requests for DVP-92

### DIFF
--- a/baseplate/sidecars/secrets_fetcher.py
+++ b/baseplate/sidecars/secrets_fetcher.py
@@ -107,9 +107,7 @@ def fetch_instance_identity() -> str:
 
     """
     logger.debug("Fetching identity.")
-    resp = requests.get(
-        "http://169.254.169.254/latest/dynamic/instance-identity/pkcs7",
-        timeout=5)
+    resp = requests.get("http://169.254.169.254/latest/dynamic/instance-identity/pkcs7", timeout=5)
     resp.raise_for_status()
     return resp.text
 

--- a/baseplate/sidecars/secrets_fetcher.py
+++ b/baseplate/sidecars/secrets_fetcher.py
@@ -107,7 +107,9 @@ def fetch_instance_identity() -> str:
 
     """
     logger.debug("Fetching identity.")
-    resp = requests.get("http://169.254.169.254/latest/dynamic/instance-identity/pkcs7")
+    resp = requests.get(
+        "http://169.254.169.254/latest/dynamic/instance-identity/pkcs7",
+        timeout=5)
     resp.raise_for_status()
     return resp.text
 
@@ -300,6 +302,7 @@ class VaultClient:
             response = self.session.get(
                 urllib.parse.urljoin(self.base_url, posixpath.join("v1", secret_name)),
                 headers={"X-Vault-Token": self.token},
+                timeout=5,  # seconds
             )
             response.raise_for_status()
         except requests.HTTPError as e:


### PR DESCRIPTION
This is a probable fix for secrets-fetcher sidecars sometimes hanging
and causing spinnaker deploys to fail.  The Requests library by default
will not apply a timeout, and so will happily wait forever if there is
no HTTP response.