### PR TITLE
Fix Thrift pool connection leak when a ServerTimeout is raised while releasing a connection

### DIFF
--- a/tests/unit/lib/thrift_pool_tests.py
+++ b/tests/unit/lib/thrift_pool_tests.py
@@ -200,6 +200,17 @@ class ThriftConnectionPoolTests(unittest.TestCase):
         self.assertEqual(self.mock_queue.put.call_count, 1)
         self.assertEqual(self.mock_queue.put.call_args, mock.call(None))
 
+    def test_release_server_timeout(self):
+        mock_prot = mock.Mock(spec=THeaderProtocol.THeaderProtocol)
+        mock_prot.trans = mock.Mock(spec=TSocket.TSocket)
+        mock_prot.trans.isOpen.side_effect = ServerTimeout("span", 10.0, False)
+
+        with self.assertRaises(ServerTimeout):
+            self.pool._release(mock_prot)
+
+        self.assertEqual(self.mock_queue.put.call_count, 1)
+        self.assertEqual(self.mock_queue.put.call_args, mock.call(None))
+
     @mock.patch("time.time")
     def test_context_normal(self, mock_time):
         mock_time.return_value = 123


### PR DESCRIPTION
_(disclaimer: I haven't 100% confirmed that this is the root cause of our connection leak, but think that it is likely. Would appreciate any insights here!)_

If a `ServerTimeout` exception is raised while the Thrift Pool is releasing a connection, the connection is not properly released back into the pool. This causes a connection leak as the pool size is permanently decreased until restart, eventually resulting in service instability.

Given the difficulty of properly managing these connections, it might make sense to introduce some kind of self-healing mechanism.