### PR TITLE
Conform zipkin traceId, spanId, parentId specs

### DIFF
--- a/baseplate/__init__.py
+++ b/baseplate/__init__.py
@@ -124,8 +124,9 @@ class TraceInfo(NamedTuple):
         with any upstream requests.
 
         """
-        trace_id = str(random.getrandbits(64))
-        return cls(trace_id=trace_id, parent_id=None, span_id=trace_id, sampled=None, flags=None)
+        trace_id = "{0:0{1}x}".format(random.getrandbits(128), 32)
+        span_id = "{0:0{1}x}".format(random.getrandbits(64), 16)
+        return cls(trace_id=trace_id, parent_id=None, span_id=span_id, sampled=None, flags=None)
 
     @classmethod
     def from_upstream(

--- a/baseplate/observers/tracing.py
+++ b/baseplate/observers/tracing.py
@@ -279,7 +279,9 @@ class TraceSpanObserver(SpanObserver):
             "binaryAnnotations": binary_annotations,
         }
 
-        span["parentId"] = self.span.parent_id or 0
+        if self.span.parent_id:
+            span["parentId"] = self.span.parent_id
+
         return span
 
     def _serialize(self) -> Dict[str, Any]:

--- a/tests/integration/pyramid_tests.py
+++ b/tests/integration/pyramid_tests.py
@@ -115,15 +115,15 @@ class ConfiguratorTests(unittest.TestCase):
 
     @mock.patch("random.getrandbits")
     def test_no_trace_headers(self, getrandbits):
-        getrandbits.return_value = 1234
+        getrandbits.return_value = 3735928559
         self.test_app.get("/example")
 
         self.assertEqual(self.observer.on_server_span_created.call_count, 1)
 
         context, server_span = self.observer.on_server_span_created.call_args[0]
-        self.assertEqual(server_span.trace_id, "1234")
+        self.assertEqual(server_span.trace_id, "0" * 24 + "deadbeef")
         self.assertEqual(server_span.parent_id, None)
-        self.assertEqual(server_span.id, "1234")
+        self.assertEqual(server_span.id, "0" * 8 + "deadbeef")
 
         self.assertTrue(self.server_observer.on_start.called)
         self.assertTrue(self.server_observer.on_finish.called)
@@ -222,7 +222,7 @@ class ConfiguratorTests(unittest.TestCase):
 
     @mock.patch("random.getrandbits")
     def test_distrust_headers(self, getrandbits):
-        getrandbits.return_value = 9999
+        getrandbits.return_value = 3735928559
         self.baseplate_configurator.header_trust_handler.trust_headers = False
 
         self.test_app.get(
@@ -230,9 +230,9 @@ class ConfiguratorTests(unittest.TestCase):
         )
 
         context, server_span = self.observer.on_server_span_created.call_args[0]
-        self.assertEqual(server_span.trace_id, str(getrandbits.return_value))
+        self.assertEqual(server_span.trace_id, "0" * 24 + "deadbeef")
         self.assertEqual(server_span.parent_id, None)
-        self.assertEqual(server_span.id, str(getrandbits.return_value))
+        self.assertEqual(server_span.id, "0" * 8 + "deadbeef")
 
     def test_local_trace_in_context(self):
         self.test_app.get("/trace_context")

--- a/tests/integration/tracing_tests.py
+++ b/tests/integration/tracing_tests.py
@@ -90,7 +90,7 @@ class TracingTests(unittest.TestCase):
             span = self.server_span_observer._serialize()
             self.assertEqual(span["name"], "example")
             self.assertEqual(len(span["annotations"]), 2)
-            self.assertEqual(span["parentId"], 0)
+            self.assertFalse("parentId" in span)
 
     def test_local_tracing_embedded(self):
         with mock.patch.object(

--- a/tests/unit/observers/tracing_tests.py
+++ b/tests/unit/observers/tracing_tests.py
@@ -245,10 +245,10 @@ class TraceSpanObserverTests(TraceTestBase):
         span_obj = self.test_span_observer._to_span_obj([], [])
         self.assertEqual(span_obj["parentId"], self.span.parent_id)
 
-    def test_to_span_obj_sets_default_parent_id(self):
+    def test_to_span_obj_default_no_parent_id(self):
         self.span.parent_id = None
         span_obj = self.test_span_observer._to_span_obj([], [])
-        self.assertEqual(span_obj["parentId"], 0)
+        self.assertFalse("parentId" in span_obj)
 
     def test_incr_tag_adds_binary_annotation(self):
         self.test_span_observer.binary_annotations = []


### PR DESCRIPTION
Using v1 API defined in https://github.com/openzipkin/zipkin-api/blob/7692ca7be4dc3be9225db550d60c4d30e6e9ec59/zipkin-api.yaml

traceId to 32 character lowercase hex string
spanId to 16 character lowercase hex string
parentId to be absent for root span

Currently required changes to prove out a grafana-agent + tempo tracing architecture.