### PR TITLE
Don't show confusing exception context on event publisher errors

### DIFF
--- a/baseplate/sidecars/event_publisher.py
+++ b/baseplate/sidecars/event_publisher.py
@@ -224,14 +224,17 @@ def publish_events() -> None:
 
         try:
             batcher.add(message)
+            continue
         except BatchFull:
-            serialized = batcher.serialize()
-            try:
-                publisher.publish(serialized)
-            except Exception:
-                logger.exception("Events publishing failed.")
-            batcher.reset()
-            batcher.add(message)
+            pass
+
+        serialized = batcher.serialize()
+        try:
+            publisher.publish(serialized)
+        except Exception:
+            logger.exception("Events publishing failed.")
+        batcher.reset()
+        batcher.add(message)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This is also happening because the real codepath is in an except:
branch. By moving it out, we don't add the extra exception context to
any real exceptions and the error messages are clearer.