### PR TITLE
Fix local span metrics observers registering child observers (#592)

### DIFF
--- a/baseplate/observers/metrics.py
+++ b/baseplate/observers/metrics.py
@@ -124,6 +124,14 @@ class MetricsLocalSpanObserver(SpanObserver):
     def on_incr_tag(self, key: str, delta: float) -> None:
         self.batch.counter(key).increment(delta, sample_rate=self.sample_rate)
 
+    def on_child_span_created(self, span: Span) -> None:
+        observer: SpanObserver
+        if isinstance(span, LocalSpan):
+            observer = MetricsLocalSpanObserver(self.batch, span, self.sample_rate)
+        else:
+            observer = MetricsClientSpanObserver(self.batch, span, self.sample_rate)
+        span.register(observer)
+
     def on_finish(self, exc_info: Optional[_ExcInfo]) -> None:
         self.timer.stop()
 

--- a/baseplate/observers/metrics_tagged.py
+++ b/baseplate/observers/metrics_tagged.py
@@ -183,11 +183,11 @@ class TaggedMetricsLocalSpanObserver(SpanObserver):
         observer: SpanObserver
         if isinstance(span, LocalSpan):
             observer = TaggedMetricsLocalSpanObserver(
-                self.batch, span, self.allowlist, self.sample_rate
+                self.batch, span, self.whitelist, self.sample_rate
             )
         else:
             observer = TaggedMetricsClientSpanObserver(
-                self.batch, span, self.allowlist, self.sample_rate
+                self.batch, span, self.whitelist, self.sample_rate
             )
         span.register(observer)
 

--- a/baseplate/observers/metrics_tagged.py
+++ b/baseplate/observers/metrics_tagged.py
@@ -179,6 +179,18 @@ class TaggedMetricsLocalSpanObserver(SpanObserver):
         else:
             self.tags[key] = value
 
+    def on_child_span_created(self, span: Span) -> None:
+        observer: SpanObserver
+        if isinstance(span, LocalSpan):
+            observer = TaggedMetricsLocalSpanObserver(
+                self.batch, span, self.allowlist, self.sample_rate
+            )
+        else:
+            observer = TaggedMetricsClientSpanObserver(
+                self.batch, span, self.allowlist, self.sample_rate
+            )
+        span.register(observer)
+
     def on_finish(self, exc_info: Optional[_ExcInfo]) -> None:
         filtered_tags = {k: v for (k, v) in self.tags.items() if k in self.whitelist}
         for key, delta in self.counters.items():

--- a/tests/unit/observers/metrics_tagged_tests.py
+++ b/tests/unit/observers/metrics_tagged_tests.py
@@ -1,8 +1,12 @@
 import unittest
 
+from typing import Any
+from typing import Dict
+from typing import Optional
 from unittest import mock
 
 from baseplate import LocalSpan
+from baseplate import RequestContext
 from baseplate import ServerSpan
 from baseplate import Span
 from baseplate.lib.metrics import Batch
@@ -197,6 +201,12 @@ class LocalSpanObserverTests(unittest.TestCase):
         self.assertFalse("error" in self.observer_empty_whitelist.tags)
         self.assertFalse("test" in self.observer_empty_whitelist.tags)
 
+    def test_on_child_span_created(self):
+        mock_child_span = mock.Mock()
+        mock_child_span.name = "example"
+        self.observer.on_child_span_created(mock_child_span)
+        self.assertEqual(mock_child_span.register.call_count, 1)
+
 
 class ClientSpanObserverTests(unittest.TestCase):
     def setUp(self):
@@ -271,3 +281,9 @@ class ClientSpanObserverTests(unittest.TestCase):
         self.observer.on_finish(exc_info=(ServerTimeout, ServerTimeout("timeout", 3.0, False)))
         self.assertFalse(self.observer.tags["success"])
         self.assertFalse("timed_out" in self.observer.tags)
+
+    def test_on_child_span_created(self):
+        mock_child_span = mock.Mock()
+        mock_child_span.name = "example"
+        self.observer.on_child_span_created(mock_child_span)
+        self.assertEqual(mock_child_span.register.call_count, 1)

--- a/tests/unit/observers/metrics_tagged_tests.py
+++ b/tests/unit/observers/metrics_tagged_tests.py
@@ -1,12 +1,8 @@
 import unittest
 
-from typing import Any
-from typing import Dict
-from typing import Optional
 from unittest import mock
 
 from baseplate import LocalSpan
-from baseplate import RequestContext
 from baseplate import ServerSpan
 from baseplate import Span
 from baseplate.lib.metrics import Batch

--- a/tests/unit/observers/metrics_tagged_tests.py
+++ b/tests/unit/observers/metrics_tagged_tests.py
@@ -277,9 +277,3 @@ class ClientSpanObserverTests(unittest.TestCase):
         self.observer.on_finish(exc_info=(ServerTimeout, ServerTimeout("timeout", 3.0, False)))
         self.assertFalse(self.observer.tags["success"])
         self.assertFalse("timed_out" in self.observer.tags)
-
-    def test_on_child_span_created(self):
-        mock_child_span = mock.Mock()
-        mock_child_span.name = "example"
-        self.observer.on_child_span_created(mock_child_span)
-        self.assertEqual(mock_child_span.register.call_count, 1)

--- a/tests/unit/observers/metrics_tests.py
+++ b/tests/unit/observers/metrics_tests.py
@@ -120,3 +120,19 @@ class LocalSpanObserverTests(unittest.TestCase):
 
         observer.on_finish(exc_info=None)
         self.assertEqual(mock_timer.stop.call_count, 1)
+
+    def test_spans_under_local_spans(self):
+        mock_batch = mock.Mock(spec=Batch)
+
+        mock_local_span = mock.Mock(spec=LocalSpan)
+        mock_local_span.name = "example"
+        mock_local_span.component_name = "some_component"
+
+        mock_nested_span = mock.Mock(spec=LocalSpan)
+        mock_nested_span.name = "nested"
+        mock_nested_span.component_name = "some_component2"
+
+        observer = MetricsLocalSpanObserver(mock_batch, mock_local_span)
+        observer.on_child_span_created(mock_nested_span)
+
+        self.assertEqual(mock_nested_span.register.call_count, 1)


### PR DESCRIPTION
This fixes an issue where the local span metrics observers (tagged and
untagged) would not register child observers when nesting spans beneath
local spans.

Backport of 10d5082760922312a8f1b35724a1315a3e65eaec