### PR TITLE
Fix Thrift pool connection leak

### DIFF
--- a/baseplate/lib/thrift_pool.py
+++ b/baseplate/lib/thrift_pool.py
@@ -16,7 +16,6 @@ A basic example of usage::
 """
 import contextlib
 import logging
-import queue
 import socket
 import time
 
@@ -33,6 +32,8 @@ from thrift.Thrift import TApplicationException
 from thrift.Thrift import TException
 from thrift.transport.TSocket import TSocket
 from thrift.transport.TTransport import TTransportException
+
+import gevent.queue as queue
 
 from baseplate.lib import config
 from baseplate.lib.retry import RetryPolicy


### PR DESCRIPTION
If a `ServerTimeout` exception is raised as a Thrift connection is being released back into the pool then the connection is never released. This results in a connection leak and eventually causes service instability until the service is restarted. I have [stack traces](https://gist.github.snooguts.net/rogan-murley/110ec99c68ea78be3b5b13f67edbab7b) and [connection pool usage graphs](https://gist.github.snooguts.net/rogan-murley/0071fb116b924c74138a5f57fdf1083b) showing this behavior.

<img width="294" alt="Screenshot 2022-01-18 at 17 58 46" src="https://user-images.githubusercontent.com/3668870/149992639-850e2401-7007-4ea6-9fc8-aca13526fd9e.png">

> Server timeout error spike (blue) followed by stepwise Thrift pool usage increase consistent with a connection leak (purple)

The above stack trace was surprising because gevent queues should provide atomicity: a context switch should not happen during a non-blocking `.put()`. However from stack traces I can see that the Thrift pool does not use a gevent queue, it actually uses the standard library queue. It appears that queues (other than `SimpleQueue`) are [not ever monkey patched by gevent](https://github.com/gevent/gevent/issues/1248#issuecomment-430469639), so you need to explicitly import gevent queues if you want to use them.

The standard library queue works fine with gevent as it is built ontop of threads (which themselves are patched by gevent), but has worse performance and doesn't provide atomicity guarantees. In this PR I have swapped the Thrift pool to use the gevent queue. This should prevent context switching during the `.put()` and so fix the connection leak.

There are other uses of standard library queues rather than gevent queues in baseplate.py which should also be reviewed.
