### PR TITLE
event publisher sidecar: allow http endpoint

### DIFF
--- a/baseplate/sidecars/event_publisher.py
+++ b/baseplate/sidecars/event_publisher.py
@@ -101,7 +101,7 @@ class V2JBatch(V2Batch):
 class BatchPublisher:
     def __init__(self, metrics_client: metrics.Client, cfg: Any):
         self.metrics = metrics_client
-        self.url = f"https://{cfg.collector.hostname}/v{cfg.collector.version}"
+        self.url = f"{cfg.collector.scheme}://{cfg.collector.hostname}/v{cfg.collector.version}"
         self.key_name = cfg.key.name
         self.key_secret = cfg.key.secret
         self.session = requests.Session()
@@ -194,6 +194,7 @@ def publish_events() -> None:
             "collector": {
                 "hostname": config.String,
                 "version": config.Optional(config.String, default="2"),
+                "scheme": config.Optional(config.String, default="https"),
             },
             "key": {"name": config.String, "secret": config.Base64},
             "max_queue_size": config.Optional(config.Integer, MAX_QUEUE_SIZE),

--- a/tests/unit/lib/events/publisher_tests.py
+++ b/tests/unit/lib/events/publisher_tests.py
@@ -82,6 +82,7 @@ class PublisherTests(unittest.TestCase):
         self.config.collector = config.ConfigNamespace()
         self.config.collector.hostname = "test.local"
         self.config.collector.version = 1
+        self.config.collector.scheme = "https"
         self.config.key = config.ConfigNamespace()
         self.config.key.name = "TestKey"
         self.config.key.secret = b"hunter2"


### PR DESCRIPTION
We are working on a project to have a "proxy" between sidecar and event
collector to reduce the volume of events send to event collector. Since
this "proxy" is entirely internal facing, making it available under http
instead of https is much easier (we don't have to setup nginx-ingress
and a domain name for it).

Thus, adding a scheme config, and default to https, to allow http
endpoints.