### PR TITLE
Fix incorrect syntax in write to syslog

### DIFF
--- a/baseplate/server/__init__.py
+++ b/baseplate/server/__init__.py
@@ -458,7 +458,7 @@ def load_and_run_shell() -> None:
                     write = self.logfile.write
                     if kind=='input':
                         # Generate an RFC 5424 compliant syslog format
-                        write(f"<13>1 {{datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S.%fZ")}} {{os.uname().nodename}} baseplate-shell {{os.getpid()}} {{message_id}} - {{data}}")
+                        write(f'<13>1 {{datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S.%fZ")}} {{os.uname().nodename}} baseplate-shell {{os.getpid()}} {{message_id}} - {{data}}')
                     elif kind=='output' and self.log_output:
                         odata = u'\\n'.join([u'#[Out]# %s' % s
                                         for s in data.splitlines()])


### PR DESCRIPTION
# Description

The change in format of log written in ipython in #620 resulted in syntax errors. This was resulting in errors being thrown when `baseplate-shell` was invoked. 
```
  app          This project's app instance
  context      The context for this shell instance's span  File "<ipython-input-1-4d8d683be66b>", line 9
    write(f"<13>1 {datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S.%fZ")} {os.uname().nodename} baseplate-shell {os.getpid()} {message_id} - {data}")
                                               ^
SyntaxError: f-string: unmatched '('
```

Once corrected the logs look like:
```
[reddit-service-report] <13>1 2021-09-26T02:00:22.710966Z reddit-service-report-844d8c4694-pdvc6 baseplate-shell 938 IEXC - 
[reddit-service-report] <13>1 2021-09-26T02:00:22.711082Z reddit-service-report-844d8c4694-pdvc6 baseplate-shell 938 ISTR - Start IPython logging
[reddit-service-report] <13>1 2021-09-26T02:00:39.312812Z reddit-service-report-844d8c4694-pdvc6 baseplate-shell 938 IEXC - 1+1==11
```