### PR TITLE
Fix annoying extra IPython exception in shell tracebacks

### DIFF
--- a/baseplate/server/__init__.py
+++ b/baseplate/server/__init__.py
@@ -475,20 +475,22 @@ def load_and_run_shell() -> None:
         start_ipython(argv=[], user_ns=env, config=ipython_config)
         raise SystemExit
     except ImportError:
-        newbanner = f"Baseplate Interactive Shell\nPython {sys.version}\n\n"
-        banner = newbanner + banner
+        pass
 
-        try:
-            import readline
+    newbanner = f"Baseplate Interactive Shell\nPython {sys.version}\n\n"
+    banner = newbanner + banner
 
-            readline.set_completer(Completer(env).complete)
-            readline.parse_and_bind("tab: complete")
+    try:
+        import readline
 
-        except ImportError:
-            pass
+        readline.set_completer(Completer(env).complete)
+        readline.parse_and_bind("tab: complete")
 
-        shell = LoggedInteractiveConsole(_locals=env, logpath=console_logpath)
-        shell.interact(banner)
+    except ImportError:
+        pass
+
+    shell = LoggedInteractiveConsole(_locals=env, logpath=console_logpath)
+    shell.interact(banner)
 
 
 def _get_shell_log_path() -> str:


### PR DESCRIPTION
This is happening because Python's adding the original "IPython isn't
installed" exception's context to any later exceptions because we're
running the fallback shell in the except: branch. By doing it outside,
we avoid this.