### PR TITLE
Add baseplate-shell logging for audit purposes

### DIFF
--- a/baseplate/server/__init__.py
+++ b/baseplate/server/__init__.py
@@ -542,4 +542,4 @@ class LoggedInteractiveConsole(code.InteractiveConsole):
         prompt = f"<{self.pri}>1 {timestamp} {self.hostname} baseplate-shell {self.pid} {message_id} {structured} {message}"
         with open(self.output_file, "w") as f:
             print(prompt, file=f)
-        self.output_file.flush()
+            f.flush()

--- a/baseplate/server/__init__.py
+++ b/baseplate/server/__init__.py
@@ -469,7 +469,6 @@ def load_and_run_shell() -> None:
             """
         ]
         ipython_config.TerminalInteractiveShell.banner2 = banner
-        # ipython_config.InteractiveShell.logfile = console_logpath
         ipython_config.LoggingMagics.quiet = True
         start_ipython(argv=[], user_ns=env, config=ipython_config)
         raise SystemExit
@@ -504,12 +503,12 @@ def _is_containerized() -> bool:
     """Determine if we're running in a container based on cgroup awareness for various container runtimes."""
     path = "/proc/self/cgroup"
     in_container = ["kubepods", "docker", "containerd"]
-    if (
-        os.path.exists("/.dockerenv")
-        or os.path.isfile(path)
-        and any(in_container in line for line in open(path))
-    ):
+    if os.path.exists("/.dockerenv"):
         return True
+    elif os.path.isfile(path):
+        for c in in_container:
+            if (c in line for line in open(path)):
+                return True
     return False
 
 
@@ -526,8 +525,8 @@ class LoggedInteractiveConsole(code.InteractiveConsole):
     def __del__(self):
         self.output_file.close()
 
-    def raw_input(self, _prompt=""):
-        data = input(_prompt)
+    def raw_input(self, prompt=""):
+        data = input(prompt)
         print(f"{datetime.now()} {os.getpid()} - {data}", file=self.output_file)
         self.output_file.flush()
         return data

--- a/baseplate/server/__init__.py
+++ b/baseplate/server/__init__.py
@@ -179,7 +179,7 @@ def configure_logging(config: Configuration, debug: bool) -> None:
 
     # add PID 1 stdout logging if we're containerized and not running under init system
     if _is_containerized() and os.getppid() != 1:
-        file_handler = logging.FileHandler("/proc/1/fd/1", mode='w')
+        file_handler = logging.FileHandler("/proc/1/fd/1", mode="w")
         file_handler.setFormatter(formatter)
         root_logger.addHandler(file_handler)
 
@@ -537,7 +537,9 @@ class LoggedInteractiveConsole(code.InteractiveConsole):
         self.log_event(message=data, message_id="CEXC")
         return data
 
-    def log_event(self, message: str, message_id: Optional[str] = "-", structured: Optional[str] = "-"):
+    def log_event(
+        self, message: str, message_id: Optional[str] = "-", structured: Optional[str] = "-"
+    ):
         """Generate an RFC 5424 compliant syslog format."""
         timestamp = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S.%fZ")
         prompt = f"<{self.pri}>1 {timestamp} {self.hostname} baseplate-shell {self.pid} {message_id} {structured} {message}"

--- a/baseplate/server/__init__.py
+++ b/baseplate/server/__init__.py
@@ -466,7 +466,7 @@ def _shell_commands_log_path() -> str:
     # Define path for console log output
     pid_1_path = "/proc/1/fd/1"
     # check if running in a containerized environment
-    if os.getenv('KUBERNETES_SERVICE_HOST') and os.access(pid_1_path, os.W_OK):
+    if os.getenv("KUBERNETES_SERVICE_HOST") and os.access(pid_1_path, os.W_OK):
         return os.path.abspath(pid_1_path)
     else:
         return os.path.abspath("/var/log/.shell_history")

--- a/baseplate/server/__init__.py
+++ b/baseplate/server/__init__.py
@@ -520,7 +520,7 @@ def _is_containerized() -> bool:
 
 
 class LoggedInteractiveConsole(code.InteractiveConsole):
-    def __init__(self, _locals, logpath):
+    def __init__(self, _locals: dict[str, Any], logpath: str) -> None:
         code.InteractiveConsole.__init__(self, _locals)
         self.output_file = logpath
         self.pid = os.getpid()
@@ -529,14 +529,14 @@ class LoggedInteractiveConsole(code.InteractiveConsole):
         self.hostname = os.uname().nodename
         self.log_event(message="Start InteractiveConsole logging", message_id="CSTR")
 
