### PR TITLE
Update greenlet version to support py3.10

### DIFF
--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, "3.10"]
 
     container:
       image: python:${{ matrix.python-version }}

--- a/requirements-transitive.txt
+++ b/requirements-transitive.txt
@@ -24,7 +24,7 @@ docutils==0.16
 geomet==0.2.1.post1
 gevent==21.1.2
 graphviz==0.16
-greenlet==1.0.0
+greenlet==1.1.2
 hupper==1.10.2
 idna==2.10
 imagesize==1.2.0


### PR DESCRIPTION
# Description
To support python 3.10 greenlet needs to be updated to atleast 1.1.0.
[1.1.2](https://greenlet.readthedocs.io/en/latest/changes.html#id1) seems somehow karmic for baseplate 2.2.3