### PR TITLE
sqlalchemy: Don't truncate the executed statement, just the tag

### DIFF
--- a/baseplate/clients/sqlalchemy.py
+++ b/baseplate/clients/sqlalchemy.py
@@ -191,9 +191,7 @@ class SQLAlchemyEngineContextFactory(ContextFactory):
 
         trace_name = "{}.{}".format(context_name, "execute")
         span = server_span.make_child(trace_name)
-        if len(statement) > 1024:
-            statement = statement[:1024] + "..."
-        span.set_tag("statement", statement)
+        span.set_tag("statement", statement[:1021] + "..." if len(statement) > 1024 else statement)
         span.start()
 
         conn.info["span"] = span

--- a/tests/integration/sqlalchemy_tests.py
+++ b/tests/integration/sqlalchemy_tests.py
@@ -54,6 +54,18 @@ class SQLAlchemyEngineTests(unittest.TestCase):
         self.assertIsNone(span_observer.on_finish_exc_info)
         span_observer.assert_tag("statement", "SELECT * FROM test;")
 
+    def test_very_long_query(self):
+        with self.server_span:
+            self.server_span.context.db.execute("SELECT *" + (" " * 1024) + "FROM test;")
+
+        server_span_observer = self.baseplate_observer.get_only_child()
+        span_observer = server_span_observer.get_only_child()
+        self.assertTrue(span_observer.on_start_called)
+        self.assertTrue(span_observer.on_finish_called)
+        self.assertIsNone(span_observer.on_finish_exc_info)
+        tag = span_observer.tags["statement"]
+        assert len(tag) <= 1024
+
     def test_nested_local_span(self):
         with self.server_span:
             with self.server_span.make_child(


### PR DESCRIPTION
This broke in d16351f575bb7cc2c3df0986107e8768fefde3e7. Long queries
were having the actually executed SQL be truncated as well which
obviously leads to syntax errors with the appended ellipsis.