### PR TITLE
make sentry with_locals configurable

### DIFF
--- a/baseplate/observers/sentry.py
+++ b/baseplate/observers/sentry.py
@@ -71,6 +71,7 @@ def init_sentry_client_from_config(raw_config: config.RawConfig, **kwargs: Any) 
                 "environment": config.Optional(config.String, default=None),
                 "sample_rate": config.Optional(config.Percent, default=1),
                 "ignore_errors": config.Optional(config.TupleOf(config.String), default=()),
+                "with_locals": config.Optional(config.Boolean, default=False),
             }
         },
     )
@@ -88,7 +89,7 @@ def init_sentry_client_from_config(raw_config: config.RawConfig, **kwargs: Any) 
     ignore_errors.extend(cfg.sentry.ignore_errors)
     kwargs.setdefault("ignore_errors", ignore_errors)
 
-    kwargs.setdefault("with_locals", False)
+    kwargs.setdefault("with_locals", cfg.sentry.with_locals)
 
     client = sentry_sdk.Client(**kwargs)
     sentry_sdk.Hub.current.bind_client(client)

--- a/docs/api/baseplate/observers/sentry.rst
+++ b/docs/api/baseplate/observers/sentry.rst
@@ -41,6 +41,9 @@ the Sentry observer.
    # classes to not report.
    sentry.ignore_errors = my_service.UninterestingException
 
+   # optional: whether or not local variables are sent along with stackframes. this
+   # could expose PII.
+   sentry.with_locals = true
    ...
 
 


### PR DESCRIPTION
Currently, this is defaulted to false but is not configurable. This
commit enables users to configure with_locals to suit their needs.