### PR TITLE
Add extra config to Kafka consumer factory

### DIFF
--- a/baseplate/frameworks/queue_consumer/kafka.py
+++ b/baseplate/frameworks/queue_consumer/kafka.py
@@ -213,7 +213,7 @@ class _BaseKafkaQueueConsumerFactory(QueueConsumerFactory):
         kafka_consume_batch_size: int = 1,
         message_unpack_fn: KafkaMessageDeserializer = json.loads,
         health_check_fn: Optional[HealthcheckCallback] = None,
-        kafka_config: Dict[str, Any] = None,
+        kafka_config: Optional[Dict[str, Any]] = None,
     ) -> "_BaseKafkaQueueConsumerFactory":
         """Return a new `_BaseKafkaQueueConsumerFactory`.
 
@@ -238,7 +238,7 @@ class _BaseKafkaQueueConsumerFactory(QueueConsumerFactory):
             and returns the message in the format the handler expects. Defaults to `json.loads`.
         :param health_check_fn: A `baseplate.server.queue_consumer.HealthcheckCallback`
             function that can be used to customize your health check.
-        :param kafka_config: Dict[str, Any]: An optional config for confluent_kafka.Consumer
+        :param kafka_config: An optional config for confluent_kafka.Consumer
 
         """
         service_name, _, group_name = group_id.partition(".")
@@ -267,7 +267,7 @@ class _BaseKafkaQueueConsumerFactory(QueueConsumerFactory):
         bootstrap_servers: str,
         group_id: str,
         topics: Sequence[str],
-        kafka_config: Dict[str, Any] = None,
+        kafka_config: Optional[Dict[str, Any]] = None,
     ) -> confluent_kafka.Consumer:
         consumer_config = {
             "bootstrap.servers": bootstrap_servers,

--- a/baseplate/frameworks/queue_consumer/kafka.py
+++ b/baseplate/frameworks/queue_consumer/kafka.py
@@ -213,6 +213,7 @@ class _BaseKafkaQueueConsumerFactory(QueueConsumerFactory):
         kafka_consume_batch_size: int = 1,
         message_unpack_fn: KafkaMessageDeserializer = json.loads,
         health_check_fn: Optional[HealthcheckCallback] = None,
+        kafka_config: Dict[str, Any] = None,
     ) -> "_BaseKafkaQueueConsumerFactory":
         """Return a new `_BaseKafkaQueueConsumerFactory`.
 
@@ -237,13 +238,14 @@ class _BaseKafkaQueueConsumerFactory(QueueConsumerFactory):
             and returns the message in the format the handler expects. Defaults to `json.loads`.
         :param health_check_fn: A `baseplate.server.queue_consumer.HealthcheckCallback`
             function that can be used to customize your health check.
+        :param kafka_config: Dict[str, Any]: An optional config for confluent_kafka.Consumer
 
         """
         service_name, _, group_name = group_id.partition(".")
         assert service_name and group_name, "group_id must start with 'SERVICENAME.'"
         assert name == f"kafka_consumer.{group_name}"
 
-        consumer = cls.make_kafka_consumer(bootstrap_servers, group_id, topics)
+        consumer = cls.make_kafka_consumer(bootstrap_servers, group_id, topics, kafka_config)
 
         return cls(
             name=name,
@@ -261,7 +263,11 @@ class _BaseKafkaQueueConsumerFactory(QueueConsumerFactory):
 
     @classmethod
     def make_kafka_consumer(
-        cls, bootstrap_servers: str, group_id: str, topics: Sequence[str]
+        cls,
+        bootstrap_servers: str,
+        group_id: str,
+        topics: Sequence[str],
+        kafka_config: Dict[str, Any] = None,
     ) -> confluent_kafka.Consumer:
         consumer_config = {
             "bootstrap.servers": bootstrap_servers,
@@ -272,6 +278,8 @@ class _BaseKafkaQueueConsumerFactory(QueueConsumerFactory):
             "auto.offset.reset": "latest",
         }
         consumer_config.update(cls._consumer_config())
+        if kafka_config:
+            consumer_config.update(kafka_config)
         consumer = confluent_kafka.Consumer(consumer_config)
 
         try:

--- a/tests/unit/frameworks/queue_consumer/kafka_tests.py
+++ b/tests/unit/frameworks/queue_consumer/kafka_tests.py
@@ -256,8 +256,11 @@ class TestInOrderConsumerFactory:
             topics={"topic_1": mock.Mock(), "topic_2": mock.Mock(), "topic_3": mock.Mock()}
         )
         kafka_consumer.return_value = mock_consumer
+        extra_config = {"queued.max.messages.kbytes": 10000}
 
-        _consumer = InOrderConsumerFactory.make_kafka_consumer(bootstrap_servers, group_id, topics)
+        _consumer = InOrderConsumerFactory.make_kafka_consumer(
+            bootstrap_servers, group_id, topics, extra_config
+        )
 
         assert _consumer == mock_consumer
 
@@ -270,6 +273,7 @@ class TestInOrderConsumerFactory:
                 "session.timeout.ms": 10000,
                 "max.poll.interval.ms": 300000,
                 "enable.auto.commit": "false",
+                "queued.max.messages.kbytes": 10000,
             }
         )
         mock_consumer.subscribe.assert_called_once()
@@ -284,9 +288,12 @@ class TestInOrderConsumerFactory:
             topics={"topic_1": mock.Mock(), "topic_2": mock.Mock(), "topic_3": mock.Mock()}
         )
         kafka_consumer.return_value = mock_consumer
+        extra_config = {"queued.max.messages.kbytes": 100}
 
         with pytest.raises(AssertionError):
-            InOrderConsumerFactory.make_kafka_consumer(bootstrap_servers, group_id, ["topic_4"])
+            InOrderConsumerFactory.make_kafka_consumer(
+                bootstrap_servers, group_id, ["topic_4"], extra_config
+            )
 
         kafka_consumer.assert_called_once_with(
             {
@@ -297,6 +304,7 @@ class TestInOrderConsumerFactory:
                 "session.timeout.ms": 10000,
                 "max.poll.interval.ms": 300000,
                 "enable.auto.commit": "false",
+                "queued.max.messages.kbytes": 100,
             }
         )
         mock_consumer.subscribe.assert_not_called()


### PR DESCRIPTION
My tests showed that passing `queued.max.messages.kbytes` parameter to Kafka consumer made it more stable when facing lags (service could start up and process the backed up messages without bumping up the pod memory). However, hardcoding this value can be harmful in other scenarios, when there's enough of memory and the raw throughput is more important.

So, the idea is: to accept extra config parameters for `confluent_kafka.Consumer`. It will allow extending the consumer factories without completely forking them; right now the only way to pass additional parameter is a fork as far as I know.