### PR TITLE
Fix local span metrics observers registering child observers

### DIFF
--- a/baseplate/observers/metrics.py
+++ b/baseplate/observers/metrics.py
@@ -124,6 +124,14 @@ class MetricsLocalSpanObserver(SpanObserver):
     def on_incr_tag(self, key: str, delta: float) -> None:
         self.batch.counter(key).increment(delta, sample_rate=self.sample_rate)
 
+    def on_child_span_created(self, span: Span) -> None:
+        observer: SpanObserver
+        if isinstance(span, LocalSpan):
+            observer = MetricsLocalSpanObserver(self.batch, span, self.sample_rate)
+        else:
+            observer = MetricsClientSpanObserver(self.batch, span, self.sample_rate)
+        span.register(observer)
+
     def on_finish(self, exc_info: Optional[_ExcInfo]) -> None:
         self.timer.stop()
 

--- a/baseplate/observers/metrics_tagged.py
+++ b/baseplate/observers/metrics_tagged.py
@@ -160,6 +160,18 @@ class TaggedMetricsLocalSpanObserver(SpanObserver):
     def on_set_tag(self, key: str, value: Any) -> None:
         self.tags[key] = value
 
+    def on_child_span_created(self, span: Span) -> None:
+        observer: SpanObserver
+        if isinstance(span, LocalSpan):
+            observer = TaggedMetricsLocalSpanObserver(
+                self.batch, span, self.allowlist, self.sample_rate
+            )
+        else:
+            observer = TaggedMetricsClientSpanObserver(
+                self.batch, span, self.allowlist, self.sample_rate
+            )
+        span.register(observer)
+
     def on_finish(self, exc_info: Optional[_ExcInfo]) -> None:
         filtered_tags = {k: v for (k, v) in self.tags.items() if k in self.allowlist}
 

--- a/tests/unit/observers/metrics_tests.py
+++ b/tests/unit/observers/metrics_tests.py
@@ -120,3 +120,19 @@ class LocalSpanObserverTests(unittest.TestCase):
 
         observer.on_finish(exc_info=None)
         self.assertEqual(mock_timer.stop.call_count, 1)
+
+    def test_spans_under_local_spans(self):
+        mock_batch = mock.Mock(spec=Batch)
+
+        mock_local_span = mock.Mock(spec=LocalSpan)
+        mock_local_span.name = "example"
+        mock_local_span.component_name = "some_component"
+
+        mock_nested_span = mock.Mock(spec=LocalSpan)
+        mock_nested_span.name = "nested"
+        mock_nested_span.component_name = "some_component2"
+
+        observer = MetricsLocalSpanObserver(mock_batch, mock_local_span)
+        observer.on_child_span_created(mock_nested_span)
+
+        self.assertEqual(mock_nested_span.register.call_count, 1)


### PR DESCRIPTION
This fixes an issue where the local span metrics observers (tagged and
untagged) would not register child observers when nesting spans beneath
local spans.