### PR TITLE
Fix connection leaks in dependencies by monkey patching gevent queues

### DIFF
--- a/baseplate/lib/thrift_pool.py
+++ b/baseplate/lib/thrift_pool.py
@@ -16,6 +16,7 @@ A basic example of usage::
 """
 import contextlib
 import logging
+import queue
 import socket
 import time
 
@@ -24,7 +25,6 @@ from typing import Generator
 from typing import Optional
 from typing import TYPE_CHECKING
 
-from gevent import queue as gevent_queue
 from thrift.protocol import THeaderProtocol
 from thrift.protocol.TProtocol import TProtocolBase
 from thrift.protocol.TProtocol import TProtocolException
@@ -46,7 +46,7 @@ if TYPE_CHECKING:
 
     ProtocolPool = std_lib_queue.Queue[TProtocolBase]  # pylint: disable=unsubscriptable-object
 else:
-    ProtocolPool = gevent_queue.Queue
+    ProtocolPool = queue.Queue
 
 
 def _make_transport(endpoint: config.EndpointConfiguration) -> TSocket:
@@ -158,7 +158,7 @@ class ThriftConnectionPool:
         timeout: float = 1,
         max_connection_attempts: int = 3,
         protocol_factory: TProtocolFactory = _DEFAULT_PROTOCOL_FACTORY,
-        queue_cls: ProtocolPool = gevent_queue.LifoQueue(),
+        queue_cls: ProtocolPool = queue.LifoQueue(),
     ):
         self.endpoint = endpoint
         self.max_age = max_age
@@ -175,7 +175,7 @@ class ThriftConnectionPool:
     def _get_from_pool(self) -> Optional[TProtocolBase]:
         try:
             return self.pool.get(block=True, timeout=self.timeout)
-        except gevent_queue.Empty:
+        except queue.Empty:
             raise TTransportException(
                 type=TTransportException.NOT_OPEN, message="timed out waiting for a connection slot"
             )

--- a/baseplate/lib/thrift_pool.py
+++ b/baseplate/lib/thrift_pool.py
@@ -42,9 +42,7 @@ logger = logging.getLogger(__name__)
 
 
 if TYPE_CHECKING:
-    import queue as std_lib_queue
-
-    ProtocolPool = std_lib_queue.Queue[TProtocolBase]  # pylint: disable=unsubscriptable-object
+    ProtocolPool = queue.Queue[TProtocolBase]  # pylint: disable=unsubscriptable-object
 else:
     ProtocolPool = queue.Queue
 

--- a/baseplate/server/monkey.py
+++ b/baseplate/server/monkey.py
@@ -1,0 +1,13 @@
+from gevent.monkey import patch_module
+
+
+def patch_stdlib_queues() -> None:
+    """It is a common pattern to use a queue as a connection pool.
+    This pattern can leak connections if the queue is not patched by gevent
+    Gevent doesn't patch most queues by default.
+    https://github.com/gevent/gevent/issues/1875
+    """
+    import queue
+    import gevent.queue
+
+    patch_module(queue, gevent.queue, items=["Queue", "LifoQueue", "PriorityQueue"])

--- a/bin/baseplate-script
+++ b/bin/baseplate-script
@@ -7,7 +7,10 @@
 
 from gevent.monkey import patch_all
 
+from baseplate.server.monkey import patch_stdlib_queues
+
 patch_all()
+patch_stdlib_queues()
 
 from baseplate.server import load_and_run_script
 

--- a/bin/baseplate-serve
+++ b/bin/baseplate-serve
@@ -7,7 +7,10 @@
 
 from gevent.monkey import patch_all
 
+from baseplate.server.monkey import patch_stdlib_queues
+
 patch_all()
+patch_stdlib_queues()
 
 from baseplate.server import load_app_and_run_server
 

--- a/bin/baseplate-shell
+++ b/bin/baseplate-shell
@@ -7,7 +7,10 @@
 
 from gevent.monkey import patch_all
 
+from baseplate.server.monkey import patch_stdlib_queues
+
 patch_all()
+patch_stdlib_queues()
 
 from baseplate.server import load_and_run_shell
 

--- a/bin/baseplate-tshell
+++ b/bin/baseplate-tshell
@@ -7,7 +7,10 @@
 
 from gevent.monkey import patch_all
 
+from baseplate.server.monkey import patch_stdlib_queues
+
 patch_all()
+patch_stdlib_queues()
 
 from baseplate.server import load_and_run_shell
 

--- a/tests/unit/lib/thrift_pool_tests.py
+++ b/tests/unit/lib/thrift_pool_tests.py
@@ -4,8 +4,6 @@ import unittest
 
 from unittest import mock
 
-import gevent.queue
-
 from thrift.protocol import TBinaryProtocol
 from thrift.protocol import THeaderProtocol
 from thrift.Thrift import TException
@@ -298,7 +296,7 @@ class ThriftConnectionPoolTests(unittest.TestCase):
         self.assertEqual(self.mock_queue.put.call_args, mock.call(None))
 
     def test_pool_checkout_exception(self):
-        class PatchedLifoQueue(gevent.queue.LifoQueue):
+        class PatchedLifoQueue(queue.LifoQueue):
             def get(self, *args, **kwargs):
                 raise Exception
 

--- a/tests/unit/server/monkey_tests.py
+++ b/tests/unit/server/monkey_tests.py
@@ -1,0 +1,16 @@
+import importlib
+import queue
+import unittest
+
+import gevent.queue
+
+from baseplate.server.monkey import patch_stdlib_queues
+
+
+class MonkeyPatchTests(unittest.TestCase):
+    def test_patch_stdlib_queues(self):
+        assert queue.LifoQueue is not gevent.queue.LifoQueue
+        patch_stdlib_queues()
+        assert queue.LifoQueue is gevent.queue.LifoQueue
+        importlib.reload(queue)
+        assert queue.LifoQueue is not gevent.queue.LifoQueue


### PR DESCRIPTION
Connection pools implemented using standard library queues [can leak connections when a gevent timeout exception is raised](https://github.com/gevent/gevent/issues/1875). To avoid this gevent queues should be used rather than standard library queues.

We fixed this in [baseplate.py Thrift pools](https://github.com/reddit/baseplate.py/pull/643), but there are still many such issues in dependencies. In some cases [we can explicitly use a gevent queue](https://github.com/reddit/baseplate.py/pull/646), but in other cases we have to [monkey patch](https://github.com/celery/kombu/blob/master/kombu/resource.py).

Previously we did not monkey patch because it is unclear why gevent `patch_queue` and `patch_all` does not patch by default. I've [raised an issue asking the gevent team about this](https://github.com/gevent/gevent/issues/1875), and also started canarying such a change in a Reddit service that was experiencing Kombu connection leaks. The service hasn't experienced any issues with the change so I'd like to merge it upstream.