### PR TITLE
Add queue config flag to Thrift pool

### DIFF
--- a/baseplate/lib/thrift_pool.py
+++ b/baseplate/lib/thrift_pool.py
@@ -75,6 +75,7 @@ def thrift_pool_from_config(
 
     * ``endpoint`` (required): A ``host:port`` pair, e.g. ``localhost:2014``,
         where the Thrift server can be found.
+    * ``fifo_queue``: True will enable use of a FIFO queue instead of the default LIFO queue.
     * ``size``: The size of the connection pool.
     * ``max_age``: The oldest a connection can be before it's recycled and
         replaced with a new one. Written as a
@@ -93,6 +94,7 @@ def thrift_pool_from_config(
     parser = config.SpecParser(
         {
             "endpoint": config.Endpoint,
+            "fifo_queue": config.Optional(config.Boolean, default=False),
             "size": config.Optional(config.Integer, default=10),
             "max_age": config.Optional(config.Timespan, default=config.Timespan("1 minute")),
             "timeout": config.Optional(config.Timespan, default=config.Timespan("1 second")),
@@ -102,6 +104,8 @@ def thrift_pool_from_config(
     )
     options = parser.parse(prefix[:-1], app_config)
 
+    if options.fifo_queue:
+        kwargs.setdefault("queue_cls", queue.Queue())
     if options.size is not None:
         kwargs.setdefault("size", options.size)
     if options.max_age is not None:

--- a/tests/unit/lib/thrift_pool_tests.py
+++ b/tests/unit/lib/thrift_pool_tests.py
@@ -68,6 +68,16 @@ class MaxRetriesRenameTests(unittest.TestCase):
         new_retry_policy.assert_called_with(attempts=5)
 
 
+class ThriftFIFOPoolTests(unittest.TestCase):
+    def test_fifo_queue_config(self):
+        config = {
+            "fifo-test.endpoint": "127.0.0.1:1234",
+            "fifo-test.fifo_queue": "true",
+        }
+        pool = thrift_pool.thrift_pool_from_config(config, prefix="fifo-test.")
+        self.assertTrue(isinstance(pool.pool, queue.Queue))
+
+
 class ThriftConnectionPoolTests(unittest.TestCase):
     def setUp(self):
         self.mock_queue = mock.Mock(spec=queue.Queue)


### PR DESCRIPTION
Add a `fifo_queue` flag to the `thrift_pool_from_config` constructor.
This allows easy runtime configuration of the `queue_cls`.

Signed-off-by: SuperQ <superq@gmail.com>