### PR TITLE
Linter upgrade

### DIFF
--- a/baseplate/clients/cassandra.py
+++ b/baseplate/clients/cassandra.py
@@ -285,7 +285,7 @@ class CassandraSessionAdapter:
         timeout: Union[float, object] = _NOT_SET,
         **kwargs: Any,
     ) -> ResponseFuture:
-        trace_name = "{}.{}".format(self.context_name, "execute")
+        trace_name = f"{self.context_name}.execute"
         span = self.server_span.make_child(trace_name)
         span.start()
         # TODO: include custom payload
@@ -321,7 +321,7 @@ class CassandraSessionAdapter:
             except KeyError:
                 pass
 
-        trace_name = "{}.{}".format(self.context_name, "prepare")
+        trace_name = f"{self.context_name}.prepare"
         with self.server_span.make_child(trace_name) as span:
             span.set_tag("statement", query)
             prepared = self.session.prepare(query)

--- a/baseplate/clients/kombu.py
+++ b/baseplate/clients/kombu.py
@@ -237,7 +237,7 @@ class _KombuProducer:
         if self.serializer:
             kwargs.setdefault("serializer", self.serializer.name)
 
-        trace_name = "{}.{}".format(self.name, "publish")
+        trace_name = f"{self.name}.publish"
         child_span = self.span.make_child(trace_name)
 
         child_span.set_tag("kind", "producer")

--- a/baseplate/clients/sqlalchemy.py
+++ b/baseplate/clients/sqlalchemy.py
@@ -189,7 +189,7 @@ class SQLAlchemyEngineContextFactory(ContextFactory):
         context_name = conn._execution_options["context_name"]
         server_span = conn._execution_options["server_span"]
 
-        trace_name = "{}.{}".format(context_name, "execute")
+        trace_name = f"{context_name}.execute"
         span = server_span.make_child(trace_name)
         span.set_tag("statement", statement[:1021] + "..." if len(statement) > 1024 else statement)
         span.start()

--- a/baseplate/clients/thrift.py
+++ b/baseplate/clients/thrift.py
@@ -214,8 +214,7 @@ def _build_thrift_proxy_method(name: str) -> Callable[..., Any]:
 
         raise TTransportException(
             type=TTransportException.TIMED_OUT,
-            message="retry policy exhausted while attempting {}.{}, "
-            "last error was: {}".format(self.namespace, name, last_error),
+            message=f"retry policy exhausted while attempting {self.namespace}.{name}, last error was: {last_error}",
         )
 
     return _call_thrift_method

--- a/baseplate/frameworks/pyramid/__init__.py
+++ b/baseplate/frameworks/pyramid/__init__.py
@@ -233,7 +233,9 @@ class BaseplateConfigurator:
                 request.edge_context = self.edge_context_factory.from_upstream(edge_payload)
 
         span = self.baseplate.make_server_span(
-            request, name=request.matched_route.name, trace_info=trace_info,
+            request,
+            name=request.matched_route.name,
+            trace_info=trace_info,
         )
         span.set_tag("http.url", request.url)
         span.set_tag("http.method", request.method)
@@ -285,6 +287,7 @@ def get_is_healthy_probe(request: Request) -> int:
         return IsHealthyProbe._NAMES_TO_VALUES[code.upper()]
     except KeyError:
         logger.warning(
-            "Unrecognized health check type %s, fallback to READINESS", code,
+            "Unrecognized health check type %s, fallback to READINESS",
+            code,
         )
         return IsHealthyProbe.READINESS

--- a/baseplate/lib/config.py
+++ b/baseplate/lib/config.py
@@ -238,7 +238,7 @@ def File(mode: str = "r") -> Callable[[str], IO]:  # noqa: D401
 
     def open_file(text: str) -> IO:
         try:
-            return open(text, mode=mode)  # pylint: disable=R1732
+            return open(text, mode=mode, encoding="UTF-8")  # pylint: disable=R1732
         except OSError:
             raise ValueError(f"could not open file: {text}")
 

