### PR TITLE
rm annoying Prometheus Client log that isnt helpful

### DIFF
--- a/baseplate/observers/prometheus.py
+++ b/baseplate/observers/prometheus.py
@@ -115,9 +115,9 @@ class PrometheusServerSpanObserver(SpanObserver):
 
 class PrometheusClientSpanObserver(SpanObserver):
     def __init__(self) -> None:
-        logger.warning("PrometheusClientSpanObserver not implemented")
+        logger.debug("PrometheusClientSpanObserver not implemented")
 
 
 class PrometheusLocalSpanObserver(SpanObserver):
     def __init__(self) -> None:
-        logger.warning("PrometheusLocalSpanObserver not implemented")
+        logger.debug("PrometheusLocalSpanObserver not implemented")


### PR DESCRIPTION
This log message is not useful and is spamming the logs in the services that upgrade to v2.4.1. This PR fixes that.