### PR TITLE
Update docstring to use read_file

### DIFF
--- a/baseplate/lib/config.py
+++ b/baseplate/lib/config.py
@@ -24,7 +24,7 @@ server, The ``config_parser.items(...)`` step is taken care of for you and
     from baseplate import config
     from tempfile import NamedTemporaryFile
     config_parser = configparser.RawConfigParser()
-    config_parser.readfp(open("docs/config_example.ini"))
+    config_parser.read_file(open("docs/config_example.ini"))
 
     tempfile = NamedTemporaryFile()
     tempfile.write(b"cool")
@@ -540,7 +540,7 @@ class DictOf(Parser[ConfigNamespace]):
         import configparser
         from baseplate import config
         config_parser = configparser.RawConfigParser()
-        config_parser.readfp(open("docs/config_dictof_example.ini"))
+        config_parser.read_file(open("docs/config_dictof_example.ini"))
         raw_config = dict(config_parser.items("app:main"))
 
     .. doctest:: dictof_simple
@@ -570,7 +570,7 @@ class DictOf(Parser[ConfigNamespace]):
         import configparser
         from baseplate import config
         config_parser = configparser.RawConfigParser()
-        config_parser.readfp(open("docs/config_dictof_spec_example.ini"))
+        config_parser.read_file(open("docs/config_dictof_spec_example.ini"))
         raw_config = dict(config_parser.items("app:main"))
 
     .. doctest:: dictof_spec


### PR DESCRIPTION
# Description
`configparser.readfp` has been deprecated and it is recommended to use `read_file` instead. This simply updates the docstrings/doctests  to use the  recommended method.

[Reference](https://docs.python.org/3/library/configparser.html#configparser.ConfigParser.readfp) 

Tested locally using:
```
 docker-compose run baseplate make test
```