--- a/baseplate/lib/file_watcher.py
+++ b/baseplate/lib/file_watcher.py
@@ -118,7 +118,9 @@ class FileWatcher(Generic[T]):
         self._mtime = 0.0
         self._data: Union[T, Type[_NOT_LOADED]] = _NOT_LOADED
         self._open_options = _OpenOptions(
-            mode="rb" if binary else "r", encoding=encoding, newline=newline
+            mode="rb" if binary else "r",
+            encoding=encoding or ("UTF-8" if not binary else None),
+            newline=newline,
         )
 
         backoff = backoff or DEFAULT_FILEWATCHER_BACKOFF
@@ -184,6 +186,7 @@ class FileWatcher(Generic[T]):
         if self._mtime < current_mtime:
             logger.debug("Loading %s.", self._path)
             try:
+                # pylint: disable=unspecified-encoding
                 with open(self._path, **self._open_options._asdict()) as f:
                     self._data = self._parser(f)
             except Exception as exc:

--- a/baseplate/lib/message_queue.py
+++ b/baseplate/lib/message_queue.py
@@ -24,7 +24,7 @@ class TimedOutError(MessageQueueError):
 # is rather opaque.
 class InvalidParametersError(ValueError):
     def __init__(self, inner: Exception):
-        super().__init__("%s (check fs.mqueue.{msg_max,msgsize_max} sysctls?)" % inner)
+        super().__init__(f"{inner} (check fs.mqueue.{{msg_max,msgsize_max}} sysctls?)")
 
 
 # this wrapper-exception is here just to give the user a bit more of an idea

--- a/baseplate/lib/metrics.py
+++ b/baseplate/lib/metrics.py
@@ -113,7 +113,9 @@ class RawTransport(Transport):
     """A transport which sends messages on a socket."""
 
     def __init__(
-        self, endpoint: config.EndpointConfiguration, swallow_network_errors: bool = False,
+        self,
+        endpoint: config.EndpointConfiguration,
+        swallow_network_errors: bool = False,
     ):
         self.swallow_network_errors = swallow_network_errors
         self.socket = socket.socket(endpoint.family, socket.SOCK_DGRAM)
@@ -290,7 +292,10 @@ class Timer:
     """
 
     def __init__(
-        self, transport: Transport, name: bytes, tags: Optional[Dict[str, Any]] = None,
+        self,
+        transport: Transport,
+        name: bytes,
+        tags: Optional[Dict[str, Any]] = None,
     ):
         self.transport = transport
         self.name = name
@@ -462,7 +467,10 @@ class Histogram:
     """
 
     def __init__(
-        self, transport: Transport, name: bytes, tags: Optional[Dict[str, Any]] = None,
+        self,
+        transport: Transport,
+        name: bytes,
+        tags: Optional[Dict[str, Any]] = None,
     ) -> None:
         self.transport = transport
         self.name = name
