### PR TITLE
sqlalchemy: limit statement tag length

### DIFF
--- a/baseplate/clients/sqlalchemy.py
+++ b/baseplate/clients/sqlalchemy.py
@@ -191,6 +191,8 @@ class SQLAlchemyEngineContextFactory(ContextFactory):
 
         trace_name = "{}.{}".format(context_name, "execute")
         span = server_span.make_child(trace_name)
+        if len(statement) > 1024:
+            statement = statement[:1024] + "..."
         span.set_tag("statement", statement)
         span.start()
 

--- a/requirements-transitive.txt
+++ b/requirements-transitive.txt
@@ -79,7 +79,6 @@ SQLAlchemy==1.4.12
 thrift-unofficial==0.14.1
 toml==0.10.2
 translationstring==1.4
-typed-ast==1.4.2
 typing-extensions==3.7.4.3
 urllib3==1.26.6
 venusian==3.0.0


### PR DESCRIPTION
related to https://github.com/reddit/baseplate.py/pull/613

I logged some spans and saw that the ORM was generating a statement that grows with the length of a list of ids. I need to change that query but it still seems like it could be a good idea to limit what is allowed.

We could also log a warning in when binary annotations are created on the span with really long strings too.