### PR TITLE
Prevent tracing SidecarRecorder from trying to send traces that are t…

### DIFF
--- a/baseplate/observers/tracing.py
+++ b/baseplate/observers/tracing.py
@@ -563,6 +563,7 @@ class SidecarRecorder(Recorder):
                 MAX_SPAN_SIZE,
                 len(serialized_str),
             )
+            return
         try:
             self.queue.put(serialized_str, timeout=0)
         except TimedOutError:


### PR DESCRIPTION
I have a downstream service sending large traces and It's breaking an endpoint. The comment in this method states that it's called in the request/response path so given that trying to send messages that are too large raises it looks like we should return here.