### PR TITLE
Swallow and log exceptions in event_publisher sidecar

### DIFF
--- a/baseplate/sidecars/event_publisher.py
+++ b/baseplate/sidecars/event_publisher.py
@@ -225,7 +225,10 @@ def publish_events() -> None:
             batcher.add(message)
         except BatchFull:
             serialized = batcher.serialize()
-            publisher.publish(serialized)
+            try:
+                publisher.publish(serialized)
+            except Exception:
+                logger.exception("Events publishing failed.")
             batcher.reset()
             batcher.add(message)
 


### PR DESCRIPTION
In the same spirit of https://github.com/reddit/baseplate.py/pull/576,
we don't want sidecars to crash and bring down the whole pod, so swallow
and log the exceptions instead of crash.