### PR TITLE
Extend support for environment variable expansion

### DIFF
--- a/baseplate/server/__init__.py
+++ b/baseplate/server/__init__.py
@@ -39,6 +39,8 @@ from typing import Sequence
 from typing import TextIO
 from typing import Tuple
 
+from expandvars import expandvars
+from expandvars import ExpandvarsException
 from gevent.server import StreamServer
 
 from baseplate import Baseplate
@@ -124,7 +126,11 @@ class EnvironmentInterpolation(configparser.Interpolation):
         value: str,
         defaults: Mapping[str, str],
     ) -> str:
-        return os.path.expandvars(value)
+        try:
+            return expandvars(value, nounset=True)
+        except ExpandvarsException:
+            logger.warning("Failed to interpolate config value %s for option %s", value, option)
+            return value
 
 
 class Configuration(NamedTuple):

--- a/requirements-transitive.txt
+++ b/requirements-transitive.txt
@@ -21,6 +21,7 @@ confluent-kafka==1.6.0
 coverage==5.4
 cryptography==3.4.4
 docutils==0.16
+expandvars==0.7.0
 geomet==0.2.1.post1
 gevent==21.1.2
 graphviz==0.16

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ mypy==0.910
 pydocstyle==5.1.1
 pylint==2.9.6
 pytest==6.2.2
+pytest-check==1.0.4
 pytest-cov==2.11.1
 pytz==2021.1
 reorder-python-imports==2.4.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -72,6 +72,9 @@ ignore_missing_imports = True
 [mypy-cqlmapper.*]
 ignore_missing_imports = True
 
+[mypy-expandvars.*]
+ignore_missing_imports = True
+
 [mypy-gevent.*]
 ignore_missing_imports = True
 

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
     python_requires=">=3.7",
     setup_requires=["setuptools_scm"],
     install_requires=[
+        "expandvars>=0.7.0",
         "posix_ipc>=1.0.0,<2.0",
         "python-json-logger>=2.0,<3.0",
         "requests>=2.21.0,<3.0",


### PR DESCRIPTION
# Description
Use the [expandvars](https://github.com/sayanarijit/expandvars/) library to support different bash parameter expansion methods.

This allows use cases such as providing defaults, offsets and indirection.

To retain compatibility any error in expansion (whether due to missing variable, or invalid syntax) will not raise but simply return the config value as declared in the config file - while logging a warning.

`pytest-check` was added to development dependencies to use multiple assertions per test case