-    def raw_input(self, prompt=""):
+    def raw_input(self, prompt: Optional[str] = "") -> str:
         data = input(prompt)
         self.log_event(message=data, message_id="CEXC")
         return data
 
     def log_event(
         self, message: str, message_id: Optional[str] = "-", structured: Optional[str] = "-"
-    ):
+    ) -> None:
         """Generate an RFC 5424 compliant syslog format."""
         timestamp = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S.%fZ")
         prompt = f"<{self.pri}>1 {timestamp} {self.hostname} baseplate-shell {self.pid} {message_id} {structured} {message}"

--- a/baseplate/server/__init__.py
+++ b/baseplate/server/__init__.py
@@ -24,7 +24,6 @@ import warnings
 from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
-from psutil import Process
 from rlcompleter import Completer
 from types import FrameType
 from typing import Any
@@ -40,6 +39,7 @@ from typing import TextIO
 from typing import Tuple
 
 from gevent.server import StreamServer
+from psutil import Process
 
 from baseplate import Baseplate
 from baseplate.lib import warn_deprecated

--- a/baseplate/server/__init__.py
+++ b/baseplate/server/__init__.py
@@ -486,7 +486,7 @@ def load_and_run_shell() -> None:
         except ImportError:
             pass
 
-        shell = LoggedInteractiveConsole(locals=env, logpath=console_logpath)
+        shell = LoggedInteractiveConsole(_locals=env, logpath=console_logpath)
         shell.interact(banner)
 
 
@@ -520,9 +520,9 @@ def _is_containerized() -> bool:
 
 
 class LoggedInteractiveConsole(code.InteractiveConsole):
-    def __init__(self, locals, logpath):
-        code.InteractiveConsole.__init__(self, locals)
-        self.output_file = open(logpath, "w")
+    def __init__(self, _locals, logpath):
+        code.InteractiveConsole.__init__(self, _locals)
+        self.output_file = logpath
         self.pid = os.getpid()
         # PRI = User Level Facility (1) * 8 + Notice Severity (5)
         self.pri = 13
@@ -534,7 +534,8 @@ class LoggedInteractiveConsole(code.InteractiveConsole):
 
     def raw_input(self, prompt=""):
         data = input(prompt)