@@ -494,7 +502,10 @@ class Gauge:
     """
 
     def __init__(
-        self, transport: Transport, name: bytes, tags: Optional[Dict[str, Any]] = None,
+        self,
+        transport: Transport,
+        name: bytes,
+        tags: Optional[Dict[str, Any]] = None,
     ):
         self.transport = transport
         self.name = name

--- a/baseplate/lib/metrics.py
+++ b/baseplate/lib/metrics.py
@@ -124,7 +124,7 @@ class RawTransport(Transport):
     def send(self, serialized_metric: bytes) -> None:
         try:
             self.socket.sendall(serialized_metric)
-        except socket.error as exc:
+        except OSError as exc:
             if self.swallow_network_errors:
                 logger.exception("Failed to send to metrics collector")
                 return

--- a/baseplate/lib/service_discovery.py
+++ b/baseplate/lib/service_discovery.py
@@ -67,7 +67,7 @@ class _Inventory(NamedTuple):
 def _parse(watched_file: IO) -> _Inventory:
     backends = []
     for d in json.load(watched_file):
-        endpoint = Endpoint("%s:%d" % (d["host"], d["port"]))
+        endpoint = Endpoint(f"{d['host']}:{d['port']:d}")
         weight = d["weight"] if d["weight"] is not None else 1
         backend = Backend(d["id"], d["name"], endpoint, weight)
         backends.append(backend)

--- a/baseplate/lib/thrift_pool.py
+++ b/baseplate/lib/thrift_pool.py
@@ -236,7 +236,7 @@ class ThriftConnectionPool:
                 raise TTransportException(
                     type=TTransportException.TIMED_OUT, message="timed out interacting with socket"
                 )
-            except socket.error as exc:
+            except OSError as exc:
                 raise TTransportException(type=TTransportException.UNKNOWN, message=str(exc))
         except (TApplicationException, TProtocolException, TTransportException):
             # these exceptions usually indicate something low-level went wrong,

--- a/baseplate/observers/metrics_tagged.py
+++ b/baseplate/observers/metrics_tagged.py
@@ -182,7 +182,8 @@ class TaggedMetricsLocalSpanObserver(SpanObserver):
         self.timer.stop()
 
         self.batch.counter(
-            f"{self.base_name}.rate", {**filtered_tags, "success": not exc_info},
+            f"{self.base_name}.rate",
+            {**filtered_tags, "success": not exc_info},
         ).increment(sample_rate=self.sample_rate)
 
         self.batch.flush()
@@ -221,7 +222,8 @@ class TaggedMetricsClientSpanObserver(SpanObserver):
         self.timer.stop()
 
         self.batch.counter(
-            f"{self.base_name}.rate", {**filtered_tags, "success": not exc_info},
+            f"{self.base_name}.rate",
+            {**filtered_tags, "success": not exc_info},
         ).increment(sample_rate=self.sample_rate)
 
         self.batch.flush()

--- a/baseplate/observers/timeout.py
+++ b/baseplate/observers/timeout.py
@@ -29,7 +29,8 @@ class TimeoutBaseplateObserver(BaseplateObserver):
             {
                 "server_timeout": {
                     "default": config.Optional(
-                        config.TimespanOrInfinite, default=config.InfiniteTimespan,
+                        config.TimespanOrInfinite,
+                        default=config.InfiniteTimespan,
                     ),
                     "debug": config.Optional(config.Boolean, default=False),
                     "by_endpoint": config.DictOf(config.TimespanOrInfinite),

--- a/baseplate/observers/tracing.py
+++ b/baseplate/observers/tracing.py
@@ -547,7 +547,9 @@ class SidecarRecorder(Recorder):
 
     def __init__(self, queue_name: str):
         self.queue = MessageQueue(
-            "/traces-" + queue_name, max_messages=MAX_QUEUE_SIZE, max_message_size=MAX_SPAN_SIZE,
+            "/traces-" + queue_name,
+            max_messages=MAX_QUEUE_SIZE,
+            max_message_size=MAX_SPAN_SIZE,
         )
 
     def send(self, span: TraceSpanObserver) -> None:

--- a/baseplate/server/__init__.py
+++ b/baseplate/server/__init__.py
@@ -520,7 +520,7 @@ def _is_containerized() -> bool:
         return True
 
     try:
-        with open("/proc/self/cgroup") as my_cgroups_file:
+        with open("/proc/self/cgroup", encoding="UTF-8") as my_cgroups_file:
             my_cgroups = my_cgroups_file.read()
 
             for hint in ["kubepods", "docker", "containerd"]:
@@ -536,7 +536,7 @@ def _has_PID1_parent() -> bool:
     """Determine parent PIDs up the tree until PID 1 or 0 is reached, do this natively"""
     parent_pid = os.getppid()
     while parent_pid > 1:
-        with open(f"/proc/{parent_pid}/status") as proc_status:
+        with open(f"/proc/{parent_pid}/status", encoding="UTF-8") as proc_status:
             for line in proc_status.readlines():
                 if line.startswith("PPid:"):
                     parent_pid = int(line.replace("PPid:", ""))
@@ -564,6 +564,6 @@ class LoggedInteractiveConsole(code.InteractiveConsole):
         """Generate an RFC 5424 compliant syslog format."""
         timestamp = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S.%fZ")
         prompt = f"<{self.pri}>1 {timestamp} {self.hostname} baseplate-shell {self.pid} {message_id} {structured} {message}"
-        with open(self.output_file, "w") as f:
+        with open(self.output_file, "w", encoding="UTF-8") as f:
             print(prompt, file=f)
             f.flush()

--- a/baseplate/server/__init__.py
+++ b/baseplate/server/__init__.py
@@ -442,7 +442,7 @@ def load_and_run_shell() -> None:
     # generate banner text
     banner = "Available Objects:\n"
     for var in sorted(env_banner.keys()):
-        banner += "\n  {:<12} {}".format(var, env_banner[var])
+        banner += f"\n  {var:<12} {env_banner[var]}"
 
     console_logpath = _get_shell_log_path()
 
@@ -526,7 +526,7 @@ def _is_containerized() -> bool:
             for hint in ["kubepods", "docker", "containerd"]:
                 if hint in my_cgroups:
                     return True
-    except IOError:
+    except OSError:
         pass
 
     return False
@@ -536,10 +536,10 @@ def _has_PID1_parent() -> bool:
     """Determine parent PIDs up the tree until PID 1 or 0 is reached, do this natively"""
     parent_pid = os.getppid()
     while parent_pid > 1:
-        with open(f"/proc/{parent_pid}/status", "r") as proc_status:
+        with open(f"/proc/{parent_pid}/status") as proc_status:
             for line in proc_status.readlines():
                 if line.startswith("PPid:"):
-                    parent_pid = int((line.replace("PPid:", "")))
+                    parent_pid = int(line.replace("PPid:", ""))
                     break
     return bool(parent_pid)
 

--- a/baseplate/sidecars/secrets_fetcher.py
+++ b/baseplate/sidecars/secrets_fetcher.py
@@ -123,7 +123,7 @@ def load_nonce() -> Optional[str]:
     """Load the nonce from disk."""
     try:
         logger.debug("Loading nonce.")
-        with open(NONCE_FILENAME) as f:
+        with open(NONCE_FILENAME, encoding="UTF-8") as f:
             return f.read()
     except OSError as exc:
         logger.debug("Nonce not found: %s.", exc)
@@ -188,7 +188,7 @@ class VaultClientFactory:
 
         """
         try:
