### PR TITLE
Add default prometheus metrics to clients

### DIFF
--- a/baseplate/clients/memcache/__init__.py
+++ b/baseplate/clients/memcache/__init__.py
@@ -133,31 +133,31 @@ class MemcacheContextFactory(ContextFactory):
     PROM_PREFIX = "bp_memcached_pool"
     PROM_LABELS = ["pool"]
 
-    promTotalConnections = Gauge(
+    prom_total_connections = Gauge(
         f"{PROM_PREFIX}_size",
         "Maximum size of this pool",
         PROM_LABELS,
     )
 
-    promUsedConnections = Gauge(
+    prom_used_connections = Gauge(
         f"{PROM_PREFIX}_in_use",
         "Number of connections in this pool currently in use",
         PROM_LABELS,
     )
 
-    promFreeConnections = Gauge(
+    prom_free_connections = Gauge(
         f"{PROM_PREFIX}_free",
         "Number of free connections in this pool",
         PROM_LABELS,
     )
 
-    def __init__(self, pooled_client: PooledClient, name: str = "memcache"):
+    def __init__(self, pooled_client: PooledClient, name: str = "default"):
         self.pooled_client = pooled_client
 
         pool = self.pooled_client.client_pool
-        self.promTotalConnections.labels(name).set_function(lambda: pool.max_size)
-        self.promFreeConnections.labels(name).set_function(lambda: len(pool.free))
-        self.promUsedConnections.labels(name).set_function(lambda: len(pool.used))
+        self.prom_total_connections.labels(name).set_function(lambda: pool.max_size)
+        self.prom_free_connections.labels(name).set_function(lambda: len(pool.free))
+        self.prom_used_connections.labels(name).set_function(lambda: len(pool.used))
 
     def report_memcache_runtime_metrics(self, batch: metrics.Client) -> None:
         pool = self.pooled_client.client_pool

--- a/baseplate/clients/memcache/__init__.py
+++ b/baseplate/clients/memcache/__init__.py
@@ -134,8 +134,8 @@ class MemcacheContextFactory(ContextFactory):
     PROM_LABELS = ["pool"]
 
     pool_size_gauge = Gauge(
-        f"{PROM_PREFIX}_size",
-        "Maximum size of this pool",
+        f"{PROM_PREFIX}_max_size",
+        "Maximum number of connections allowed in this pool",
         PROM_LABELS,
     )
 

--- a/baseplate/clients/memcache/__init__.py
+++ b/baseplate/clients/memcache/__init__.py
@@ -133,20 +133,20 @@ class MemcacheContextFactory(ContextFactory):
     PROM_PREFIX = "bp_memcached_pool"
     PROM_LABELS = ["pool"]
 
-    prom_total_connections = Gauge(
+    pool_size_gauge = Gauge(
         f"{PROM_PREFIX}_size",
         "Maximum size of this pool",
         PROM_LABELS,
     )
 
-    prom_used_connections = Gauge(
-        f"{PROM_PREFIX}_in_use",
+    used_connections_gauge = Gauge(
+        f"{PROM_PREFIX}_active_connections",
         "Number of connections in this pool currently in use",
         PROM_LABELS,
     )
 
-    prom_free_connections = Gauge(
-        f"{PROM_PREFIX}_free",
+    free_connections_gauge = Gauge(
+        f"{PROM_PREFIX}_free_connections",
         "Number of free connections in this pool",
         PROM_LABELS,
     )
@@ -155,9 +155,9 @@ class MemcacheContextFactory(ContextFactory):
         self.pooled_client = pooled_client
 
         pool = self.pooled_client.client_pool
-        self.prom_total_connections.labels(name).set_function(lambda: pool.max_size)
-        self.prom_free_connections.labels(name).set_function(lambda: len(pool.free))
-        self.prom_used_connections.labels(name).set_function(lambda: len(pool.used))
+        self.pool_size_gauge.labels(name).set_function(lambda: pool.max_size)
+        self.free_connections_gauge.labels(name).set_function(lambda: len(pool.free))
+        self.used_connections_gauge.labels(name).set_function(lambda: len(pool.used))
 
     def report_memcache_runtime_metrics(self, batch: metrics.Client) -> None:
         pool = self.pooled_client.client_pool

--- a/baseplate/clients/redis.py
+++ b/baseplate/clients/redis.py
@@ -103,12 +103,12 @@ class RedisContextFactory(ContextFactory):
         PROM_LABELS,
     )
     idle_connections = Gauge(
-        f"{PROM_PREFIX}_connections_idle",
+        f"{PROM_PREFIX}_idle_connections",
         "Number of idle connections in this redisbp pool",
         PROM_LABELS,
     )
     open_connections = Gauge(
-        f"{PROM_PREFIX}_connections_open",
+        f"{PROM_PREFIX}_active_connections",
         "Number of open connections in this redisbp pool",
         PROM_LABELS,
     )

--- a/baseplate/clients/redis.py
+++ b/baseplate/clients/redis.py
@@ -97,18 +97,18 @@ class RedisContextFactory(ContextFactory):
     PROM_PREFIX = "bp_redis_pool"
     PROM_LABELS = ["pool"]
 
-    totalConnections = Gauge(
+    total_connections = Gauge(
         f"{PROM_PREFIX}_connections",
         "Number of connections in this redisbp pool",
         PROM_LABELS,
     )
-    idleConnections = Gauge(
-        f"{PROM_PREFIX}_idle_connections",
+    idle_connections = Gauge(
+        f"{PROM_PREFIX}_connections_idle",
         "Number of idle connections in this redisbp pool",
         PROM_LABELS,
     )
-    openConnections = Gauge(
-        f"{PROM_PREFIX}_open_connections",
+    open_connections = Gauge(
+        f"{PROM_PREFIX}_connections_open",
         "Number of open connections in this redisbp pool",
         PROM_LABELS,
     )
@@ -117,9 +117,11 @@ class RedisContextFactory(ContextFactory):
         self.connection_pool = connection_pool
 
         if isinstance(connection_pool, redis.BlockingConnectionPool):
-            self.totalConnections.labels(name).set_function(lambda: connection_pool.max_connections)
-            self.idleConnections.labels(name).set_function(connection_pool.pool.qsize)
-            self.openConnections.labels(name).set_function(
+            self.total_connections.labels(name).set_function(
+                lambda: connection_pool.max_connections
+            )
+            self.idle_connections.labels(name).set_function(connection_pool.pool.qsize)
+            self.open_connections.labels(name).set_function(
                 lambda: len(connection_pool._connections)  # type: ignore
             )
 

--- a/baseplate/clients/redis.py
+++ b/baseplate/clients/redis.py
@@ -99,7 +99,7 @@ class RedisContextFactory(ContextFactory):
 
     total_connections = Gauge(
         f"{PROM_PREFIX}_size",
-        "Maximum number of connections in this redisbp pool",
+        "Maximum number of connections allowed in this redisbp pool",
         PROM_LABELS,
     )
     idle_connections = Gauge(

--- a/baseplate/clients/redis.py
+++ b/baseplate/clients/redis.py
@@ -5,6 +5,8 @@ from typing import Optional
 
 import redis
 
+from prometheus_client import Gauge
+
 # redis.client.StrictPipeline was renamed to redis.client.Pipeline in version 3.0
 try:
     from redis.client import StrictPipeline as Pipeline  # type: ignore
@@ -75,7 +77,7 @@ class RedisClient(config.Parser):
 
     def parse(self, key_path: str, raw_config: config.RawConfig) -> "RedisContextFactory":
         connection_pool = pool_from_config(raw_config, f"{key_path}.", **self.kwargs)
-        return RedisContextFactory(connection_pool)
+        return RedisContextFactory(connection_pool, key_path)
 
 
 class RedisContextFactory(ContextFactory):
@@ -92,8 +94,34 @@ class RedisContextFactory(ContextFactory):
 
     """
 
-    def __init__(self, connection_pool: redis.ConnectionPool):
+    PROM_PREFIX = "bp_redis_pool"
+    PROM_LABELS = ["pool"]
+
+    totalConnections = Gauge(
+        f"{PROM_PREFIX}_connections",
+        "Number of connections in this redisbp pool",
+        PROM_LABELS,
+    )
+    idleConnections = Gauge(
+        f"{PROM_PREFIX}_idle_connections",
+        "Number of idle connections in this redisbp pool",
+        PROM_LABELS,
+    )
+    openConnections = Gauge(
+        f"{PROM_PREFIX}_open_connections",
+        "Number of open connections in this redisbp pool",
+        PROM_LABELS,
+    )
+
+    def __init__(self, connection_pool: redis.ConnectionPool, name: str = "redis"):
         self.connection_pool = connection_pool
+
+        if isinstance(connection_pool, redis.BlockingConnectionPool):
+            self.totalConnections.labels(name).set_function(lambda: connection_pool.max_connections)
+            self.idleConnections.labels(name).set_function(connection_pool.pool.qsize)
+            self.openConnections.labels(name).set_function(
+                lambda: len(connection_pool._connections)  # type: ignore
+            )
 
     def report_runtime_metrics(self, batch: metrics.Client) -> None:
         if not isinstance(self.connection_pool, redis.BlockingConnectionPool):

--- a/baseplate/clients/redis.py
+++ b/baseplate/clients/redis.py
@@ -98,8 +98,8 @@ class RedisContextFactory(ContextFactory):
     PROM_LABELS = ["pool"]
 
     total_connections = Gauge(
-        f"{PROM_PREFIX}_connections",
-        "Number of connections in this redisbp pool",
+        f"{PROM_PREFIX}_size",
+        "Maximum number of connections in this redisbp pool",
         PROM_LABELS,
     )
     idle_connections = Gauge(

--- a/baseplate/clients/redis.py
+++ b/baseplate/clients/redis.py
@@ -97,8 +97,8 @@ class RedisContextFactory(ContextFactory):
     PROM_PREFIX = "bp_redis_pool"
     PROM_LABELS = ["pool"]
 
-    total_connections = Gauge(
-        f"{PROM_PREFIX}_size",
+    max_connections = Gauge(
+        f"{PROM_PREFIX}_max_size",
         "Maximum number of connections allowed in this redisbp pool",
         PROM_LABELS,
     )
@@ -117,9 +117,7 @@ class RedisContextFactory(ContextFactory):
         self.connection_pool = connection_pool
 
         if isinstance(connection_pool, redis.BlockingConnectionPool):
-            self.total_connections.labels(name).set_function(
-                lambda: connection_pool.max_connections
-            )
+            self.max_connections.labels(name).set_function(lambda: connection_pool.max_connections)
             self.idle_connections.labels(name).set_function(connection_pool.pool.qsize)
             self.open_connections.labels(name).set_function(
                 lambda: len(connection_pool._connections)  # type: ignore

--- a/baseplate/clients/redis_cluster.py
+++ b/baseplate/clients/redis_cluster.py
@@ -9,6 +9,7 @@ from typing import Optional
 
 import rediscluster
 
+from prometheus_client import Gauge
 from rediscluster.pipeline import ClusterPipeline
 
 from baseplate import Span
@@ -331,7 +332,7 @@ class ClusterRedisClient(config.Parser):
 
     def parse(self, key_path: str, raw_config: config.RawConfig) -> "ClusterRedisContextFactory":
         connection_pool = cluster_pool_from_config(raw_config, f"{key_path}.", **self.kwargs)
-        return ClusterRedisContextFactory(connection_pool)
+        return ClusterRedisContextFactory(connection_pool, key_path)
 
 
 class ClusterRedisContextFactory(ContextFactory):
@@ -346,8 +347,32 @@ class ClusterRedisContextFactory(ContextFactory):
     :param connection_pool: A connection pool.
     """
 
-    def __init__(self, connection_pool: rediscluster.ClusterConnectionPool):
+    PROM_PREFIX = "bp_redis_cluster_pool"
+    PROM_LABELS = ["pool"]
+
+    promTotalConnections = Gauge(
+        f"{PROM_PREFIX}_connections",
+        "Number of connections in this redis cluster pool",
+        PROM_LABELS,
+    )
+    promOpenConnections = Gauge(
+        f"{PROM_PREFIX}_open_connections",
+        "Number of open connections in this redis cluster pool",
+        PROM_LABELS,
+    )
+
+    def __init__(
+        self, connection_pool: rediscluster.ClusterConnectionPool, name: str = "redis_cluster"
+    ):
         self.connection_pool = connection_pool
+
+        if isinstance(connection_pool, rediscluster.ClusterBlockingConnectionPool):
+            self.promTotalConnections.labels(name).set_function(
+                lambda: connection_pool.max_connections
+            )
+            self.promOpenConnections.labels(name).set_function(
+                lambda: len(connection_pool._connections)
+            )
 
     def report_runtime_metrics(self, batch: metrics.Client) -> None:
         if not isinstance(self.connection_pool, rediscluster.ClusterBlockingConnectionPool):

--- a/baseplate/clients/redis_cluster.py
+++ b/baseplate/clients/redis_cluster.py
@@ -350,12 +350,12 @@ class ClusterRedisContextFactory(ContextFactory):
     PROM_PREFIX = "bp_redis_cluster_pool"
     PROM_LABELS = ["pool"]
 
-    promTotalConnections = Gauge(
+    total_connections_gauge = Gauge(
         f"{PROM_PREFIX}_connections",
         "Number of connections in this redis cluster pool",
         PROM_LABELS,
     )
-    promOpenConnections = Gauge(
+    open_connections_gauge = Gauge(
         f"{PROM_PREFIX}_open_connections",
         "Number of open connections in this redis cluster pool",
         PROM_LABELS,
@@ -367,10 +367,10 @@ class ClusterRedisContextFactory(ContextFactory):
         self.connection_pool = connection_pool
 
         if isinstance(connection_pool, rediscluster.ClusterBlockingConnectionPool):
-            self.promTotalConnections.labels(name).set_function(
+            self.total_connections_gauge.labels(name).set_function(
                 lambda: connection_pool.max_connections
             )
-            self.promOpenConnections.labels(name).set_function(
+            self.open_connections_gauge.labels(name).set_function(
                 lambda: len(connection_pool._connections)
             )
 

--- a/baseplate/clients/redis_cluster.py
+++ b/baseplate/clients/redis_cluster.py
@@ -350,9 +350,9 @@ class ClusterRedisContextFactory(ContextFactory):
     PROM_PREFIX = "bp_redis_cluster_pool"
     PROM_LABELS = ["pool"]
 
-    total_connections_gauge = Gauge(
-        f"{PROM_PREFIX}_connections",
-        "Number of connections in this redis cluster pool",
+    max_connections_gauge = Gauge(
+        f"{PROM_PREFIX}_max_size",
+        "Maximum number of connections allowed in this redis cluster pool",
         PROM_LABELS,
     )
     open_connections_gauge = Gauge(
@@ -367,7 +367,7 @@ class ClusterRedisContextFactory(ContextFactory):
         self.connection_pool = connection_pool
 
         if isinstance(connection_pool, rediscluster.ClusterBlockingConnectionPool):
-            self.total_connections_gauge.labels(name).set_function(
+            self.max_connections_gauge.labels(name).set_function(
                 lambda: connection_pool.max_connections
             )
             self.open_connections_gauge.labels(name).set_function(

--- a/baseplate/clients/sqlalchemy.py
+++ b/baseplate/clients/sqlalchemy.py
@@ -159,25 +159,25 @@ class SQLAlchemyEngineContextFactory(ContextFactory):
     PROM_PREFIX = "bp_sqlalchemy_pool"
     PROM_LABELS = ["pool"]
 
-    prom_total_connections = Gauge(
+    total_connections_gauge = Gauge(
         f"{PROM_PREFIX}_connections",
         "Total number of connections in this pool",
         PROM_LABELS,
     )
 
-    prom_checked_in_connections = Gauge(
-        f"{PROM_PREFIX}_idle",
+    checked_in_connections_gauge = Gauge(
+        f"{PROM_PREFIX}_idle_connections",
         "Number of available, checked in, connections in this pool",
         PROM_LABELS,
     )
 
-    prom_checked_out_connections = Gauge(
-        f"{PROM_PREFIX}_active",
+    checked_out_connections_gauge = Gauge(
+        f"{PROM_PREFIX}_active_connections",
         "Number of connections in use, or checked out, in this pool",
         PROM_LABELS,
     )
 
-    prom_overflow_connections = Gauge(
+    overflow_connections_gauge = Gauge(
         f"{PROM_PREFIX}_overflow_connections",
         "Number of connections over the desired size of this pool",
         PROM_LABELS,
@@ -191,10 +191,10 @@ class SQLAlchemyEngineContextFactory(ContextFactory):
 
         pool = self.engine.pool
         if isinstance(pool, QueuePool):
-            self.prom_total_connections.labels(name).set_function(pool.size)
-            self.prom_checked_in_connections.labels(name).set_function(pool.checkedin)
-            self.prom_checked_out_connections.labels(name).set_function(pool.checkedout)
-            self.prom_overflow_connections.labels(name).set_function(pool.overflow)
+            self.total_connections_gauge.labels(name).set_function(pool.size)
+            self.checked_in_connections_gauge.labels(name).set_function(pool.checkedin)
+            self.checked_out_connections_gauge.labels(name).set_function(pool.checkedout)
+            self.overflow_connections_gauge.labels(name).set_function(pool.overflow)
 
     def report_runtime_metrics(self, batch: metrics.Client) -> None:
         pool = self.engine.pool

--- a/baseplate/clients/sqlalchemy.py
+++ b/baseplate/clients/sqlalchemy.py
@@ -159,25 +159,25 @@ class SQLAlchemyEngineContextFactory(ContextFactory):
     PROM_PREFIX = "bp_sqlalchemy_pool"
     PROM_LABELS = ["pool"]
 
-    promTotalConnections = Gauge(
-        f"{PROM_PREFIX}_size",
+    prom_total_connections = Gauge(
+        f"{PROM_PREFIX}_connections",
         "Total number of connections in this pool",
         PROM_LABELS,
     )
 
-    promCheckedInConnections = Gauge(
-        f"{PROM_PREFIX}_checked_in",
+    prom_checked_in_connections = Gauge(
+        f"{PROM_PREFIX}_idle",
         "Number of available, checked in, connections in this pool",
         PROM_LABELS,
     )
 
-    promCheckedOutConnections = Gauge(
-        f"{PROM_PREFIX}_checked_out",
+    prom_checked_out_connections = Gauge(
+        f"{PROM_PREFIX}_active",
         "Number of connections in use, or checked out, in this pool",
         PROM_LABELS,
     )
 
-    promOverflowConnections = Gauge(
+    prom_overflow_connections = Gauge(
         f"{PROM_PREFIX}_overflow_connections",
         "Number of connections over the desired size of this pool",
         PROM_LABELS,
@@ -191,10 +191,10 @@ class SQLAlchemyEngineContextFactory(ContextFactory):
 
         pool = self.engine.pool
         if isinstance(pool, QueuePool):
-            self.promTotalConnections.labels(name).set_function(pool.size)
-            self.promCheckedInConnections.labels(name).set_function(pool.checkedin)
-            self.promCheckedOutConnections.labels(name).set_function(pool.checkedout)
-            self.promOverflowConnections.labels(name).set_function(pool.overflow)
+            self.prom_total_connections.labels(name).set_function(pool.size)
+            self.prom_checked_in_connections.labels(name).set_function(pool.checkedin)
+            self.prom_checked_out_connections.labels(name).set_function(pool.checkedout)
+            self.prom_overflow_connections.labels(name).set_function(pool.overflow)
 
     def report_runtime_metrics(self, batch: metrics.Client) -> None:
         pool = self.engine.pool

--- a/baseplate/clients/sqlalchemy.py
+++ b/baseplate/clients/sqlalchemy.py
@@ -156,7 +156,7 @@ class SQLAlchemyEngineContextFactory(ContextFactory):
 
     """
 
-    PROM_PREFIX = "sqlalchemy_pool"
+    PROM_PREFIX = "bp_sqlalchemy_pool"
     PROM_LABELS = ["pool"]
 
     promTotalConnections = Gauge(

--- a/baseplate/clients/sqlalchemy.py
+++ b/baseplate/clients/sqlalchemy.py
@@ -159,9 +159,9 @@ class SQLAlchemyEngineContextFactory(ContextFactory):
     PROM_PREFIX = "bp_sqlalchemy_pool"
     PROM_LABELS = ["pool"]
 
-    total_connections_gauge = Gauge(
-        f"{PROM_PREFIX}_connections",
-        "Total number of connections in this pool",
+    max_connections_gauge = Gauge(
+        f"{PROM_PREFIX}_max_size",
+        "Maximum number of connections allowed in this pool",
         PROM_LABELS,
     )
 
@@ -191,7 +191,7 @@ class SQLAlchemyEngineContextFactory(ContextFactory):
 
         pool = self.engine.pool
         if isinstance(pool, QueuePool):
-            self.total_connections_gauge.labels(name).set_function(pool.size)
+            self.max_connections_gauge.labels(name).set_function(pool.size)
             self.checked_in_connections_gauge.labels(name).set_function(pool.checkedin)
             self.checked_out_connections_gauge.labels(name).set_function(pool.checkedout)
             self.overflow_connections_gauge.labels(name).set_function(pool.overflow)

--- a/baseplate/clients/thrift.py
+++ b/baseplate/clients/thrift.py
@@ -74,14 +74,14 @@ class ThriftContextFactory(ContextFactory):
     PROM_PREFIX = "bp_thrift_pool"
     PROM_LABELS = ["client_cls"]
 
-    prom_total_connections = Gauge(
-        f"{PROM_PREFIX}_size",
+    total_connections_gauge = Gauge(
+        f"{PROM_PREFIX}_connections",
         "Number of connections in this thrift pool",
         PROM_LABELS,
     )
 
-    prom_used_connections = Gauge(
-        f"{PROM_PREFIX}_in_use",
+    active_connections_gauge = Gauge(
+        f"{PROM_PREFIX}_active_connections",
         "Number of connections currently in use in this thrift pool",
         PROM_LABELS,
     )
@@ -100,8 +100,8 @@ class ThriftContextFactory(ContextFactory):
         )
 
         pool_name = type(self.client_cls).__name__
-        self.prom_total_connections.labels(pool_name).set_function(lambda: self.pool.size)
-        self.prom_used_connections.labels(pool_name).set_function(lambda: self.pool.checkedout)
+        self.total_connections_gauge.labels(pool_name).set_function(lambda: self.pool.size)
+        self.active_connections_gauge.labels(pool_name).set_function(lambda: self.pool.checkedout)
 
     def report_runtime_metrics(self, batch: metrics.Client) -> None:
         batch.gauge("pool.size").replace(self.pool.size)

--- a/baseplate/clients/thrift.py
+++ b/baseplate/clients/thrift.py
@@ -71,7 +71,7 @@ class ThriftContextFactory(ContextFactory):
 
     """
 
-    PROM_PREFIX = "thrift_pool"
+    PROM_PREFIX = "bp_thrift_pool"
     PROM_LABELS = ["client_cls"]
 
     promTotalConnections = Gauge(

--- a/baseplate/clients/thrift.py
+++ b/baseplate/clients/thrift.py
@@ -74,13 +74,13 @@ class ThriftContextFactory(ContextFactory):
     PROM_PREFIX = "bp_thrift_pool"
     PROM_LABELS = ["client_cls"]
 
-    promTotalConnections = Gauge(
+    prom_total_connections = Gauge(
         f"{PROM_PREFIX}_size",
         "Number of connections in this thrift pool",
         PROM_LABELS,
     )
 
-    promUsedConnections = Gauge(
+    prom_used_connections = Gauge(
         f"{PROM_PREFIX}_in_use",
         "Number of connections currently in use in this thrift pool",
         PROM_LABELS,
@@ -100,8 +100,8 @@ class ThriftContextFactory(ContextFactory):
         )
 
         pool_name = type(self.client_cls).__name__
-        self.promTotalConnections.labels(pool_name).set_function(lambda: self.pool.size)
-        self.promUsedConnections.labels(pool_name).set_function(lambda: self.pool.checkedout)
+        self.prom_total_connections.labels(pool_name).set_function(lambda: self.pool.size)
+        self.prom_used_connections.labels(pool_name).set_function(lambda: self.pool.checkedout)
 
     def report_runtime_metrics(self, batch: metrics.Client) -> None:
         batch.gauge("pool.size").replace(self.pool.size)

--- a/baseplate/clients/thrift.py
+++ b/baseplate/clients/thrift.py
@@ -74,9 +74,9 @@ class ThriftContextFactory(ContextFactory):
     PROM_PREFIX = "bp_thrift_pool"
     PROM_LABELS = ["client_cls"]
 
-    total_connections_gauge = Gauge(
-        f"{PROM_PREFIX}_connections",
-        "Number of connections in this thrift pool",
+    max_connections_gauge = Gauge(
+        f"{PROM_PREFIX}_max_size",
+        "Maximum number of connections in this thrift pool before blocking",
         PROM_LABELS,
     )
 
@@ -100,7 +100,7 @@ class ThriftContextFactory(ContextFactory):
         )
 
         pool_name = type(self.client_cls).__name__
-        self.total_connections_gauge.labels(pool_name).set_function(lambda: self.pool.size)
+        self.max_connections_gauge.labels(pool_name).set_function(lambda: self.pool.size)
         self.active_connections_gauge.labels(pool_name).set_function(lambda: self.pool.checkedout)
 
     def report_runtime_metrics(self, batch: metrics.Client) -> None:

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(
         "requests>=2.21.0,<3.0",
         "thrift-unofficial>=0.14.1,<1.0",
         "gevent>=20.5.0",
+        "prometheus-client>=0.12.0",
     ],
     extras_require=extras_require,
     scripts=[

--- a/tests/unit/clients/memcache_tests.py
+++ b/tests/unit/clients/memcache_tests.py
@@ -11,7 +11,7 @@ else:
     del pymemcache
 
 from baseplate.lib.config import ConfigurationError
-from baseplate.clients.memcache import pool_from_config
+from baseplate.clients.memcache import pool_from_config, MemcacheContextFactory
 from baseplate.clients.memcache import lib as memcache_lib
 
 
@@ -53,6 +53,16 @@ class PoolFromConfigTests(unittest.TestCase):
             {"memcache.endpoint": "localhost:1234", "memcache.no_delay": "False"}
         )
         self.assertEqual(pool.no_delay, False)
+
+    def test_metrics(self):
+        max_pool_size = "123"
+        ctx = MemcacheContextFactory(
+            pool_from_config(
+                {"memcache.endpoint": "localhost:1234", "memcache.max_pool_size": max_pool_size}
+            )
+        )
+        metric = ctx.promTotalConnections.collect()
+        self.assertEqual(metric[0].samples[0].value, float(max_pool_size))
 
 
 class SerdeTests(unittest.TestCase):

--- a/tests/unit/clients/memcache_tests.py
+++ b/tests/unit/clients/memcache_tests.py
@@ -61,7 +61,7 @@ class PoolFromConfigTests(unittest.TestCase):
                 {"memcache.endpoint": "localhost:1234", "memcache.max_pool_size": max_pool_size}
             )
         )
-        metric = ctx.promTotalConnections.collect()
+        metric = ctx.total_connections_gauge.collect()
         self.assertEqual(metric[0].samples[0].value, float(max_pool_size))
 
 

--- a/tests/unit/clients/memcache_tests.py
+++ b/tests/unit/clients/memcache_tests.py
@@ -61,7 +61,7 @@ class PoolFromConfigTests(unittest.TestCase):
                 {"memcache.endpoint": "localhost:1234", "memcache.max_pool_size": max_pool_size}
             )
         )
-        metric = ctx.total_connections_gauge.collect()
+        metric = ctx.pool_size_gauge.collect()
         self.assertEqual(metric[0].samples[0].value, float(max_pool_size))
 
 

--- a/tests/unit/clients/memcache_tests.py
+++ b/tests/unit/clients/memcache_tests.py
@@ -61,8 +61,9 @@ class PoolFromConfigTests(unittest.TestCase):
                 {"memcache.endpoint": "localhost:1234", "memcache.max_pool_size": max_pool_size}
             )
         )
-        metric = ctx.pool_size_gauge.collect()
-        self.assertEqual(metric[0].samples[0].value, float(max_pool_size))
+        metric = ctx.pool_size_gauge.collect()[0]
+        sample = [sample for sample in metric.samples if sample.labels["pool"] == "default"][0]
+        self.assertEqual(sample.value, float(max_pool_size))
 
 
 class SerdeTests(unittest.TestCase):

--- a/tests/unit/clients/redis_tests.py
+++ b/tests/unit/clients/redis_tests.py
@@ -30,7 +30,7 @@ class PoolFromConfigTests(unittest.TestCase):
                 {"redis.url": "redis://localhost:1234/0", "redis.max_connections": max_connections}
             )
         )
-        metric = ctx.total_connections.collect()
+        metric = ctx.max_connections.collect()
         self.assertEqual(metric[0].samples[0].value, float(max_connections))
 
     def test_timeouts(self):

--- a/tests/unit/clients/redis_tests.py
+++ b/tests/unit/clients/redis_tests.py
@@ -30,7 +30,7 @@ class PoolFromConfigTests(unittest.TestCase):
                 {"redis.url": "redis://localhost:1234/0", "redis.max_connections": max_connections}
             )
         )
-        metric = ctx.totalConnections.collect()
+        metric = ctx.total_connections.collect()
         self.assertEqual(metric[0].samples[0].value, float(max_connections))
 
     def test_timeouts(self):


### PR DESCRIPTION
This adds Prometheus client metrics equivalent to the existing statsd ones.

## Caveat
I've added an identifying name to each of the client classes that produce metrics, defaulted in each case except for the thrift client where it can be inferred from the class. In the case of instantiating two clients of the same class the last to be instantiated would otherwise be the only one to report metrics. However if clients are dynamically created at runtime this can cause labels to disappear and reappear in the prometheus server on restart.