### PR TITLE
Run tests on Python 3.9

### DIFF
--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9]
 
     container:
       image: python:${{ matrix.python-version }}
@@ -37,6 +37,8 @@ jobs:
             ${{ runner.os }}-pip-
 
       - name: Install dependencies
+        env:
+          CASS_DRIVER_NO_EXTENSIONS: theytaketoolongtobuild
         run: |
           python --version
           python -m pip install -r requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,15 @@
 FROM ghcr.io/reddit/thrift-compiler:0.14.1 AS thrift
 
-FROM python:3.8
+FROM python:3.9
 
 COPY --from=thrift /usr/local/bin/thrift /usr/local/bin/thrift
 
 WORKDIR /src
+
+# cassandra-driver doesn't seem to publish pre-compiled wheels for py39 so we
+# have to wait for some hefty native extensions to build. skip this because we
+# don't care for our tests.
+ENV CASS_DRIVER_NO_EXTENSIONS theytaketoolongtobuild
 
 COPY requirements*.txt ./
 RUN pip install -r requirements.txt

--- a/baseplate/clients/redis.py
+++ b/baseplate/clients/redis.py
@@ -7,9 +7,9 @@ import redis
 
 # redis.client.StrictPipeline was renamed to redis.client.Pipeline in version 3.0
 try:
-    from redis.client import StrictPipeline as Pipeline
+    from redis.client import StrictPipeline as Pipeline  # type: ignore
 except ImportError:
-    from redis.client import Pipeline  # type: ignore
+    from redis.client import Pipeline
 
 from baseplate import Span
 from baseplate.clients import ContextFactory
@@ -182,7 +182,7 @@ class MonitoredRedisPipeline(Pipeline):
         super().__init__(connection_pool, response_callbacks, **kwargs)
 
     # pylint: disable=arguments-differ
-    def execute(self, **kwargs: Any) -> Any:  # type: ignore
+    def execute(self, **kwargs: Any) -> Any:
         with self.server_span.make_child(self.trace_name):
             return super().execute(**kwargs)
 

--- a/baseplate/lib/config.py
+++ b/baseplate/lib/config.py
@@ -238,7 +238,7 @@ def File(mode: str = "r") -> Callable[[str], IO]:  # noqa: D401
 
     def open_file(text: str) -> IO:
         try:
-            return open(text, mode=mode)
+            return open(text, mode=mode)  # pylint: disable=R1732
         except OSError:
             raise ValueError(f"could not open file: {text}")
 

--- a/baseplate/lint/db_query_string_format_plugin.py
+++ b/baseplate/lint/db_query_string_format_plugin.py
@@ -24,7 +24,7 @@ class NoDbQueryStringFormatChecker(BaseChecker):
 
     def check_string_is_query(self, string: str) -> bool:
         query = string.split(" ")
-        if query[0].lower() in self.query_verbs and ("{}" or "%s" in query):
+        if query[0].lower() in self.query_verbs and ("{}" in query or "%s" in query):
             return True
         return False
 

--- a/baseplate/server/queue_consumer.py
+++ b/baseplate/server/queue_consumer.py
@@ -213,6 +213,7 @@ class QueueConsumerServer:
                 except (Exception, ServerTimeout):
                     logger.exception("Unhandled error in pump or handler thread, terminating.")
                     self._terminate()
+                return None
 
             return _run_and_terminate
 

--- a/baseplate/sidecars/secrets_fetcher.py
+++ b/baseplate/sidecars/secrets_fetcher.py
@@ -353,7 +353,7 @@ def trigger_callback(
         if last_proc and last_proc.poll() is None:
             logger.info("Previous callback process is still running. Skipping")
         else:
-            return subprocess.Popen([callback, secrets_file])
+            return subprocess.Popen([callback, secrets_file])  # pylint: disable=R1732
     return last_proc
 
 

--- a/requirements-transitive.txt
+++ b/requirements-transitive.txt
@@ -81,7 +81,7 @@ toml==0.10.2
 translationstring==1.4
 typed-ast==1.4.2
 typing-extensions==3.7.4.3
-urllib3==1.26.4
+urllib3==1.26.6
 venusian==3.0.0
 vine==1.3.0
 waitress==1.4.4

--- a/requirements-transitive.txt
+++ b/requirements-transitive.txt
@@ -67,6 +67,7 @@ requests==2.25.1
 sentry-sdk==0.20.1
 six==1.15.0
 snowballstemmer==2.1.0
+sortedcontainers==2.4.0
 soupsieve==2.2
 sphinxcontrib-applehelp==1.0.2
 sphinxcontrib-devhelp==1.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,13 +4,13 @@
 # See install_requires and extras_require in setup.py for the range of versions
 # supported.
 -r requirements-transitive.txt
-astroid==2.4.2
+astroid==2.6.6
 black==19.10b0
 flake8==3.8.4
 lxml==4.6.2
 mypy==0.800
 pydocstyle==5.1.1
-pylint==2.6.0
+pylint==2.9.6
 pytest==6.2.2
 pytest-cov==2.11.1
 pytz==2021.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ astroid==2.6.6
 black==19.10b0
 flake8==3.8.4
 lxml==4.6.2
-mypy==0.800
+mypy==0.910
 pydocstyle==5.1.1
 pylint==2.9.6
 pytest==6.2.2
@@ -18,6 +18,9 @@ reorder-python-imports==2.4.0
 sphinx==3.4.3
 sphinx-autodoc-typehints==1.11.1
 sphinxcontrib-spelling==7.1.0
+types-redis==3.5.3
+types-requests==2.25.6
+types-setuptools==57.0.2
 webtest==2.0.35
 wheel==0.36.2
 fakeredis==1.5.0

--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,7 @@ setup(
         "Programming Language :: Python",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Topic :: Software Development :: Libraries",
         "Topic :: Software Development :: Libraries :: Application Frameworks",
     ],


### PR DESCRIPTION
Since we're using Python 3.9 in a few places already it's important our test suite runs against it. Pylint needed an upgrade to be able to handle some changes in the language. That's the bulk of this PR. I took the opportunity to bump mypy as well but it only affected some pragma comments so there's no functional change.