-        self.log_event(message=data, message_id="CEXC")
+        with open(self.output_file, "w"):
+            self.log_event(message=data, message_id="CEXC")
         return data
 
     def log_event(

--- a/baseplate/server/__init__.py
+++ b/baseplate/server/__init__.py
@@ -512,6 +512,7 @@ def _is_containerized() -> bool:
         return True
     return False
 
+
 class LoggedInteractiveConsole(code.InteractiveConsole):
     def __init__(self, locals, logpath):
         code.InteractiveConsole.__init__(self, locals)

--- a/baseplate/server/__init__.py
+++ b/baseplate/server/__init__.py
@@ -520,7 +520,7 @@ def _is_containerized() -> bool:
 
 
 class LoggedInteractiveConsole(code.InteractiveConsole):
-    def __init__(self, _locals: dict[str, Any], logpath: str) -> None:
+    def __init__(self, _locals: Dict[str, Any], logpath: str) -> None:
         code.InteractiveConsole.__init__(self, _locals)
         self.output_file = logpath
         self.pid = os.getpid()

--- a/baseplate/server/__init__.py
+++ b/baseplate/server/__init__.py
@@ -176,7 +176,7 @@ def configure_logging(config: Configuration, debug: bool) -> None:
     root_logger.setLevel(logging_level)
     root_logger.addHandler(handler)
 
-    if (os.getpid() != 1):
+    if os.getpid() != 1:
         file_handler = logging.FileHandler("/proc/1/fd/1")
         file_handler.setFormatter(formatter)
         root_logger.addHandler(handler)
@@ -466,14 +466,16 @@ def _shell_commands_log_path() -> str:
     # Define path for console log output
     pid_1_path = "/proc/1/fd/1"
     # check if running in a containerized environment
-    if (os.getenv('KUBERNETES_SERVICE_HOST') and os.access(pid_1_path, os.W_OK)):
+    if os.getenv('KUBERNETES_SERVICE_HOST') and os.access(pid_1_path, os.W_OK):
         return os.path.abspath(pid_1_path)
     else:
         return os.path.abspath("/var/log/.shell_history")
 
+
 def _InteractiveConsole_setup(env: Dict, console_logpath: str) -> None:
     # Setup some quality of life console interactions
     import readline
+
     readline.set_completer(Completer(env).complete)
     readline.parse_and_bind("tab: complete")
 

--- a/baseplate/server/__init__.py
+++ b/baseplate/server/__init__.py
@@ -529,13 +529,9 @@ class LoggedInteractiveConsole(code.InteractiveConsole):
         self.hostname = os.uname().nodename
         self.log_event(message="Start InteractiveConsole logging", message_id="CSTR")
 
-    def __del__(self):
-        self.output_file.close()
-
     def raw_input(self, prompt=""):
         data = input(prompt)
-        with open(self.output_file, "w"):
-            self.log_event(message=data, message_id="CEXC")
+        self.log_event(message=data, message_id="CEXC")
         return data
 
     def log_event(
@@ -544,5 +540,6 @@ class LoggedInteractiveConsole(code.InteractiveConsole):
         """Generate an RFC 5424 compliant syslog format."""
         timestamp = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S.%fZ")
         prompt = f"<{self.pri}>1 {timestamp} {self.hostname} baseplate-shell {self.pid} {message_id} {structured} {message}"
-        print(prompt, file=self.output_file)
+        with open(self.output_file, "w") as f:
+            print(prompt, file=f)
         self.output_file.flush()

--- a/baseplate/server/__init__.py
+++ b/baseplate/server/__init__.py
@@ -429,7 +429,7 @@ def load_and_run_shell() -> None:
     for var in sorted(env_banner.keys()):
         banner += "\n  {:<12} {}".format(var, env_banner[var])
 
-    console_logpath = _shell_commands_log_path()
+    console_logpath = _get_shell_log_path()
 
     try:
         # try to use IPython if possible
@@ -453,7 +453,7 @@ def load_and_run_shell() -> None:
         banner = newbanner + banner
 
         try:
-            _InteractiveConsole_setup(env, console_logpath)
+            _set_up_interactive_console(env, console_logpath)
 
         except ImportError:
             pass
@@ -462,7 +462,7 @@ def load_and_run_shell() -> None:
         shell.interact(banner)
 
 
-def _shell_commands_log_path() -> str:
+def _get_shell_log_path() -> str:
     # Define path for console log output
     pid_1_path = "/proc/1/fd/1"
     # check if running in a containerized environment
@@ -471,7 +471,7 @@ def _shell_commands_log_path() -> str:
     return os.path.abspath("/var/log/.shell_history")
 
 
-def _InteractiveConsole_setup(env: Dict, console_logpath: str) -> None:
+def _set_up_interactive_console(env: Dict, console_logpath: str) -> None:
     # Setup some quality of life console interactions
     import readline
 

--- a/baseplate/server/__init__.py
+++ b/baseplate/server/__init__.py
@@ -526,7 +526,7 @@ def _has_PID1_parent() -> bool:
                 if line.startswith("PPid:"):
                     parent_pid = int((line.replace("PPid:", "")))
                     break
-    return True if parent_pid == 1 else False
+    return bool(parent_pid)
 
 
 class LoggedInteractiveConsole(code.InteractiveConsole):

--- a/baseplate/server/__init__.py
+++ b/baseplate/server/__init__.py
@@ -422,7 +422,7 @@ def load_and_run_shell() -> None:
         setup = _load_factory(config.shell["setup"])
         setup(env, env_banner)
 
-    configure_logging(config, False)
+    configure_logging(config, args.debug)
 
     # generate banner text
     banner = "Available Objects:\n"
@@ -468,8 +468,7 @@ def _shell_commands_log_path() -> str:
     # check if running in a containerized environment
     if os.getenv("KUBERNETES_SERVICE_HOST") and os.access(pid_1_path, os.W_OK):
         return os.path.abspath(pid_1_path)
-    else:
-        return os.path.abspath("/var/log/.shell_history")
+    return os.path.abspath("/var/log/.shell_history")
 
 
 def _InteractiveConsole_setup(env: Dict, console_logpath: str) -> None:
@@ -478,6 +477,7 @@ def _InteractiveConsole_setup(env: Dict, console_logpath: str) -> None:
 
     readline.set_completer(Completer(env).complete)
     readline.parse_and_bind("tab: complete")
+    readline.set_history_length(10000)
 
     # Define audit logging with readline history
     def save_console_history(history_path=console_logpath) -> None:


### PR DESCRIPTION
This PR aims to add audit logging (or what is at least possible) for the `baseplate-shell`functionality. 

* IPython
~~So IPython doesn't have an API for capturing input, but does have a history logging functionality that can be forced via CLI. This was opted over the messiness of dealing with IPython profiles (especially in the container space). This allows realtime streaming of the commands to stdout for shipping upstream. There's no option to prefix this to help parse the logs, but any non-JSON error logs should be treated as human interacted so that should be sufficient. It does initialize with a `# IPython log file` entry~~

PR now approaches this by monkeypatching `IPython.logger.log_write()` to be able to handle log formatting and also disable the ability to stop logs.

* code.InteractiveConsole
InteractiveConsole, because it's dependent on `readline` for it's history functionality, can leverage a common pattern of capturing the history and writing it out upon session close. This does have a draw back of a long running sessions or an ungraceful shutdown dropping the logs. It might be more preferable to overriding `readline`'s stdin/stdout behaviors...

Note: also added tab completion as part of the InteractiveConsole setup