-            with open(K8S_SERVICE_ACCOUNT_TOKEN_FILE) as f:
+            with open(K8S_SERVICE_ACCOUNT_TOKEN_FILE, encoding="UTF-8") as f:
                 token = f.read()
         except OSError:
             logger.error(
@@ -325,7 +325,7 @@ def fetch_secrets(
         secrets[secret_name], expiration = client.get_secret(secret_name)
         soonest_expiration = min(soonest_expiration, expiration)
 
-    with open(cfg.output.path + ".tmp", "w") as f:
+    with open(cfg.output.path + ".tmp", "w", encoding="UTF-8") as f:
         os.fchown(f.fileno(), cfg.output.owner, cfg.output.group)
         os.fchmod(f.fileno(), cfg.output.mode)
 

--- a/baseplate/sidecars/secrets_fetcher.py
+++ b/baseplate/sidecars/secrets_fetcher.py
@@ -123,7 +123,7 @@ def load_nonce() -> Optional[str]:
     """Load the nonce from disk."""
     try:
         logger.debug("Loading nonce.")
-        with open(NONCE_FILENAME, "r") as f:
+        with open(NONCE_FILENAME) as f:
             return f.read()
     except OSError as exc:
         logger.debug("Nonce not found: %s.", exc)
@@ -188,7 +188,7 @@ class VaultClientFactory:
 
         """
         try:
-            with open(K8S_SERVICE_ACCOUNT_TOKEN_FILE, "r") as f:
+            with open(K8S_SERVICE_ACCOUNT_TOKEN_FILE) as f:
                 token = f.read()
         except OSError:
             logger.error(

--- a/baseplate/thrift/BaseplateService.py
+++ b/baseplate/thrift/BaseplateService.py
@@ -229,7 +229,8 @@ class is_healthy_result(object):
     __slots__ = ("success",)
 
     def __init__(
-        self, success=None,
+        self,
+        success=None,
     ):
         self.success = success
 
@@ -290,6 +291,14 @@ class is_healthy_result(object):
 
 
 all_structs.append(is_healthy_result)
-is_healthy_result.thrift_spec = ((0, TType.BOOL, "success", None, None,),)  # 0
+is_healthy_result.thrift_spec = (
+    (
+        0,
+        TType.BOOL,
+        "success",
+        None,
+        None,
+    ),
+)  # 0
 fix_spec(all_structs)
 del all_structs

--- a/baseplate/thrift/BaseplateServiceV2.py
+++ b/baseplate/thrift/BaseplateServiceV2.py
@@ -177,7 +177,8 @@ class is_healthy_args(object):
     __slots__ = ("request",)
 
     def __init__(
-        self, request=None,
+        self,
+        request=None,
     ):
         self.request = request
 
@@ -241,7 +242,13 @@ class is_healthy_args(object):
 all_structs.append(is_healthy_args)
 is_healthy_args.thrift_spec = (
     None,  # 0
-    (1, TType.STRUCT, "request", [IsHealthyRequest, None], None,),  # 1
+    (
+        1,
+        TType.STRUCT,
+        "request",
+        [IsHealthyRequest, None],
+        None,
+    ),  # 1
 )
 
 
@@ -255,7 +262,8 @@ class is_healthy_result(object):
     __slots__ = ("success",)
 
     def __init__(
-        self, success=None,
+        self,
+        success=None,
     ):
         self.success = success
 
@@ -316,6 +324,14 @@ class is_healthy_result(object):
 
 
 all_structs.append(is_healthy_result)
-is_healthy_result.thrift_spec = ((0, TType.BOOL, "success", None, None,),)  # 0
+is_healthy_result.thrift_spec = (
+    (
+        0,
+        TType.BOOL,
+        "success",
+        None,
+        None,
+    ),
+)  # 0
 fix_spec(all_structs)
 del all_structs

--- a/baseplate/thrift/ttypes.py
+++ b/baseplate/thrift/ttypes.py
@@ -162,7 +162,8 @@ class IsHealthyRequest(object):
     __slots__ = ("probe",)
 
     def __init__(
-        self, probe=None,
+        self,
+        probe=None,
     ):
         self.probe = probe
 
@@ -259,7 +260,11 @@ class Error(TException):
     )
 
     def __init__(
-        self, code=None, message=None, details=None, retryable=None,
+        self,
+        code=None,
+        message=None,
+        details=None,
+        retryable=None,
     ):
         super(Error, self).__setattr__("code", code)
         super(Error, self).__setattr__("message", message)
@@ -273,7 +278,14 @@ class Error(TException):
         raise TypeError("can't modify immutable instance")
 
     def __hash__(self):
-        return hash(self.__class__) ^ hash((self.code, self.message, self.details, self.retryable,))
+        return hash(self.__class__) ^ hash(
+            (
+                self.code,
+                self.message,
+                self.details,
+                self.retryable,
+            )
+        )
 
     @classmethod
     def read(cls, iprot):
@@ -334,7 +346,12 @@ class Error(TException):
                 iprot.skip(ftype)
             iprot.readFieldEnd()
         iprot.readStructEnd()
-        return cls(code=code, message=message, details=details, retryable=retryable,)
+        return cls(
+            code=code,
+            message=message,
+            details=details,
+            retryable=retryable,
+        )
 
     def write(self, oprot):
         if oprot._fast_encode is not None and self.thrift_spec is not None:
@@ -393,15 +410,45 @@ class Error(TException):
 all_structs.append(IsHealthyRequest)
 IsHealthyRequest.thrift_spec = (
     None,  # 0
-    (1, TType.I32, "probe", None, None,),  # 1
+    (
+        1,
+        TType.I32,
+        "probe",
+        None,
+        None,
+    ),  # 1
 )
 all_structs.append(Error)
 Error.thrift_spec = (
     None,  # 0
-    (1, TType.I32, "code", None, None,),  # 1
-    (2, TType.STRING, "message", "UTF8", None,),  # 2
-    (3, TType.MAP, "details", (TType.STRING, "UTF8", TType.STRING, "UTF8", False), None,),  # 3
-    (4, TType.BOOL, "retryable", None, None,),  # 4
+    (
+        1,
+        TType.I32,
+        "code",
+        None,
+        None,
+    ),  # 1
+    (
+        2,
+        TType.STRING,
+        "message",
+        "UTF8",
+        None,
+    ),  # 2
+    (
+        3,
+        TType.MAP,
+        "details",
+        (TType.STRING, "UTF8", TType.STRING, "UTF8", False),
+        None,
+    ),  # 3
+    (
+        4,
+        TType.BOOL,
+        "retryable",
+        None,
+        None,
+    ),  # 4
 )
 fix_spec(all_structs)
 del all_structs

--- a/requirements-transitive.txt
+++ b/requirements-transitive.txt
@@ -42,9 +42,10 @@ netifaces==0.10.9
 objgraph==3.5.0
 packaging==20.9
 PasteDeploy==2.1.1
-pathspec==0.8.1
+pathspec==0.9.0
 plaster==1.0
 plaster-pastedeploy==0.7
+platformdirs==2.4.0
 pluggy==0.13.1
 posix-ipc==1.0.5
 py==1.10.0
@@ -78,8 +79,9 @@ sphinxcontrib-serializinghtml==1.1.4
 SQLAlchemy==1.4.12
 thrift-unofficial==0.14.1
 toml==0.10.2
+tomli==1.2.2
 translationstring==1.4
-typing-extensions==3.7.4.3
+typing-extensions==3.10.0.2
 urllib3==1.26.6
 venusian==3.0.0
 vine==1.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@
 # supported.
 -r requirements-transitive.txt
 astroid==2.6.6
-black==19.10b0
+black==21.10b0
 flake8==3.8.4
 lxml==4.6.5
 mypy==0.910

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,14 +4,14 @@
 # See install_requires and extras_require in setup.py for the range of versions
 # supported.
 -r requirements-transitive.txt
-astroid==2.6.6
+astroid==2.8.4
 black==21.10b0
 flake8==3.8.4
 lxml==4.6.5
 mypy==0.910
 prometheus-client==0.12.0
 pydocstyle==5.1.1
-pylint==2.9.6
+pylint==2.11.1
 pytest==6.2.2
 pytest-cov==2.11.1
 pytz==2021.1

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -25,7 +25,7 @@ def get_endpoint_or_skip_container(name, default_port):
         sock = socket.socket(endpoint.family, socket.SOCK_STREAM)
         sock.settimeout(0.1)
         sock.connect(endpoint.address)
-    except socket.error:
+    except OSError:
         raise unittest.SkipTest("could not find %s server for integration tests" % name)
     else:
         sock.close()
@@ -51,7 +51,7 @@ class TestSpanObserver(SpanObserver):
         self.tags[key] = value
 
     def assert_tag(self, key, value):
-        assert key in self.tags, "{!r} not found in tags ({!r})".format(key, list(self.tags.keys()))
+        assert key in self.tags, f"{key!r} not found in tags ({list(self.tags.keys())!r})"
         assert self.tags[key] == value, "tag {!r}: expected value {!r} but found {!r}".format(
             key, value, self.tags[key]
         )

--- a/tests/integration/test_thrift/TestService.py
+++ b/tests/integration/test_thrift/TestService.py
@@ -194,7 +194,9 @@ class example_result(object):
     )
 
     def __init__(
-        self, success=None, exc=None,
+        self,
+        success=None,
+        exc=None,
     ):
         self.success = success
         self.exc = exc
@@ -266,8 +268,20 @@ class example_result(object):
 
 all_structs.append(example_result)
 example_result.thrift_spec = (
-    (0, TType.BOOL, "success", None, None,),  # 0
-    (1, TType.STRUCT, "exc", [ExpectedException, None], None,),  # 1
+    (
+        0,
+        TType.BOOL,
+        "success",
+        None,
+        None,
+    ),  # 0
+    (
+        1,
+        TType.STRUCT,
+        "exc",
+        [ExpectedException, None],
+        None,
+    ),  # 1
 )
 fix_spec(all_structs)
 del all_structs

--- a/tests/integration/test_thrift/ttypes.py
+++ b/tests/integration/test_thrift/ttypes.py
@@ -97,7 +97,9 @@ class ExampleStruct(object):
     )
 
     def __init__(
-        self, string_field=None, int_field=None,
+        self,
+        string_field=None,
+        int_field=None,
     ):
         self.string_field = string_field
         self.int_field = int_field
@@ -178,8 +180,20 @@ ExpectedException.thrift_spec = ()
 all_structs.append(ExampleStruct)
 ExampleStruct.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, "string_field", "UTF8", None,),  # 1
-    (2, TType.I64, "int_field", None, None,),  # 2
+    (
+        1,
+        TType.STRING,
+        "string_field",
+        "UTF8",
+        None,
+    ),  # 1
+    (
+        2,
+        TType.I64,
+        "int_field",
+        None,
+        None,
+    ),  # 2
 )
 fix_spec(all_structs)
 del all_structs

--- a/tests/integration/thrift_tests.py
+++ b/tests/integration/thrift_tests.py
@@ -80,7 +80,10 @@ def raw_thrift_client(endpoint, client_spec):
 
 @contextlib.contextmanager
 def baseplate_thrift_client(
-    endpoint, client_spec, client_span_observer=None, timeout=None,
+    endpoint,
+    client_spec,
+    client_span_observer=None,
+    timeout=None,
 ):
     app_config = {
         "baseplate.service_name": "fancy test client",

--- a/tests/integration/tracing_tests.py
+++ b/tests/integration/tracing_tests.py
@@ -74,7 +74,8 @@ class TracingTests(unittest.TestCase):
         self.baseplate.register(self.observer)
 
         self.baseplate_configurator = BaseplateConfigurator(
-            self.baseplate, header_trust_handler=StaticTrustHandler(trust_headers=True),
+            self.baseplate,
+            header_trust_handler=StaticTrustHandler(trust_headers=True),
         )
         configurator.include(self.baseplate_configurator.includeme)
         app = configurator.make_wsgi_app()

--- a/tests/unit/lib/file_watcher_tests.py
+++ b/tests/unit/lib/file_watcher_tests.py
@@ -147,7 +147,7 @@ class FileWatcherTests(unittest.TestCase):
             ) as open_mock:
                 watcher.get_data()
             open_mock.assert_called_once_with(
-                watched_file.name, encoding=None, mode="r", newline=None
+                watched_file.name, encoding="UTF-8", mode="r", newline=None
             )
 
             watcher = file_watcher.FileWatcher(

--- a/tests/unit/lib/file_watcher_tests.py
+++ b/tests/unit/lib/file_watcher_tests.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import builtins
 import json
 import os

--- a/tests/unit/lib/metrics_tests.py
+++ b/tests/unit/lib/metrics_tests.py
@@ -1,4 +1,3 @@
-# coding=utf8
 import socket
 import unittest
 

--- a/tests/unit/observers/tracing_tests.py
+++ b/tests/unit/observers/tracing_tests.py
@@ -223,14 +223,14 @@ class TraceSpanObserverTests(TraceTestBase):
 
     def test_create_binary_annotation(self):
         annotation = self.test_span_observer._create_binary_annotation("test-key", "test-value")
-        self.assertEquals(annotation["key"], "test-key")
-        self.assertEquals(annotation["value"], "test-value")
+        self.assertEqual(annotation["key"], "test-key")
+        self.assertEqual(annotation["value"], "test-value")
         self.assertTrue(annotation["endpoint"])
 
     def test_create_binary_annotation_coerces_string(self):
         annotation = self.test_span_observer._create_binary_annotation("test-key", 1)
-        self.assertEquals(annotation["key"], "test-key")
-        self.assertEquals(annotation["value"], "1")
+        self.assertEqual(annotation["key"], "test-key")
+        self.assertEqual(annotation["value"], "1")
         self.assertTrue(annotation["endpoint"])
 
     def test_on_set_tag_adds_binary_annotation(self):
@@ -238,8 +238,8 @@ class TraceSpanObserverTests(TraceTestBase):
         self.assertFalse(self.test_span_observer.binary_annotations)
         self.test_span_observer.on_set_tag("test-key", "test-value")
         annotation = self.test_span_observer.binary_annotations[0]
-        self.assertEquals(annotation["key"], "test-key")
-        self.assertEquals(annotation["value"], "test-value")
+        self.assertEqual(annotation["key"], "test-key")
+        self.assertEqual(annotation["value"], "test-value")
 
     def test_to_span_obj_sets_parent_id(self):
         span_obj = self.test_span_observer._to_span_obj([], [])
@@ -257,8 +257,8 @@ class TraceSpanObserverTests(TraceTestBase):
         self.test_span_observer.on_incr_tag("test-key", 5)
         self.test_span_observer.on_finish(None)
         annotation = self.test_span_observer.binary_annotations[0]
-        self.assertEquals(annotation["key"], "counter.test-key")
-        self.assertEquals(annotation["value"], "8.0")
+        self.assertEqual(annotation["key"], "counter.test-key")
+        self.assertEqual(annotation["value"], "8.0")
 
 
 class TraceServerSpanObserverTests(TraceTestBase):

--- a/tests/unit/sidecars/live_data_watcher_tests.py
+++ b/tests/unit/sidecars/live_data_watcher_tests.py
@@ -17,7 +17,7 @@ class NodeWatcherTests(unittest.TestCase):
 
     def test_on_change(self):
         dest = self.output_dir.joinpath("data.txt")
-        inst = NodeWatcher(str(dest), os.getuid(), os.getgid(), 777,)
+        inst = NodeWatcher(str(dest), os.getuid(), os.getgid(), 777)
 
         new_content = b"foobar"
         inst.on_change(new_content, None)
@@ -27,7 +27,7 @@ class NodeWatcherTests(unittest.TestCase):
 
     def test_on_change_new_dir(self):
         dest = self.output_dir.joinpath("data/output.json")
-        inst = NodeWatcher(str(dest), os.getuid(), os.getgid(), 777,)
+        inst = NodeWatcher(str(dest), os.getuid(), os.getgid(), 777)
 
         new_content = b"foobar"
         inst.on_change(new_content, None)
@@ -35,7 +35,7 @@ class NodeWatcherTests(unittest.TestCase):
 
     def test_on_change_deep_new_dir(self):
         dest = self.output_dir.joinpath("data/foo/bar.json")
-        inst = NodeWatcher(str(dest), os.getuid(), os.getgid(), 777,)
+        inst = NodeWatcher(str(dest), os.getuid(), os.getgid(), 777)
 
         new_content = b"foobar"
         inst.on_change(new_content, None)


### PR DESCRIPTION
This is the prerequisite commits from https://github.com/reddit/baseplate.py/pull/627 but without the actual Python 3.10 support. 

Once @alisaifee's fix to the C extension in Thrift (https://github.com/apache/thrift/commit/b724787d373de99fee2222ab0eb2e052f8c8d3ed) is in a published release we can start requiring that here and add Py 3.10 support ([which looks like this](https://github.com/reddit/baseplate.py/pull/627/commits/c02193a64d2c2bac591305d86b63b4f3893f3478)) assuming that the rest of the toolchain is ready for it. But until then, I wanted to land these patches so they don't get more stale as other stuff gets changed.