### PR TITLE
Support loading encrypted contents from S3 bucket for live_data_watch

### DIFF
--- a/baseplate/sidecars/live_data_watcher.py
+++ b/baseplate/sidecars/live_data_watcher.py
@@ -38,7 +38,8 @@ class NodeWatcher:
         self.mode = mode
 
     @staticmethod
-    def get_encrypted_json_from_s3(bucket_name: str, file_key: str, region_name: str, sse_key: str
+    def get_encrypted_json_from_s3(
+        bucket_name: str, file_key: str, region_name: str, sse_key: str
     ) -> Optional[dict]:
         s3_client = boto3.client(
             "s3",

--- a/baseplate/sidecars/live_data_watcher.py
+++ b/baseplate/sidecars/live_data_watcher.py
@@ -70,7 +70,7 @@ class NodeWatcher:
         return data
 
     @staticmethod
-    def get_data_to_write(json_data: dict, data: bytes) -> Optional[bytes]:
+    def get_data_to_write(json_data: dict, data: Optional[bytes]) -> Optional[bytes]:
         # Check if we have a JSON in a special format containing:
         # data = {
         #    "live_data_watcher_load_type": str

--- a/baseplate/sidecars/live_data_watcher.py
+++ b/baseplate/sidecars/live_data_watcher.py
@@ -6,16 +6,15 @@ import logging
 import os
 import sys
 import time
-import boto3
 
 from pathlib import Path
 from typing import Any
 from typing import NoReturn
 from typing import Optional
 
+import boto3
 
 from botocore.client import ClientError
-
 from kazoo.client import KazooClient
 from kazoo.protocol.states import ZnodeStat
 
@@ -39,8 +38,7 @@ class NodeWatcher:
         self.mode = mode
 
     @staticmethod
-    def get_encrypted_json_from_s3(
-        self, bucket_name:str, file_key: str, region_name:str, sse_key: str
+    def get_encrypted_json_from_s3(bucket_name: str, file_key: str, region_name: str, sse_key: str
     ) -> Optional[dict]:
         s3_client = boto3.client(
             "s3",
@@ -57,7 +55,6 @@ class NodeWatcher:
         try:
             s3_object = s3_client.get_object(**kwargs)
             data = s3_object["Body"].read()
-
         except ClientError as error:
             logger.exception(
                 "Failed to load from S3. Received error code %s: %s",
@@ -80,16 +77,18 @@ class NodeWatcher:
         # downloading the contents of encrypted files uploaded to S3.
         if json_data.get("live_data_watcher_load_type") == "S3":
             # Only write the data if we actually managed to fetch its contents.
-            bucket_name=json_data.get("bucket_name")
-            file_key=json_data.get("file_key"),
-            sse_key=json_data.get("sse_key")
+            bucket_name = json_data.get("bucket_name")
+            file_key = (json_data.get("file_key"),)
+            sse_key = json_data.get("sse_key")
             region_name = json_data.get("region_name")
             # We require all of these keys to properly read from S3.
             if bucket_name is None or file_key is None or sse_key is None or region_name is None:
                 logger.debug("Missing data in live data watch zk node to read from S3.")
                 return None
             # If we have all the correct keys, attempt to read the config from S3.
-            json_data = NodeWatcher.get_encrypted_json_from_s3(bucket_name=bucket_name, file_key=file_key, region_name=region_name, sse_key=sse_key)
+            json_data = NodeWatcher.get_encrypted_json_from_s3(
+                bucket_name=bucket_name, file_key=file_key, region_name=region_name, sse_key=sse_key
+            )
             return json_data
         else:
             return data
@@ -125,7 +124,9 @@ class NodeWatcher:
                 if data_to_write is not None:
                     tmpfile.write(data_to_write)
                 else:
-                    logger.warning("No data written to destination node. Something is likely misconfigured.")
+                    logger.warning(
+                        "No data written to destination node. Something is likely misconfigured."
+                    )
         os.rename(self.dest + ".tmp", self.dest)
 
 

--- a/baseplate/sidecars/live_data_watcher.py
+++ b/baseplate/sidecars/live_data_watcher.py
@@ -40,7 +40,7 @@ class NodeWatcher:
     @staticmethod
     def get_encrypted_json_from_s3(
         bucket_name: str, file_key: str, region_name: str, sse_key: str
-    ) -> Optional[dict]:
+    ) -> Optional[bytes]:
         s3_client = boto3.client(
             "s3",
             region_name=region_name,

--- a/baseplate/sidecars/live_data_watcher.py
+++ b/baseplate/sidecars/live_data_watcher.py
@@ -95,7 +95,7 @@ class NodeWatcher:
             )
         return data
 
-    def handle_empty_data(self):
+    def handle_empty_data(self) -> None:
         # the data node does not exist
         try:
             logger.info("Removing %r; watched node deleted.", self.dest)

--- a/baseplate/sidecars/live_data_watcher.py
+++ b/baseplate/sidecars/live_data_watcher.py
@@ -80,7 +80,7 @@ class NodeWatcher:
         if json_data.get("live_data_watcher_load_type") == "S3":
             # Only write the data if we actually managed to fetch its contents.
             bucket_name = json_data.get("bucket_name")
-            file_key = (json_data.get("file_key"),)
+            file_key = json_data.get("file_key")
             sse_key = json_data.get("sse_key")
             region_name = json_data.get("region_name")
             # We require all of these keys to properly read from S3.

--- a/baseplate/sidecars/live_data_watcher.py
+++ b/baseplate/sidecars/live_data_watcher.py
@@ -88,10 +88,10 @@ class NodeWatcher:
                 logger.debug("Missing data in live data watch zk node to read from S3.")
                 return None
             # If we have all the correct keys, attempt to read the config from S3.
-            json_data = NodeWatcher.get_encrypted_json_from_s3(
+            s3_data = NodeWatcher.get_encrypted_json_from_s3(
                 bucket_name=bucket_name, file_key=file_key, region_name=region_name, sse_key=sse_key
             )
-            return json_data
+            return s3_data
         else:
             return data
 

--- a/baseplate/sidecars/live_data_watcher.py
+++ b/baseplate/sidecars/live_data_watcher.py
@@ -1,18 +1,18 @@
 """Watch nodes in ZooKeeper and sync their contents to disk on change."""
 import argparse
 import configparser
+import json
 import logging
 import os
 import sys
 import time
-import json
-from tkinter import E
-import requests
 
 from pathlib import Path
 from typing import Any
 from typing import NoReturn
 from typing import Optional
+
+import requests
 
 from kazoo.client import KazooClient
 from kazoo.protocol.states import ZnodeStat
@@ -56,7 +56,7 @@ class NodeWatcher:
         #    "md5_hashed_data": str
         # }
         # If the load type is 'http', this format is an indication that we support
-        # downloading the contents of files uploaded to S3, GCP, etc when provided 
+        # downloading the contents of files uploaded to S3, GCP, etc when provided
         # with an accessible URL.
         if json_data.get("live_data_watcher_load_type") == "http":
             # Only write the data if we actually managed to fetch its contents.
@@ -90,7 +90,7 @@ class NodeWatcher:
                 os.fchown(tmpfile.fileno(), self.owner, self.group)
             os.fchmod(tmpfile.fileno(), self.mode)
             try:
-                json_data = json.loads(data.decode('UTF-8'))
+                json_data = json.loads(data.decode("UTF-8"))
             except json.decoder.JSONDecodeError:
                 # If JSON fails to decode, still write the bytes data since
                 # we don't necessarily know if the the contents of the znode

--- a/baseplate/sidecars/live_data_watcher.py
+++ b/baseplate/sidecars/live_data_watcher.py
@@ -41,7 +41,7 @@ class NodeWatcher:
     @staticmethod
     def get_encrypted_json_from_s3(
         self, bucket_name:str, file_key: str, region_name:str, sse_key: str
-    ) -> tuple[Optional[dict], dict]:
+    ) -> Optional[dict]:
         s3_client = boto3.client(
             "s3",
             region_name=region_name,

--- a/baseplate/sidecars/live_data_watcher.py
+++ b/baseplate/sidecars/live_data_watcher.py
@@ -56,7 +56,7 @@ class NodeWatcher:
         #    "md5_hashed_data": str
         # }
         # If the load type is 'http', this format is an indication that we support
-        # downloading the contents of files uploaded to S3, GCP, etc when provided
+        # downloading the contents of files uploaded to S3, GCS, etc when provided
         # with an accessible URL.
         if json_data.get("live_data_watcher_load_type") == "http":
             # Only write the data if we actually managed to fetch its contents.

--- a/baseplate/sidecars/live_data_watcher.py
+++ b/baseplate/sidecars/live_data_watcher.py
@@ -46,7 +46,7 @@ class NodeWatcher:
             "s3",
             region_name=region_name,
         )
-        json_data = None
+        data: Optional[bytes] = None
         # The S3 data must be Server Side Encrypted and we should have the decryption key.
         kwargs = {
             "Bucket": bucket_name,
@@ -57,8 +57,7 @@ class NodeWatcher:
         try:
             s3_object = s3_client.get_object(**kwargs)
             data = s3_object["Body"].read()
-            if data:
-                json_data = json.loads(data.decode("utf-8"))
+
         except ClientError as error:
             logger.exception(
                 "Failed to load from S3. Received error code %s: %s",
@@ -69,10 +68,7 @@ class NodeWatcher:
         except ValueError as error:
             logger.exception(error)
             return None
-        except json.decoder.JSONDecodeError as error:
-            logger.exception(error)
-            return None
-        return json_data
+        return data
 
     @staticmethod
     def get_data_to_write(json_data: dict, data: bytes) -> Optional[bytes]:

--- a/baseplate/sidecars/live_data_watcher.py
+++ b/baseplate/sidecars/live_data_watcher.py
@@ -102,9 +102,6 @@ class NodeWatcher:
         # the data node does not exist
         try:
             logger.info("Removing %r; watched node deleted.", self.dest)
-            logger.warning(
-                "No data written to destination file. Something is likely misconfigured."
-            )
             os.unlink(self.dest)
         except OSError as exc:
             logger.debug("%s: couldn't unlink: %s", self.dest, exc)
@@ -133,7 +130,9 @@ class NodeWatcher:
                 # If no exceptions, we have valid JSON, and can parse accordingly.
                 data = NodeWatcher.get_data_to_write(json_data, data)
                 if data is None:
-                    self.handle_empty_data()
+                    logger.warning(
+                        "No data written to destination file. Something is likely misconfigured."
+                    )
                     return
                 tmpfile.write(data)
         os.rename(self.dest + ".tmp", self.dest)

--- a/baseplate/sidecars/live_data_watcher.py
+++ b/baseplate/sidecars/live_data_watcher.py
@@ -13,7 +13,6 @@ from typing import Any
 from typing import NoReturn
 from typing import Optional
 
-import requests
 
 from botocore.client import ClientError
 
@@ -38,7 +37,7 @@ class NodeWatcher:
         self.owner = owner
         self.group = group
         self.mode = mode
-        
+
     @staticmethod
     def get_encrypted_json_from_s3(
         self, bucket_name:str, file_key: str, region_name:str, sse_key: str

--- a/baseplate/sidecars/live_data_watcher.py
+++ b/baseplate/sidecars/live_data_watcher.py
@@ -73,7 +73,7 @@ class NodeWatcher:
         return data
 
     @staticmethod
-    def get_data_to_write(json_data: dict, data: Optional[bytes]) -> Optional[bytes]:
+    def get_data_to_write(json_data: dict, data: bytes) -> Optional[bytes]:
         # Check if we have a JSON in a special format containing:
         # data = {
         #    "live_data_watcher_load_type": str
@@ -93,7 +93,7 @@ class NodeWatcher:
                 )
                 return None
             # If we have all the correct keys, attempt to read the config from S3.
-            data = NodeWatcher.get_encrypted_data_from_s3(
+            return NodeWatcher.get_encrypted_data_from_s3(
                 bucket_name=bucket_name, file_key=file_key, region_name=region_name, sse_key=sse_key
             )
         return data

--- a/baseplate/sidecars/live_data_watcher.py
+++ b/baseplate/sidecars/live_data_watcher.py
@@ -62,7 +62,7 @@ class NodeWatcher:
             # Only write the data if we actually managed to fetch its contents.
             url = json_data.get("data")
             if url is None:
-                logger.exception("No url found in zk source JSON node.")
+                logger.debug("No url found in zk source JSON node.")
                 return None
             url_data = NodeWatcher.fetch_data_from_url(url)
             if url_data is None:

--- a/baseplate/sidecars/live_data_watcher.py
+++ b/baseplate/sidecars/live_data_watcher.py
@@ -12,9 +12,9 @@ from typing import Any
 from typing import NoReturn
 from typing import Optional
 
-import boto3
+import boto3  # type: ignore
 
-from botocore.client import ClientError
+from botocore.client import ClientError  # type: ignore
 from kazoo.client import KazooClient
 from kazoo.protocol.states import ZnodeStat
 
@@ -45,7 +45,7 @@ class NodeWatcher:
             "s3",
             region_name=region_name,
         )
-        data: Optional[bytes] = None
+        data = None
         # The S3 data must be Server Side Encrypted and we should have the decryption key.
         kwargs = {
             "Bucket": bucket_name,

--- a/baseplate/sidecars/live_data_watcher.py
+++ b/baseplate/sidecars/live_data_watcher.py
@@ -73,7 +73,7 @@ class NodeWatcher:
         return data
 
     @staticmethod
-    def get_data_to_write(json_data: dict, data: bytes) -> Optional[bytes]:
+    def get_data_to_write(json_data: dict, data: Optional[bytes]) -> Optional[bytes]:
         # Check if we have a JSON in a special format containing:
         # data = {
         #    "live_data_watcher_load_type": str
@@ -93,7 +93,7 @@ class NodeWatcher:
                 )
                 return None
             # If we have all the correct keys, attempt to read the config from S3.
-            return NodeWatcher.get_encrypted_data_from_s3(
+            data = NodeWatcher.get_encrypted_data_from_s3(
                 bucket_name=bucket_name, file_key=file_key, region_name=region_name, sse_key=sse_key
             )
         return data
@@ -109,7 +109,7 @@ class NodeWatcher:
         except OSError as exc:
             logger.debug("%s: couldn't unlink: %s", self.dest, exc)
 
-    def on_change(self, data: bytes, _znode_stat: ZnodeStat) -> None:
+    def on_change(self, data: Optional[bytes], _znode_stat: ZnodeStat) -> None:
         if data is None:
             self.handle_empty_data()
             return

--- a/baseplate/sidecars/live_data_watcher.py
+++ b/baseplate/sidecars/live_data_watcher.py
@@ -38,7 +38,7 @@ class NodeWatcher:
         self.mode = mode
 
     @staticmethod
-    def get_encrypted_json_from_s3(
+    def get_encrypted_data_from_s3(
         bucket_name: str, file_key: str, region_name: str, sse_key: str
     ) -> Optional[bytes]:
         s3_client = boto3.client(
@@ -78,22 +78,22 @@ class NodeWatcher:
         # If the load type is 'S3', this format is an indication that we support
         # downloading the contents of encrypted files uploaded to S3.
         if json_data.get("live_data_watcher_load_type") == "S3":
-            # Only write the data if we actually managed to fetch its contents.
-            bucket_name = json_data.get("bucket_name")
-            file_key = json_data.get("file_key")
-            sse_key = json_data.get("sse_key")
-            region_name = json_data.get("region_name")
-            # We require all of these keys to properly read from S3.
-            if bucket_name is None or file_key is None or sse_key is None or region_name is None:
-                logger.error("Missing data in live data watch zk node to read from S3.")
+            try:
+                bucket_name = json_data["bucket_name"]
+                file_key = json_data["file_key"]
+                sse_key = json_data["sse_key"]
+                region_name = json_data["region_name"]
+            except KeyError:
+                # We require all of these keys to properly read from S3.
+                logger.exception(
+                    "Improper configuration found while attempting to load live data from S3."
+                )
                 return None
             # If we have all the correct keys, attempt to read the config from S3.
-            s3_data = NodeWatcher.get_encrypted_json_from_s3(
+            data = NodeWatcher.get_encrypted_data_from_s3(
                 bucket_name=bucket_name, file_key=file_key, region_name=region_name, sse_key=sse_key
             )
-            return s3_data
-        else:
-            return data
+        return data
 
     def on_change(self, data: bytes, _znode_stat: ZnodeStat) -> None:
         if data is None:
@@ -127,7 +127,7 @@ class NodeWatcher:
                     tmpfile.write(data_to_write)
                 else:
                     logger.warning(
-                        "No data written to destination node. Something is likely misconfigured."
+                        "No data written to destination file. Something is likely misconfigured."
                     )
         os.rename(self.dest + ".tmp", self.dest)
 

--- a/baseplate/sidecars/live_data_watcher.py
+++ b/baseplate/sidecars/live_data_watcher.py
@@ -73,18 +73,7 @@ class NodeWatcher:
             logger.exception(error)
             return None
         return json_data
-
-    @staticmethod
-    def fetch_data_from_url(url: str) -> Optional[str]:
-        data = None
-        try:
-            # Fetch the data from the url as bytes.
-            data = requests.get(url).content
-        except requests.exceptions.RequestException as e:
-            logger.exception(e)
-            return None
-        return data
-
+        
     @staticmethod
     def get_data_to_write(json_data: dict, data: bytes) -> Optional[bytes]:
         # Check if we have a JSON in a special format containing:

--- a/baseplate/sidecars/live_data_watcher.py
+++ b/baseplate/sidecars/live_data_watcher.py
@@ -55,6 +55,7 @@ class NodeWatcher:
         }
         try:
             s3_object = s3_client.get_object(**kwargs)
+            # Returns bytes.
             data = s3_object["Body"].read()
         except ClientError as error:
             logger.exception(

--- a/baseplate/sidecars/live_data_watcher.py
+++ b/baseplate/sidecars/live_data_watcher.py
@@ -38,7 +38,8 @@ class NodeWatcher:
         self.owner = owner
         self.group = group
         self.mode = mode
-
+        
+    @staticmethod
     def get_encrypted_json_from_s3(
         self, bucket_name:str, file_key: str, region_name:str, sse_key: str
     ) -> tuple[Optional[dict], dict]:
@@ -73,7 +74,7 @@ class NodeWatcher:
             logger.exception(error)
             return None
         return json_data
-        
+
     @staticmethod
     def get_data_to_write(json_data: dict, data: bytes) -> Optional[bytes]:
         # Check if we have a JSON in a special format containing:

--- a/baseplate/sidecars/live_data_watcher.py
+++ b/baseplate/sidecars/live_data_watcher.py
@@ -85,7 +85,7 @@ class NodeWatcher:
             region_name = json_data.get("region_name")
             # We require all of these keys to properly read from S3.
             if bucket_name is None or file_key is None or sse_key is None or region_name is None:
-                logger.debug("Missing data in live data watch zk node to read from S3.")
+                logger.error("Missing data in live data watch zk node to read from S3.")
                 return None
             # If we have all the correct keys, attempt to read the config from S3.
             s3_data = NodeWatcher.get_encrypted_json_from_s3(

--- a/requirements-transitive.txt
+++ b/requirements-transitive.txt
@@ -11,7 +11,6 @@ aspy.refactor-imports==2.1.1
 attrs==20.3.0
 Babel==2.9.1
 beautifulsoup4==4.9.3
-boto3==1.21.20
 cached-property==1.5.2
 cassandra-driver==3.24.0
 certifi==2020.12.5

--- a/requirements-transitive.txt
+++ b/requirements-transitive.txt
@@ -11,6 +11,7 @@ aspy.refactor-imports==2.1.1
 attrs==20.3.0
 Babel==2.9.1
 beautifulsoup4==4.9.3
+boto3==1.21.20
 cached-property==1.5.2
 cassandra-driver==3.24.0
 certifi==2020.12.5
@@ -36,6 +37,7 @@ kombu==4.6.11
 lazy-object-proxy==1.4.3
 MarkupSafe==1.1.1
 mccabe==0.6.1
+moto==3.1.4
 mypy-extensions==0.4.3
 ndg-httpsclient==0.5.1
 netifaces==0.10.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@
 -r requirements-transitive.txt
 astroid==2.8.4
 black==21.10b0
+boto3==1.21.20
 flake8==3.8.4
 lxml==4.6.5
 mypy==0.910

--- a/tests/unit/sidecars/live_data_watcher_tests.py
+++ b/tests/unit/sidecars/live_data_watcher_tests.py
@@ -68,11 +68,6 @@ class NodeWatcherTests(unittest.TestCase):
             % (logger.name),
             lc.output,
         )
-        self.assertIn(
-            "EXCEPTION:%s:Improper configuration found while attempting to load live data from S3."
-            % (logger.name),
-            lc.output,
-        )
 
     def test_on_change(self):
         dest = self.output_dir.joinpath("data.txt")

--- a/tests/unit/sidecars/live_data_watcher_tests.py
+++ b/tests/unit/sidecars/live_data_watcher_tests.py
@@ -64,7 +64,7 @@ class NodeWatcherTests(unittest.TestCase):
         self.assertEqual(dest.owner(), pwd.getpwuid(os.getuid()).pw_name)
         self.assertEqual(dest.group(), grp.getgrgid(os.getgid()).gr_name)
         self.assertIn(
-            "WARNING:%s:No data written to destination node. Something is likely misconfigured."
+            "WARNING:%s:No data written to destination file. Something is likely misconfigured."
             % (logger.name),
             lc.output,
         )

--- a/tests/unit/sidecars/live_data_watcher_tests.py
+++ b/tests/unit/sidecars/live_data_watcher_tests.py
@@ -53,7 +53,7 @@ class NodeWatcherTests(unittest.TestCase):
         self.assertEqual(dest.owner(), pwd.getpwuid(os.getuid()).pw_name)
         self.assertEqual(dest.group(), grp.getgrgid(os.getgid()).gr_name)
 
-    def test_s3_load_type_missing_keys_on_change(self):
+    def test_s3_load_type_missing_sse_key_on_change(self):
         with self.assertLogs(logger.name, level="DEBUG") as lc:
             dest = self.output_dir.joinpath("data.txt")
             inst = NodeWatcher(str(dest), os.getuid(), os.getgid(), 777)
@@ -65,6 +65,11 @@ class NodeWatcherTests(unittest.TestCase):
         self.assertEqual(dest.group(), grp.getgrgid(os.getgid()).gr_name)
         self.assertIn(
             "WARNING:%s:No data written to destination file. Something is likely misconfigured."
+            % (logger.name),
+            lc.output,
+        )
+        self.assertIn(
+            "EXCEPTION:%s:Improper configuration found while attempting to load live data from S3."
             % (logger.name),
             lc.output,
         )

--- a/tests/unit/sidecars/live_data_watcher_tests.py
+++ b/tests/unit/sidecars/live_data_watcher_tests.py
@@ -5,6 +5,7 @@ import tempfile
 import unittest
 
 from pathlib import Path
+from unittest.mock import Mock, patch
 
 from baseplate.sidecars.live_data_watcher import NodeWatcher
 
@@ -14,6 +15,23 @@ class NodeWatcherTests(unittest.TestCase):
         with tempfile.TemporaryDirectory(prefix=self.id()) as loc:
             self.output_dir = Path(loc)
             return super().run(result)
+
+    @patch("requests.get")
+    def test_http_load_type_on_change(self, request_mock: Mock):
+        # Mock the returned value from the request (bytes).
+        response_mock = Mock(status_code=200)
+        request_mock.return_value = response_mock
+        response_mock.content = b"{\"foo\":\"bar\"}"
+
+        dest = self.output_dir.joinpath("data.txt")
+        inst = NodeWatcher(str(dest), os.getuid(), os.getgid(), 777)
+
+        new_content = b"{\"live_data_watcher_load_type\":\"http\",\"data\":\"http://someurl.com/test.json\",\"md5_hashed_data\":\"hashed_data\"}"
+        expected_content = b"{\"foo\":\"bar\"}"
+        inst.on_change(new_content, None)
+        self.assertEqual(expected_content, dest.read_bytes())
+        self.assertEqual(dest.owner(), pwd.getpwuid(os.getuid()).pw_name)
+        self.assertEqual(dest.group(), grp.getgrgid(os.getgid()).gr_name)
 
     def test_on_change(self):
         dest = self.output_dir.joinpath("data.txt")

--- a/tests/unit/sidecars/live_data_watcher_tests.py
+++ b/tests/unit/sidecars/live_data_watcher_tests.py
@@ -5,7 +5,8 @@ import tempfile
 import unittest
 
 from pathlib import Path
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
+from unittest.mock import patch
 
 from baseplate.sidecars.live_data_watcher import NodeWatcher
 
@@ -21,13 +22,13 @@ class NodeWatcherTests(unittest.TestCase):
         # Mock the returned value from the request (bytes).
         response_mock = Mock(status_code=200)
         request_mock.return_value = response_mock
-        response_mock.content = b"{\"foo\":\"bar\"}"
+        response_mock.content = b'{"foo":"bar"}'
 
         dest = self.output_dir.joinpath("data.txt")
         inst = NodeWatcher(str(dest), os.getuid(), os.getgid(), 777)
 
-        new_content = b"{\"live_data_watcher_load_type\":\"http\",\"data\":\"http://someurl.com/test.json\",\"md5_hashed_data\":\"hashed_data\"}"
-        expected_content = b"{\"foo\":\"bar\"}"
+        new_content = b'{"live_data_watcher_load_type":"http","data":"http://someurl.com/test.json","md5_hashed_data":"hashed_data"}'
+        expected_content = b'{"foo":"bar"}'
         inst.on_change(new_content, None)
         self.assertEqual(expected_content, dest.read_bytes())
         self.assertEqual(dest.owner(), pwd.getpwuid(os.getuid()).pw_name)

--- a/tests/unit/sidecars/live_data_watcher_tests.py
+++ b/tests/unit/sidecars/live_data_watcher_tests.py
@@ -61,7 +61,6 @@ class NodeWatcherTests(unittest.TestCase):
 
             new_content = b'{"live_data_watcher_load_type":"S3","bucket_name":"test_bucket","file_key":"test_file_key","region_name":"us-east-1"}'
             inst.on_change(new_content, None)
-        self.assertEqual(False, os.path.exists(dest))
         self.assertIn(
             "WARNING:%s:No data written to destination file. Something is likely misconfigured."
             % (logger.name),
@@ -86,11 +85,6 @@ class NodeWatcherTests(unittest.TestCase):
             new_content = None
             inst.on_change(new_content, None)
         self.assertEqual(False, os.path.exists(dest))
-        self.assertIn(
-            "WARNING:%s:No data written to destination file. Something is likely misconfigured."
-            % (logger.name),
-            lc.output,
-        )
 
     def test_on_change_new_dir(self):
         dest = self.output_dir.joinpath("data/output.json")

--- a/tests/unit/sidecars/live_data_watcher_tests.py
+++ b/tests/unit/sidecars/live_data_watcher_tests.py
@@ -78,12 +78,11 @@ class NodeWatcherTests(unittest.TestCase):
         self.assertEqual(dest.group(), grp.getgrgid(os.getgid()).gr_name)
 
     def test_on_change_no_data(self):
-        with self.assertLogs(logger.name, level="DEBUG") as lc:
-            dest = self.output_dir.joinpath("data.txt")
-            inst = NodeWatcher(str(dest), os.getuid(), os.getgid(), 777)
+        dest = self.output_dir.joinpath("data.txt")
+        inst = NodeWatcher(str(dest), os.getuid(), os.getgid(), 777)
 
-            new_content = None
-            inst.on_change(new_content, None)
+        new_content = None
+        inst.on_change(new_content, None)
         self.assertEqual(False, os.path.exists(dest))
 
     def test_on_change_new_dir(self):

--- a/tests/unit/sidecars/live_data_watcher_tests.py
+++ b/tests/unit/sidecars/live_data_watcher_tests.py
@@ -1,38 +1,73 @@
 import grp
+import json
 import os
 import pwd
 import tempfile
 import unittest
 
 from pathlib import Path
-from unittest.mock import Mock
-from unittest.mock import patch
 
+import boto3
+
+from moto import mock_s3
+
+from baseplate.sidecars.live_data_watcher import logger
 from baseplate.sidecars.live_data_watcher import NodeWatcher
 
 
 class NodeWatcherTests(unittest.TestCase):
+    mock_s3 = mock_s3()
+
+    def setUp(self):
+        self.mock_s3.start()
+        bucket_name = "test_bucket"
+        s3_data = {"foo_encrypted": "bar_encrypted"}
+        s3_client = boto3.client(
+            "s3",
+            region_name="us-east-1",
+        )
+        s3_client.create_bucket(Bucket=bucket_name)
+        s3_client.put_object(
+            Bucket=bucket_name,
+            Key="test_file_key",
+            Body=json.dumps(s3_data).encode(),
+            SSECustomerKey="test_decryption_key",
+            SSECustomerAlgorithm="AES256",
+        )
+
+    def tearDown(self):
+        self.mock_s3.stop()
+
     def run(self, result: unittest.TestResult = None) -> unittest.TestResult:
         with tempfile.TemporaryDirectory(prefix=self.id()) as loc:
             self.output_dir = Path(loc)
             return super().run(result)
 
-    @patch("requests.get")
-    def test_http_load_type_on_change(self, request_mock: Mock):
-        # Mock the returned value from the request (bytes).
-        response_mock = Mock(status_code=200)
-        request_mock.return_value = response_mock
-        response_mock.content = b'{"foo":"bar"}'
-
+    def test_s3_load_type_on_change(self):
         dest = self.output_dir.joinpath("data.txt")
         inst = NodeWatcher(str(dest), os.getuid(), os.getgid(), 777)
-
-        new_content = b'{"live_data_watcher_load_type":"http","data":"http://someurl.com/test.json","md5_hashed_data":"hashed_data"}'
-        expected_content = b'{"foo":"bar"}'
+        new_content = b'{"live_data_watcher_load_type":"S3","bucket_name":"test_bucket","file_key":"test_file_key","sse_key":"test_decryption_key","region_name":"us-east-1"}'
+        expected_content = b'{"foo_encrypted": "bar_encrypted"}'
         inst.on_change(new_content, None)
         self.assertEqual(expected_content, dest.read_bytes())
         self.assertEqual(dest.owner(), pwd.getpwuid(os.getuid()).pw_name)
         self.assertEqual(dest.group(), grp.getgrgid(os.getgid()).gr_name)
+
+    def test_s3_load_type_missing_keys_on_change(self):
+        with self.assertLogs(logger.name, level="DEBUG") as lc:
+            dest = self.output_dir.joinpath("data.txt")
+            inst = NodeWatcher(str(dest), os.getuid(), os.getgid(), 777)
+            new_content = b'{"live_data_watcher_load_type":"S3","bucket_name":"test_bucket","file_key":"test_file_key","region_name":"us-east-1"}'
+            expected_content = b""
+            inst.on_change(new_content, None)
+        self.assertEqual(expected_content, dest.read_bytes())
+        self.assertEqual(dest.owner(), pwd.getpwuid(os.getuid()).pw_name)
+        self.assertEqual(dest.group(), grp.getgrgid(os.getgid()).gr_name)
+        self.assertIn(
+            "WARNING:%s:No data written to destination node. Something is likely misconfigured."
+            % (logger.name),
+            lc.output,
+        )
 
     def test_on_change(self):
         dest = self.output_dir.joinpath("data.txt")


### PR DESCRIPTION
#### Received [Security Team Sign-Off](https://reddit.atlassian.net/servicedesk/customer/portal/15/SH-914?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJxc2giOiI1ZjYxZDhlNjY4MjVjYzZiMjcxYmUxNTllM2QwMWVkNDg5ZDJlOGRjODU0YzQyZTU4OGUwNTUyMjBhMzkwMzJkIiwiaXNzIjoic2VydmljZWRlc2stand0LXRva2VuLWlzc3VlciIsImNvbnRleHQiOnsidXNlciI6IjI5MzUwIiwiaXNzdWUiOiJTSC05MTQifSwiZXhwIjoxNjUxODU4NDc3LCJpYXQiOjE2NDk0MzkyNzd9.nEEZ_oMQWxvcN0LmJHcwQF9pB_Ya6Dte2ylfDrFw2TQ) on this Approach

#### See [Design Doc](https://docs.google.com/document/d/1AMoZCEYJ5melDQy59z_-mybpdvODGJmNcOv34jC9lYo/edit?usp=sharing) for more detailed design info.


### Summary

We are adding support in Baseplate to be able to fetch contents from a file rather than just reading the data from the ZK Node. This specific PR allows teams to provide the necessary information to retrieve their **encrypted** file stored in an S3 Bucket.

### Why?

The Experiments team (at least) specifically needs this. Our ZK Node where we store Experiments Config data is slowly approaching its 1MB cap. We need to scale so instead we are now storing our config data in S3 File Storage. 

In the future, other teams can also begin using this if they prefer to not have to write all their data to the ZK node and instead reference a pointer to their data (or some other logic).

### How does it work?

Instead of the zk source containing ALL the data, it could instead come in a JSON blob as follows (specific example for S3):

```
data = {
    live_data_watcher_load_type: "S3"
    bucket_name: str
    file_key: str
    sse_key: str
    region_name:str
}
```

In this PR, we specifically add logic to check the contents of the zk source and if it's a JSON with key 'live_data_watcher_load_type' and value 'S3', then we know we can go and retrieve that config data from S3. We also make sure that the logic only handles encrypted files for security reasons.

If we scan the contents of the zk source and realize that the JSON key we're expecting is not there, we know to just write directly to the destination as we did before **(backwards compatible)**

In the future, other teams can support other types (not just 'S3')...but will have to define their own keys necessary to pull from the data storage (e.g. GCS)