### PR TITLE
Add environment variable interpolation to config parser

### DIFF
--- a/baseplate/lib/live_data/writer.py
+++ b/baseplate/lib/live_data/writer.py
@@ -13,6 +13,7 @@ from kazoo.exceptions import NoNodeError
 
 from baseplate.lib.live_data.zookeeper import zookeeper_client_from_config
 from baseplate.lib.secrets import secrets_store_from_config
+from baseplate.server import EnvironmentInterpolation
 
 
 logger = logging.getLogger(__name__)
@@ -90,7 +91,7 @@ def main() -> None:
     # quiet kazoo's verbose logs a bit
     logging.getLogger("kazoo").setLevel(logging.WARNING)
 
-    parser = configparser.RawConfigParser()
+    parser = configparser.RawConfigParser(interpolation=EnvironmentInterpolation())
     parser.read_file(args.config_file)
     watcher_config = dict(parser.items("live-data"))
 

--- a/baseplate/sidecars/event_publisher.py
+++ b/baseplate/sidecars/event_publisher.py
@@ -21,6 +21,7 @@ from baseplate.lib.message_queue import MessageQueue
 from baseplate.lib.message_queue import TimedOutError
 from baseplate.lib.metrics import metrics_client_from_config
 from baseplate.lib.retry import RetryPolicy
+from baseplate.server import EnvironmentInterpolation
 from baseplate.sidecars import Batch
 from baseplate.sidecars import BatchFull
 from baseplate.sidecars import SerializedBatch
@@ -184,7 +185,7 @@ def publish_events() -> None:
         level = logging.WARNING
     logging.basicConfig(level=level)
 
-    config_parser = configparser.RawConfigParser()
+    config_parser = configparser.RawConfigParser(interpolation=EnvironmentInterpolation())
     config_parser.read_file(args.config_file)
     raw_config = dict(config_parser.items("event-publisher:" + args.queue_name))
     cfg = config.parse_config(

--- a/baseplate/sidecars/live_data_watcher.py
+++ b/baseplate/sidecars/live_data_watcher.py
@@ -16,6 +16,7 @@ from kazoo.protocol.states import ZnodeStat
 from baseplate.lib import config
 from baseplate.lib.live_data.zookeeper import zookeeper_client_from_config
 from baseplate.lib.secrets import secrets_store_from_config
+from baseplate.server import EnvironmentInterpolation
 
 
 logger = logging.getLogger(__name__)
@@ -102,7 +103,7 @@ def main() -> NoReturn:
     # quiet kazoo's verbose logs a bit
     logging.getLogger("kazoo").setLevel(logging.WARNING)
 
-    parser = configparser.RawConfigParser()
+    parser = configparser.RawConfigParser(interpolation=EnvironmentInterpolation())
     parser.read_file(args.config_file)
     watcher_config = dict(parser.items("live-data"))
 

--- a/baseplate/sidecars/secrets_fetcher.py
+++ b/baseplate/sidecars/secrets_fetcher.py
@@ -82,6 +82,7 @@ import requests
 
 from baseplate import __version__ as baseplate_version
 from baseplate.lib import config
+from baseplate.server import EnvironmentInterpolation
 
 
 logger = logging.getLogger(__name__)
@@ -378,7 +379,7 @@ def main() -> None:
         level = logging.INFO
 
     logging.basicConfig(format="%(asctime)s:%(levelname)s:%(message)s", level=level)
-    parser = configparser.RawConfigParser()
+    parser = configparser.RawConfigParser(interpolation=EnvironmentInterpolation())
     parser.read_file(args.config_file)
     fetcher_config = dict(parser.items("secret-fetcher"))
 

--- a/baseplate/sidecars/trace_publisher.py
+++ b/baseplate/sidecars/trace_publisher.py
@@ -16,6 +16,7 @@ from baseplate.lib.metrics import metrics_client_from_config
 from baseplate.lib.retry import RetryPolicy
 from baseplate.observers.tracing import MAX_QUEUE_SIZE
 from baseplate.observers.tracing import MAX_SPAN_SIZE
+from baseplate.server import EnvironmentInterpolation
 from baseplate.sidecars import BatchFull
 from baseplate.sidecars import RawJSONBatch
 from baseplate.sidecars import SerializedBatch
@@ -144,7 +145,7 @@ def publish_traces() -> None:
         level = logging.WARNING
     logging.basicConfig(level=level)
 
-    config_parser = configparser.RawConfigParser()
+    config_parser = configparser.RawConfigParser(interpolation=EnvironmentInterpolation())
     config_parser.read_file(args.config_file)
 
     publisher_raw_cfg = dict(config_parser.items("trace-publisher:" + args.queue_name))

--- a/docs/cli/serve.rst
+++ b/docs/cli/serve.rst
@@ -15,6 +15,12 @@ part after is the "name". Baseplate looks for sections named ``main`` by
 default but can be overridden with the ``--server-name`` and ``--app-name``
 options.
 
+Shell-like environment variable references in configuration values will be
+expanded at server startup. For example, ``foo = $MY_PATH`` or ``foo =
+${MY_PATH}`` will result in the application seeing the value from the
+``$MY_PATH`` environment variable as the value of the ``foo`` setting as if it
+had been written in the config file directly.
+
 .. highlight:: ini
 
 The Server


### PR DESCRIPTION
This is intended to allow us to inject some configuration from
environment variables while keeping the config file explicit about where
these values are coming from.

You can do something like this in config:

```ini
foo = $BAR
```

and `foo` will be populated with the value of the environment variable `$BAR` at runtime.

This is applied to `baseplate-serve`, `baseplate-script`, and the sidecars.