### PR TITLE
Better integrate with baseplate.Error

### DIFF
--- a/baseplate/clients/thrift.py
+++ b/baseplate/clients/thrift.py
@@ -203,7 +203,7 @@ def _build_thrift_proxy_method(name: str) -> Callable[..., Any]:
             except Error as exc:
                 # a 5xx error is an unexpected exception but not 5xx are
                 # not.
-                if exc.code / 100 == 5:
+                if exc.code // 100 == 5:
                     span.finish(exc_info=sys.exc_info())
                 else:
                     span.finish()

--- a/baseplate/frameworks/thrift/__init__.py
+++ b/baseplate/frameworks/thrift/__init__.py
@@ -52,7 +52,7 @@ class _ContextAwareHandler:
                 raise
             except Error as exc:
                 # mark 5xx errors as failures since those are still "unexpected"
-                if exc.code / 100 == 5:
+                if exc.code // 100 == 5:
                     span.finish(exc_info=sys.exc_info())
                 else:
                     span.finish()

--- a/baseplate/thrift/BaseplateService.py
+++ b/baseplate/thrift/BaseplateService.py
@@ -298,7 +298,7 @@ is_healthy_result.thrift_spec = (
         "success",
         None,
         None,
-    ),
-)  # 0
+    ),  # 0
+)
 fix_spec(all_structs)
 del all_structs

--- a/baseplate/thrift/BaseplateServiceV2.py
+++ b/baseplate/thrift/BaseplateServiceV2.py
@@ -331,7 +331,7 @@ is_healthy_result.thrift_spec = (
         "success",
         None,
         None,
-    ),
-)  # 0
+    ),  # 0
+)
 fix_spec(all_structs)
 del all_structs

--- a/pylintrc
+++ b/pylintrc
@@ -162,7 +162,7 @@ ignore-mixin-members=yes
 
 # List of classes names for which member attributes should not be checked
 # (useful for classes with attributes dynamically set).
-ignored-classes=SQLObject
+ignored-classes=SQLObject,Error
 
 # When zope mode is activated, add a predefined set of Zope acquired attributes
 # to generated-members.

--- a/tests/integration/test.thrift
+++ b/tests/integration/test.thrift
@@ -1,9 +1,14 @@
+include "../../baseplate/thrift/baseplate.thrift"
+
 exception ExpectedException {
 
 }
 
 service TestService {
-    bool example() throws (1: ExpectedException exc),
+    bool example() throws (
+        1: ExpectedException exc,
+        2: baseplate.Error err,
+    ),
 }
 
 struct ExampleStruct {

--- a/tests/integration/test_thrift/TestService.py
+++ b/tests/integration/test_thrift/TestService.py
@@ -61,6 +61,8 @@ class Client(Iface):
             return result.success
         if result.exc is not None:
             raise result.exc
+        if result.err is not None:
+            raise result.err
         raise TApplicationException(
             TApplicationException.MISSING_RESULT, "example failed: unknown result"
         )
@@ -108,6 +110,9 @@ class Processor(Iface, TProcessor):
         except ExpectedException as exc:
             msg_type = TMessageType.REPLY
             result.exc = exc
+        except baseplate.thrift.ttypes.Error as err:
+            msg_type = TMessageType.REPLY
+            result.err = err
         except TApplicationException as ex:
             logging.exception("TApplication exception in handler")
             msg_type = TMessageType.EXCEPTION
@@ -185,21 +190,25 @@ class example_result(object):
     Attributes:
      - success
      - exc
+     - err
 
     """
 
     __slots__ = (
         "success",
         "exc",
+        "err",
     )
 
     def __init__(
         self,
         success=None,
         exc=None,
+        err=None,
     ):
         self.success = success
         self.exc = exc
+        self.err = err
 
     def read(self, iprot):
         if (
@@ -224,6 +233,11 @@ class example_result(object):
                     self.exc = ExpectedException.read(iprot)
                 else:
                     iprot.skip(ftype)
+            elif fid == 2:
+                if ftype == TType.STRUCT:
+                    self.err = baseplate.thrift.ttypes.Error.read(iprot)
+                else:
+                    iprot.skip(ftype)
             else:
                 iprot.skip(ftype)
             iprot.readFieldEnd()
@@ -241,6 +255,10 @@ class example_result(object):
         if self.exc is not None:
             oprot.writeFieldBegin("exc", TType.STRUCT, 1)
             self.exc.write(oprot)
+            oprot.writeFieldEnd()
+        if self.err is not None:
+            oprot.writeFieldBegin("err", TType.STRUCT, 2)
+            self.err.write(oprot)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -282,6 +300,13 @@ example_result.thrift_spec = (
         [ExpectedException, None],
         None,
     ),  # 1
+    (
+        2,
+        TType.STRUCT,
+        "err",
+        [baseplate.thrift.ttypes.Error, None],
+        None,
+    ),  # 2
 )
 fix_spec(all_structs)
 del all_structs

--- a/tests/integration/test_thrift/ttypes.py
+++ b/tests/integration/test_thrift/ttypes.py
@@ -16,6 +16,8 @@ from thrift.Thrift import TType
 from thrift.transport import TTransport
 from thrift.TRecursive import fix_spec
 
+import baseplate.thrift.ttypes
+
 all_structs = []
 
 


### PR DESCRIPTION
 * add an option to 'baseplateify_processor' to automatically convert
   unhandled errors to baseplate.Error(INTERNAL_SERVER_ERROR)
 * Record 5xx baseplate.Errors as failures