### PR TITLE
ThriftConnectionPool: catch possible timeouts in _release method

### DIFF
--- a/baseplate/lib/thrift_pool.py
+++ b/baseplate/lib/thrift_pool.py
@@ -203,10 +203,14 @@ class ThriftConnectionPool:
         return False
 
     def _release(self, prot: Optional[TProtocolBase]) -> None:
-        if prot and prot.trans.isOpen():
-            self.pool.put(prot)
-        else:
+        try:
+            if prot and prot.trans.isOpen():
+                self.pool.put(prot)
+            else:
+                self.pool.put(None)
+        except:  # noqa: E722
             self.pool.put(None)
+            raise
 
     @contextlib.contextmanager
     def connection(self) -> Generator[TProtocolBase, None, None]:


### PR DESCRIPTION
I believe the `prot.trans.isOpen` call ends up yielding to the hub which means a timeout exception can be raised here resulting in a connection slot getting counted as "used" forever.

Assuming I'm correct I'm not necessarily saying this is the best solution. Maybe it makes sense to remove the `isOpen` call here and rely on the code to detect stale connections after claiming one.