### PR TITLE
Default to gevent queue for Redis connection pool

### DIFF
--- a/baseplate/clients/redis.py
+++ b/baseplate/clients/redis.py
@@ -11,6 +11,8 @@ try:
 except ImportError:
     from redis.client import Pipeline
 
+from gevent import queue
+
 from baseplate import Span
 from baseplate.clients import ContextFactory
 from baseplate.lib import config
@@ -56,6 +58,9 @@ def pool_from_config(
         kwargs.setdefault("socket_connect_timeout", options.socket_connect_timeout.total_seconds())
     if options.socket_timeout is not None:
         kwargs.setdefault("socket_timeout", options.socket_timeout.total_seconds())
+
+    if "queue_class" not in kwargs:
+        kwargs["queue_class"] = queue.LifoQueue
 
     return redis.BlockingConnectionPool.from_url(options.url, **kwargs)
 


### PR DESCRIPTION
This change adapts https://github.com/reddit/baseplate.py/pull/643 to the Redis connection pool.

We've already been recommending that they use this queue for a while, by passing `queue_class=gevent.queue.LifoQueue` when creating their connection pool, so this just changes the default.

Note that the redis-cluster client would in theory also benefit from this but that change would require internally patching `redis-py-cluster`, which is probably not worth doing given that library has already been deprecated in favour of `redis-py`