### PR TITLE
Log the inner exception that TTransportException wraps

### DIFF
--- a/baseplate/clients/thrift.py
+++ b/baseplate/clients/thrift.py
@@ -192,7 +192,9 @@ def _build_thrift_proxy_method(name: str) -> Callable[..., Any]:
             except TTransportException as exc:
                 # the connection failed for some reason, retry if able
                 span.finish(exc_info=sys.exc_info())
-                last_error = exc
+                last_error = str(exc)
+                if exc.inner is not None:
+                    last_error += f" ({exc.inner})"
                 continue
             except (TApplicationException, TProtocolException):
                 # these are subclasses of TException but aren't ones that


### PR DESCRIPTION
I am debugging a Thrift connection issue and am seeing lots of `TTransportException` errors with the message `unexpected exception`. These `TTransportException` errors [wrap an inner exception](https://github.com/apache/thrift/blob/66d897667c451ef6560d89b979b7001c57a3eda6/lib/py/src/transport/TSocket.py#L164) containing the actual socket error, but this is never logged because it isn't shown by `TTransportException.__str__`.

This PR checks for an inner exception when logging a `TTransportException` in the Thrift client and logs it if it is present.