### PR TITLE
Use SequentialGeventHandler handler with KazooClient

### DIFF
--- a/baseplate/lib/live_data/zookeeper.py
+++ b/baseplate/lib/live_data/zookeeper.py
@@ -2,6 +2,7 @@
 from typing import Optional
 
 from kazoo.client import KazooClient
+from kazoo.handlers.gevent import SequentialGeventHandler
 
 from baseplate.lib import config
 from baseplate.lib.secrets import SecretsStore
@@ -58,6 +59,7 @@ def zookeeper_client_from_config(
         timeout=cfg.timeout.total_seconds(),
         auth_data=auth_data,
         read_only=read_only,
+        handler=SequentialGeventHandler(),
         # this retry policy tells Kazoo how often it should attempt connections
         # to ZooKeeper from its worker thread/greenlet. when the connection is
         # lost during normal operation (i.e. after it was first established)

--- a/baseplate/lib/live_data/zookeeper.py
+++ b/baseplate/lib/live_data/zookeeper.py
@@ -1,6 +1,8 @@
 """Helpers for interacting with ZooKeeper."""
 from typing import Optional
 
+import gevent
+
 from kazoo.client import KazooClient
 from kazoo.handlers.gevent import SequentialGeventHandler
 
@@ -81,5 +83,6 @@ def zookeeper_client_from_config(
             backoff=2,  # exponential backoff
             max_jitter=1,  # maximum amount to jitter sleeptimes
             max_delay=60,  # never wait longer than this
+            sleep_func=gevent.sleep,
         ),
     )


### PR DESCRIPTION
Kazoo uses the [SequentialThreadingHandler](https://github.com/python-zk/kazoo/blob/master/kazoo/handlers/threading.py) by default. As described in the docs, this handler should not be used with gevent:

```
warning::
    Do not use :class:`SequentialThreadingHandler` with applications
    using asynchronous event loops (like gevent). Use the
    :class:`~kazoo.handlers.gevent.SequentialGeventHandler` instead.
```

Since we started patching [gevent queues](https://github.com/reddit/baseplate.py/pull/656) this handler has stopped working. We need to move to the `SequentialGeventHandler`.