### PR TITLE
feat(prometheus) Implement HTTP client metrics

### DIFF
--- a/baseplate/clients/requests.py
+++ b/baseplate/clients/requests.py
@@ -225,7 +225,6 @@ class BaseplateSession:
 
             http_status_code = response.status_code
             span.set_tag("http.status_code", http_status_code)
-            span.set_tag("http.success", str(200 <= http_status_code < 400).lower())
         return response
 
 

--- a/baseplate/lib/prometheus_metrics.py
+++ b/baseplate/lib/prometheus_metrics.py
@@ -74,14 +74,14 @@ class PrometheusHTTPClientMetrics:
     def latency_seconds_metric(self, tags: Dict[str, Any]) -> Histogram:
         return http_client_latency_seconds.labels(
             http_method=tags.get("http.method", ""),
-            http_success=tags.get("http.success", ""),
+            http_success=getHTTPSuccessLabel(int(tags.get("http.status_code", "0"))),
             http_slug=tags.get("http.slug", ""),
         )
 
     def requests_total_metric(self, tags: Dict[str, Any]) -> Counter:
         return http_client_requests_total.labels(
             http_method=tags.get("http.method", ""),
-            http_success=tags.get("http.success", ""),
+            http_success=getHTTPSuccessLabel(int(tags.get("http.status_code", "0"))),
             http_response_code=tags.get("http.status_code", ""),
             http_slug=tags.get("http.slug", ""),
         )

--- a/baseplate/lib/prometheus_metrics.py
+++ b/baseplate/lib/prometheus_metrics.py
@@ -46,17 +46,23 @@ http_client_active_requests_labels = [
     "http_slug",
 ]
 
+# Latency histogram of HTTP calls made by clients
+# buckets are defined above (from 100µs to ~14.9s)
 http_client_latency_seconds = Histogram(
     "http_client_latency_seconds",
     "Description of histogram",
     http_client_latency_labels,
     buckets=default_buckets,
 )
+
+# Counter counting total HTTP requests started by a given client
 http_client_requests_total = Counter(
     "http_client_requests_total",
     "Description of counter",
     http_client_requests_total_labels,
 )
+
+# Gauge showing current number of active requests by a given client
 http_client_active_requests = Gauge(
     "http_client_active_requests",
     "Description of gauge",
@@ -104,18 +110,13 @@ class PrometheusHTTPClientMetrics:
 
 def getHTTPEndpointHandler(httpURL: str) -> str:
     """
-    hhtp://localhost:9090/user/123
+    http://localhost:9090/user/123
     Path to identify the endpoint handler, may be empty.
     Ref: https://github.snooguts.net/reddit/baseplate.spec/blob/master/component-apis/prom-metrics.md#http
-    MUST NOT include the per-request value of "request fields":
-    For example, /subreddits/{subreddit_id}/posts/{post_id}, not /subreddits/1234/posts/5678.
     """
     from urllib3.util import parse_url
 
     _, _, _, _, path, _, _ = parse_url(httpURL)
-    # TODO: remove request fields. Whats the best way to do this.
-    # there is a way to get this representation from pyramid
-    # ref: https://docs.pylonsproject.org/projects/pyramid/en/latest/api/request.html#pyramid.request.Request.url
     return path if path is not None else ""
 
 

--- a/baseplate/lib/prometheus_metrics.py
+++ b/baseplate/lib/prometheus_metrics.py
@@ -49,7 +49,7 @@ http_client_latency_seconds = Histogram(
     "http_client_latency_seconds",
     "Latency histogram of HTTP calls made by clients",
     http_client_latency_labels,
-    buckets=default_buckets,
+    buckets=default_latency_buckets,
 )
 
 # Counter counting total HTTP requests started by a given client
@@ -71,14 +71,14 @@ class PrometheusHTTPClientMetrics:
     def __init__(self) -> None:
         pass
 
-    def latency_seconds_metric(self, tags: Dict) -> Histogram:
+    def latency_seconds_metric(self, tags: Dict[str, Any]) -> Histogram:
         return http_client_latency_seconds.labels(
             http_method=tags.get("http.method", ""),
             http_success=tags.get("http.success", ""),
             http_slug=tags.get("http.slug", ""),
         )
 
-    def requests_total_metric(self, tags: Dict) -> Counter:
+    def requests_total_metric(self, tags: Dict[str, Any]) -> Counter:
         return http_client_requests_total.labels(
             http_method=tags.get("http.method", ""),
             http_success=tags.get("http.success", ""),
@@ -86,7 +86,7 @@ class PrometheusHTTPClientMetrics:
             http_slug=tags.get("http.slug", ""),
         )
 
-    def active_requests_metric(self, tags: Dict) -> Gauge:
+    def active_requests_metric(self, tags: Dict[str, Any]) -> Gauge:
         return http_client_active_requests.labels(
             http_method=tags.get("http.method", ""),
             http_slug=tags.get("http.slug", ""),
@@ -231,14 +231,14 @@ class PrometheusHTTPServerMetrics:
     def __init__(self) -> None:
         pass
 
-    def latency_seconds_metric(self, tags: Dict[str, str]) -> Any:
+    def latency_seconds_metric(self, tags: Dict[str, Any]) -> Histogram:
         return http_server_latency_seconds.labels(
             http_method=tags.get("http.method", ""),
             http_endpoint=tags.get("http.route", ""),
             http_success=getHTTPSuccessLabel(int(tags.get("http.status_code", "0"))),
         )
 
-    def requests_total_metric(self, tags: Dict[str, str]) -> Any:
+    def requests_total_metric(self, tags: Dict[str, Any]) -> Counter:
         return http_server_requests_total.labels(
             http_method=tags.get("http.method", ""),
             http_endpoint=tags.get("http.route", ""),
@@ -246,20 +246,20 @@ class PrometheusHTTPServerMetrics:
             http_response_code=tags.get("http.status_code", ""),
         )
 
-    def active_requests_metric(self, tags: Dict[str, str]) -> Any:
+    def active_requests_metric(self, tags: Dict[str, Any]) -> Gauge:
         return http_server_active_requests.labels(
             http_method=tags.get("http.method", ""),
             http_endpoint=tags.get("http.route", ""),
         )
 
-    def request_size_bytes_metric(self, tags: Dict[str, str]) -> Any:
+    def request_size_bytes_metric(self, tags: Dict[str, Any]) -> Histogram:
         return http_server_request_size_bytes.labels(
             http_method=tags.get("http.method", ""),
             http_endpoint=tags.get("http.route", ""),
             http_success=getHTTPSuccessLabel(int(tags.get("http.status_code", "0"))),
         )
 
-    def response_size_bytes_metric(self, tags: Dict[str, str]) -> Any:
+    def response_size_bytes_metric(self, tags: Dict[str, Any]) -> Histogram:
         return http_server_response_size_bytes.labels(
             http_method=tags.get("http.method", ""),
             http_endpoint=tags.get("http.route", ""),

--- a/baseplate/lib/prometheus_metrics.py
+++ b/baseplate/lib/prometheus_metrics.py
@@ -30,19 +30,16 @@ default_size_buckets = [
 http_client_latency_labels = [
     "http_method",
     "http_success",
-    "http_endpoint",
     "http_slug",
 ]
 http_client_requests_total_labels = [
     "http_method",
     "http_success",
-    "http_endpoint",
     "http_response_code",
     "http_slug",
 ]
 http_client_active_requests_labels = [
     "http_method",
-    "http_endpoint",
     "http_slug",
 ]
 
@@ -77,7 +74,6 @@ class PrometheusHTTPClientMetrics:
     def latency_seconds_metric(self, tags: Dict) -> Histogram:
         return http_client_latency_seconds.labels(
             http_method=tags.get("http.method", ""),
-            http_endpoint=getHTTPEndpointHandler(tags.get("http.url", "")),
             http_success=tags.get("http.success", ""),
             http_slug=tags.get("http.slug", ""),
         )
@@ -85,7 +81,6 @@ class PrometheusHTTPClientMetrics:
     def requests_total_metric(self, tags: Dict) -> Counter:
         return http_client_requests_total.labels(
             http_method=tags.get("http.method", ""),
-            http_endpoint=getHTTPEndpointHandler(tags.get("http.url", "")),
             http_success=tags.get("http.success", ""),
             http_response_code=tags.get("http.status_code", ""),
             http_slug=tags.get("http.slug", ""),
@@ -94,7 +89,6 @@ class PrometheusHTTPClientMetrics:
     def active_requests_metric(self, tags: Dict) -> Gauge:
         return http_client_active_requests.labels(
             http_method=tags.get("http.method", ""),
-            http_endpoint=getHTTPEndpointHandler(tags.get("http.url", "")),
             http_slug=tags.get("http.slug", ""),
         )
 
@@ -106,18 +100,6 @@ class PrometheusHTTPClientMetrics:
 
     def get_active_requests_metric(self) -> Gauge:
         return http_client_active_requests
-
-
-def getHTTPEndpointHandler(httpURL: str) -> str:
-    """
-    http://localhost:9090/user/123
-    Path to identify the endpoint handler, may be empty.
-    Ref: https://github.snooguts.net/reddit/baseplate.spec/blob/master/component-apis/prom-metrics.md#http
-    """
-    from urllib3.util import parse_url
-
-    _, _, _, _, path, _, _ = parse_url(httpURL)
-    return path if path is not None else ""
 
 
 # thrift server labels

--- a/baseplate/lib/prometheus_metrics.py
+++ b/baseplate/lib/prometheus_metrics.py
@@ -26,53 +26,6 @@ default_size_buckets = [
     default_size_start * default_size_factor ** i for i in range(default_size_count)
 ]
 
-# http server labels and metrics
-http_server_histogram_labels = [
-    "http_method",
-    "http_endpoint",
-    "http_success",
-]
-http_server_requests_total_labels = [
-    "http_method",
-    "http_endpoint",
-    "http_success",
-    "http_response_code",
-]
-http_server_active_requests_labels = [
-    "http_method",
-    "http_endpoint",
-]
-
-http_server_latency_seconds = Histogram(
-    "http_server_latency_seconds",
-    "Description of histogram",
-    http_server_histogram_labels,
-    buckets=default_buckets,
-)
-http_server_request_size_bytes = Histogram(
-    "http_server_request_size_bytes",
-    "Description of histogram",
-    http_server_histogram_labels,
-    buckets=default_buckets,
-)
-http_server_response_size_bytes = Histogram(
-    "http_server_response_size_bytes",
-    "Description of histogram",
-    http_server_histogram_labels,
-    buckets=default_buckets,
-)
-http_server_requests_total = Counter(
-    "http_server_requests_total",
-    "Description of counter",
-    http_server_requests_total_labels,
-)
-http_server_active_requests = Gauge(
-    "http_server_active_requests",
-    "Description of gauge",
-    http_server_active_requests_labels,
-)
-
-
 # http client labels and metrics
 http_client_latency_labels = [
     "http_method",

--- a/baseplate/lib/prometheus_metrics.py
+++ b/baseplate/lib/prometheus_metrics.py
@@ -47,7 +47,7 @@ http_client_active_requests_labels = [
 # buckets are defined above (from 100µs to ~14.9s)
 http_client_latency_seconds = Histogram(
     "http_client_latency_seconds",
-    "Description of histogram",
+    "Latency histogram of HTTP calls made by clients",
     http_client_latency_labels,
     buckets=default_buckets,
 )
@@ -55,14 +55,14 @@ http_client_latency_seconds = Histogram(
 # Counter counting total HTTP requests started by a given client
 http_client_requests_total = Counter(
     "http_client_requests_total",
-    "Description of counter",
+    "Total number of HTTP requests started by a given client",
     http_client_requests_total_labels,
 )
 
 # Gauge showing current number of active requests by a given client
 http_client_active_requests = Gauge(
     "http_client_active_requests",
-    "Description of gauge",
+    "Number of active requests for a given client",
     http_client_active_requests_labels,
 )
 

--- a/baseplate/lib/prometheus_metrics.py
+++ b/baseplate/lib/prometheus_metrics.py
@@ -26,6 +26,146 @@ default_size_buckets = [
     default_size_start * default_size_factor ** i for i in range(default_size_count)
 ]
 
+# http server labels and metrics
+http_server_histogram_labels = [
+    "http_method",
+    "http_endpoint",
+    "http_success",
+]
+http_server_requests_total_labels = [
+    "http_method",
+    "http_endpoint",
+    "http_success",
+    "http_response_code",
+]
+http_server_active_requests_labels = [
+    "http_method",
+    "http_endpoint",
+]
+
+http_server_latency_seconds = Histogram(
+    "http_server_latency_seconds",
+    "Description of histogram",
+    http_server_histogram_labels,
+    buckets=default_buckets,
+)
+http_server_request_size_bytes = Histogram(
+    "http_server_request_size_bytes",
+    "Description of histogram",
+    http_server_histogram_labels,
+    buckets=default_buckets,
+)
+http_server_response_size_bytes = Histogram(
+    "http_server_response_size_bytes",
+    "Description of histogram",
+    http_server_histogram_labels,
+    buckets=default_buckets,
+)
+http_server_requests_total = Counter(
+    "http_server_requests_total",
+    "Description of counter",
+    http_server_requests_total_labels,
+)
+http_server_active_requests = Gauge(
+    "http_server_active_requests",
+    "Description of gauge",
+    http_server_active_requests_labels,
+)
+
+
+# http client labels and metrics
+http_client_latency_labels = [
+    "http_method",
+    "http_success",
+    "http_endpoint",
+    "http_slug",
+]
+http_client_requests_total_labels = [
+    "http_method",
+    "http_success",
+    "http_endpoint",
+    "http_response_code",
+    "http_slug",
+]
+http_client_active_requests_labels = [
+    "http_method",
+    "http_endpoint",
+    "http_slug",
+]
+
+http_client_latency_seconds = Histogram(
+    "http_client_latency_seconds",
+    "Description of histogram",
+    http_client_latency_labels,
+    buckets=default_buckets,
+)
+http_client_requests_total = Counter(
+    "http_client_requests_total",
+    "Description of counter",
+    http_client_requests_total_labels,
+)
+http_client_active_requests = Gauge(
+    "http_client_active_requests",
+    "Description of gauge",
+    http_client_active_requests_labels,
+)
+
+
+class PrometheusHTTPClientMetrics:
+    def __init__(self) -> None:
+        pass
+
+    def latency_seconds_metric(self, tags: Dict) -> Histogram:
+        return http_client_latency_seconds.labels(
+            http_method=tags.get("http.method", ""),
+            http_endpoint=getHTTPEndpointHandler(tags.get("http.url", "")),
+            http_success=tags.get("http.success", ""),
+            http_slug=tags.get("http.slug", ""),
+        )
+
+    def requests_total_metric(self, tags: Dict) -> Counter:
+        return http_client_requests_total.labels(
+            http_method=tags.get("http.method", ""),
+            http_endpoint=getHTTPEndpointHandler(tags.get("http.url", "")),
+            http_success=tags.get("http.success", ""),
+            http_response_code=tags.get("http.status_code", ""),
+            http_slug=tags.get("http.slug", ""),
+        )
+
+    def active_requests_metric(self, tags: Dict) -> Gauge:
+        return http_client_active_requests.labels(
+            http_method=tags.get("http.method", ""),
+            http_endpoint=getHTTPEndpointHandler(tags.get("http.url", "")),
+            http_slug=tags.get("http.slug", ""),
+        )
+
+    def get_latency_seconds_metric(self) -> Histogram:
+        return http_client_latency_seconds
+
+    def get_requests_total_metric(self) -> Counter:
+        return http_client_requests_total
+
+    def get_active_requests_metric(self) -> Gauge:
+        return http_client_active_requests
+
+
+def getHTTPEndpointHandler(httpURL: str) -> str:
+    """
+    hhtp://localhost:9090/user/123
+    Path to identify the endpoint handler, may be empty.
+    Ref: https://github.snooguts.net/reddit/baseplate.spec/blob/master/component-apis/prom-metrics.md#http
+    MUST NOT include the per-request value of "request fields":
+    For example, /subreddits/{subreddit_id}/posts/{post_id}, not /subreddits/1234/posts/5678.
+    """
+    from urllib3.util import parse_url
+
+    _, _, _, _, path, _, _ = parse_url(httpURL)
+    # TODO: remove request fields. Whats the best way to do this.
+    # there is a way to get this representation from pyramid
+    # ref: https://docs.pylonsproject.org/projects/pyramid/en/latest/api/request.html#pyramid.request.Request.url
+    return path if path is not None else ""
+
+
 # thrift server labels
 thrift_server_latency_labels = [
     "thrift_method",

--- a/baseplate/observers/prometheus.py
+++ b/baseplate/observers/prometheus.py
@@ -210,3 +210,15 @@ class PrometheusClientSpanObserver(SpanObserver):
 class PrometheusLocalSpanObserver(SpanObserver):
     def __init__(self) -> None:
         logger.debug("PrometheusLocalSpanObserver not implemented")
+
+    # Proper implementation for PrometheusLocalSpanObserver will come in a future PR
+    # In the meantime, we need this logic in place to be able to emit http client metrics
+    # when running inside a local span
+    def on_child_span_created(self, span: Span) -> None:
+        observer: Optional[SpanObserver] = None
+        if isinstance(span, LocalSpan):
+            observer = PrometheusLocalSpanObserver()
+        else:
+            observer = PrometheusClientSpanObserver()
+
+        span.register(observer)

--- a/baseplate/observers/prometheus.py
+++ b/baseplate/observers/prometheus.py
@@ -184,11 +184,6 @@ class PrometheusClientSpanObserver(SpanObserver):
             )
             return
 
-        self.tags["success"] = "true"
-        if exc_info is not None:
-            self.tags["exception_type"] = exc_info[1].__class__.__name__
-            self.tags["success"] = "false"
-
         self.metrics.active_requests_metric(self.tags).dec()
         self.metrics.requests_total_metric(self.tags).inc()
         if self.start_time is not None:

--- a/baseplate/observers/prometheus.py
+++ b/baseplate/observers/prometheus.py
@@ -125,7 +125,6 @@ class PrometheusServerSpanObserver(SpanObserver):
         else:
             observer = PrometheusClientSpanObserver()
 
-        observer.on_set_tag("protocol", self.protocol)
         span.register(observer)
 
 
@@ -203,7 +202,6 @@ class PrometheusClientSpanObserver(SpanObserver):
         else:
             observer = PrometheusClientSpanObserver()
 
-        observer.on_set_tag("protocol", self.protocol)
         span.register(observer)
 
 

--- a/baseplate/observers/prometheus.py
+++ b/baseplate/observers/prometheus.py
@@ -154,7 +154,7 @@ class PrometheusClientSpanObserver(SpanObserver):
             self.metrics = PrometheusHTTPClientMetrics()
         elif self.protocol == "thrift":
             # self.metrics = PrometheusThriftClientMetrics()
-            logger.warning("PrometheusThriftClientMetrics not implemented.")
+            logger.debug("PrometheusThriftClientMetrics not implemented.")
         else:
             logger.warning(
                 "No valid protocol set for Prometheus metric collection, metrics won't be collected. Expected 'http' or 'thrift' protocol. Actual protocol: %s",

--- a/baseplate/observers/prometheus.py
+++ b/baseplate/observers/prometheus.py
@@ -44,13 +44,12 @@ class PrometheusServerSpanObserver(SpanObserver):
     def __init__(self) -> None:
         self.tags: Dict[str, Any] = {}
         self.start_time: Optional[int] = None
-        self.metrics: Any = None
-        # self.metrics: Optional[
-        #     Union[
-        #         PrometheusHTTPServerMetrics,
-        #         PrometheusThriftServerMetrics,
-        #     ]
-        # ] = None
+        self.metrics: Optional[
+            Union[
+                PrometheusHTTPServerMetrics,
+                PrometheusThriftServerMetrics,
+            ]
+        ] = None
 
     def on_set_tag(self, key: str, value: Any) -> None:
         self.tags[key] = value
@@ -112,12 +111,11 @@ class PrometheusServerSpanObserver(SpanObserver):
                 elapsed_ns / NANOSECONDS_PER_SECOND
             )
 
-        if hasattr(self.metrics, "response_size_bytes_metric"):
+        if isinstance(self.metrics, PrometheusHTTPServerMetrics):
             self.metrics.response_size_bytes_metric(self.tags).observe(
                 self.tags.get("http.response_length") or 0
             )
 
-        if hasattr(self.metrics, "request_size_bytes_metric"):
             self.metrics.request_size_bytes_metric(self.tags).observe(
                 self.tags.get("http.request_length") or 0
             )

--- a/baseplate/observers/prometheus.py
+++ b/baseplate/observers/prometheus.py
@@ -139,7 +139,7 @@ class PrometheusClientSpanObserver(SpanObserver):
         self.start_time: Optional[int] = None
         self.metrics: Optional[
             Union[PrometheusHTTPClientMetrics, PrometheusThriftClientMetrics]
-        ] = None  # Add PrometheusThriftClientMetrics when implemented
+        ] = None
 
     def on_set_tag(self, key: str, value: Any) -> None:
         self.tags[key] = value

--- a/baseplate/observers/prometheus.py
+++ b/baseplate/observers/prometheus.py
@@ -4,6 +4,7 @@ import time
 from typing import Any
 from typing import Dict
 from typing import Optional
+from typing import Union
 
 from baseplate import _ExcInfo
 from baseplate import BaseplateObserver
@@ -12,6 +13,7 @@ from baseplate import RequestContext
 from baseplate import Span
 from baseplate import SpanObserver
 from baseplate.lib.prometheus_metrics import PrometheusHTTPServerMetrics
+from baseplate.lib.prometheus_metrics import PrometheusHTTPClientMetrics
 from baseplate.lib.prometheus_metrics import PrometheusThriftServerMetrics
 
 
@@ -41,8 +43,10 @@ class PrometheusBaseplateObserver(BaseplateObserver):
 class PrometheusServerSpanObserver(SpanObserver):
     def __init__(self) -> None:
         self.tags: Dict[str, Any] = {}
-        self.start_time: Any = None
-        self.metrics: Any = None
+        self.start_time: Optional[int] = None
+        self.metrics: Optional[
+            Union[PrometheusThriftServerMetrics]
+        ] = None  # add PrometheusHTTPServerMetrics when implemented
 
     def on_set_tag(self, key: str, value: Any) -> None:
         self.tags[key] = value
@@ -127,7 +131,80 @@ class PrometheusServerSpanObserver(SpanObserver):
 
 class PrometheusClientSpanObserver(SpanObserver):
     def __init__(self) -> None:
-        logger.debug("PrometheusClientSpanObserver not implemented")
+        self.tags: Dict[str, Any] = {}
+        self.start_time: Optional[int] = None
+        self.metrics: Optional[
+            Union[PrometheusHTTPClientMetrics]
+        ] = None  # Add PrometheusThriftClientMetrics when implemented
+
+    def on_set_tag(self, key: str, value: Any) -> None:
+        self.tags[key] = value
+
+    def get_prefix(self) -> str:
+        return f"{self.protocol}_client"
+
+    def get_labels(self) -> Dict[str, str]:
+        return self.tags
+
+    @property
+    def protocol(self) -> str:
+        return self.tags.get("protocol", "unknown")
+
+    def set_metrics_by_protocol(self) -> None:
+        if self.protocol == "http":
+            self.metrics = PrometheusHTTPClientMetrics()
+        elif self.protocol == "thrift":
+            # self.metrics = PrometheusThriftClientMetrics()
+            logger.warning("PrometheusThriftClientMetrics not implemented.")
+        else:
+            logger.warning(
+                "No valid protocol set for Prometheus metric collection, metrics won't be collected. Expected 'http' or 'thrift' protocol. Actual protocol: %s",
+                self.protocol,
+            )
+        return
+
+    def on_start(self) -> None:
+        self.set_metrics_by_protocol()
+        if self.metrics is None:
+            logger.warning(
+                "No metrics set for Prometheus metric collection. Metrics will not be exported correctly."
+            )
+            return
+        self.start_time = time.perf_counter_ns()
+        self.metrics.active_requests_metric(self.tags).inc()
+
+    def on_incr_tag(self, key: str, delta: float) -> None:
+        pass
+
+    def on_finish(self, exc_info: Optional[_ExcInfo]) -> None:
+        if self.metrics is None:
+            logger.warning(
+                "No metrics set for Prometheus metric collection. Metrics will not be exported correctly."
+            )
+            return
+
+        self.tags["success"] = "true"
+        if exc_info is not None:
+            self.tags["exception_type"] = exc_info[1].__class__.__name__
+            self.tags["success"] = "false"
+
+        self.metrics.active_requests_metric(self.tags).dec()
+        self.metrics.requests_total_metric(self.tags).inc()
+        if self.start_time is not None:
+            elapsed_ns = time.perf_counter_ns() - self.start_time
+            self.metrics.latency_seconds_metric(self.tags).observe(
+                elapsed_ns / NANOSECONDS_PER_SECOND
+            )
+
+    def on_child_span_created(self, span: Span) -> None:
+        observer: Optional[SpanObserver] = None
+        if isinstance(span, LocalSpan):
+            observer = PrometheusLocalSpanObserver()
+        else:
+            observer = PrometheusClientSpanObserver()
+
+        observer.on_set_tag("protocol", self.protocol)
+        span.register(observer)
 
 
 class PrometheusLocalSpanObserver(SpanObserver):

--- a/baseplate/observers/prometheus.py
+++ b/baseplate/observers/prometheus.py
@@ -12,8 +12,8 @@ from baseplate import LocalSpan
 from baseplate import RequestContext
 from baseplate import Span
 from baseplate import SpanObserver
-from baseplate.lib.prometheus_metrics import PrometheusHTTPServerMetrics
 from baseplate.lib.prometheus_metrics import PrometheusHTTPClientMetrics
+from baseplate.lib.prometheus_metrics import PrometheusHTTPServerMetrics
 from baseplate.lib.prometheus_metrics import PrometheusThriftServerMetrics
 
 
@@ -44,9 +44,13 @@ class PrometheusServerSpanObserver(SpanObserver):
     def __init__(self) -> None:
         self.tags: Dict[str, Any] = {}
         self.start_time: Optional[int] = None
-        self.metrics: Optional[
-            Union[PrometheusThriftServerMetrics]
-        ] = None  # add PrometheusHTTPServerMetrics when implemented
+        self.metrics: Any = None
+        # self.metrics: Optional[
+        #     Union[
+        #         PrometheusHTTPServerMetrics,
+        #         PrometheusThriftServerMetrics,
+        #     ]
+        # ] = None
 
     def on_set_tag(self, key: str, value: Any) -> None:
         self.tags[key] = value

--- a/docs/api/baseplate/clients/requests.rst
+++ b/docs/api/baseplate/clients/requests.rst
@@ -31,10 +31,11 @@ declaration to your context configuration::
       }
    )
 
-You can specify an optional `client_name` in any requests client. When
-prometheus metrics are emitted, this name will be used for the label
-`http_slug`. If `client_name` is not manually specified, we default back
-to the name of the client within the context (in this case, `foo` and `bar`).
+Prometheus metrics include the `http_slug` label, by default the label
+value is set to the key name provided in the context. In the provided code
+example the  `http_slug` labels will have the values `foo` and `bar`. If you
+would like to change the value of this label you can provide the
+`client_name` keyword argument when you create the requests client.
 
 configure it in your application's configuration file:
 

--- a/docs/api/baseplate/clients/requests.rst
+++ b/docs/api/baseplate/clients/requests.rst
@@ -31,6 +31,11 @@ declaration to your context configuration::
       }
    )
 
+You can specify an optional `client_name` in any requests client. When
+prometheus metrics are emitted, this name will be used for the label
+`http_slug`. If `client_name` is not manually specified, we default back
+to the name of the client within the context (in this case, `foo` and `bar`).
+
 configure it in your application's configuration file:
 
 .. code-block:: ini

--- a/docs/api/baseplate/clients/requests.rst
+++ b/docs/api/baseplate/clients/requests.rst
@@ -32,7 +32,7 @@ declaration to your context configuration::
    )
 
 Prometheus metrics include the `http_slug` label, by default the label
-value is set to the key name provided in the context. In the provided code
+value is set to the key name provided in the context. In the above code
 example the  `http_slug` labels will have the values `foo` and `bar`. If you
 would like to change the value of this label you can provide the
 `client_name` keyword argument when you create the requests client.

--- a/tests/integration/requests_tests.py
+++ b/tests/integration/requests_tests.py
@@ -101,7 +101,6 @@ def test_client_makes_client_span(client_cls, client_name, method, http_server):
     assert client_span_observer.tags["http.url"] == http_server.url
     assert client_span_observer.tags["http.method"] == method
     assert client_span_observer.tags["http.status_code"] == 204
-    assert client_span_observer.tags["http.success"] == "true"
     assert client_span_observer.tags["http.slug"] == (
         client_name if client_name is not None else "myclient"
     )

--- a/tests/integration/requests_tests.py
+++ b/tests/integration/requests_tests.py
@@ -220,7 +220,6 @@ def test_prom(client_cls, client_name, method, http_server):
     assert http_client_requests_total_total.labels.get("http_method") == method
     assert http_client_requests_total_total.labels.get("http_response_code") == "204"
     assert http_client_requests_total_total.labels.get("http_success") == "true"
-    assert http_client_requests_total_total.labels.get("http_endpoint") == "/"
     assert http_client_requests_total_total.labels.get("http_slug") == (
         client_name if client_name is not None else "myclient"
     )
@@ -237,7 +236,6 @@ def test_prom(client_cls, client_name, method, http_server):
     assert http_client_latency_seconds_inf.labels.get("le") == "+Inf"
     assert http_client_latency_seconds_inf.labels.get("http_method") == method
     assert http_client_latency_seconds_inf.labels.get("http_success") == "true"
-    assert http_client_latency_seconds_inf.labels.get("http_endpoint") == "/"
     assert http_client_latency_seconds_inf.labels.get("http_slug") == (
         client_name if client_name is not None else "myclient"
     )
@@ -254,7 +252,6 @@ def test_prom(client_cls, client_name, method, http_server):
     assert len(http_client_active_requests[0].samples) == 1
     http_client_active_requests_samples = http_client_active_requests[0].samples[0]
     assert http_client_active_requests_samples.labels.get("http_method") == method
-    assert http_client_active_requests_samples.labels.get("http_endpoint") == "/"
     assert http_client_active_requests_samples.labels.get("http_slug") == (
         client_name if client_name is not None else "myclient"
     )

--- a/tests/integration/requests_tests.py
+++ b/tests/integration/requests_tests.py
@@ -176,7 +176,7 @@ def test_external_client_doesnt_send_headers(http_server):
 @pytest.mark.parametrize("client_cls", [InternalRequestsClient, ExternalRequestsClient])
 @pytest.mark.parametrize("client_name", [None, "", "complex.client$name"])
 @pytest.mark.parametrize("method", ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "PUT", "POST"])
-def test_prom(client_cls, client_name, method, http_server):
+def test_prometheus_http_client_metrics(client_cls, client_name, method, http_server):
     baseplate = Baseplate(
         {"myclient.filter.ip_allowlist": "127.0.0.0/8", "myclient.filter.port_denylist": "0"}
     )

--- a/tests/unit/observers/prometheus_tests.py
+++ b/tests/unit/observers/prometheus_tests.py
@@ -9,6 +9,7 @@ from prometheus_client import REGISTRY
 from baseplate import ServerSpan
 from baseplate.lib.prometheus_metrics import getHTTPSuccessLabel
 from baseplate.observers.prometheus import PrometheusBaseplateObserver
+from baseplate.observers.prometheus import PrometheusClientSpanObserver
 from baseplate.observers.prometheus import PrometheusServerSpanObserver
 
 
@@ -48,6 +49,32 @@ class TestException(Exception):
                 },
                 "latency_labels": {"http_method": "", "http_endpoint": "", "http_success": "false"},
                 "active_labels": {"http_method": "", "http_endpoint": ""},
+            },
+        ),
+        (
+            "http",
+            "client",
+            PrometheusClientSpanObserver,
+            {
+                "latency_labels": {
+                    "http_method": "",
+                    "http_success": "",
+                    "http_endpoint": "",
+                    "http_slug": "",
+                },
+                "requests_labels": {
+                    "http_method": "",
+                    "http_success": "",
+                    "http_endpoint": "",
+                    "http_response_code": "",
+                    "http_slug": "",
+                },
+                "active_labels": {
+                    "http_method": "",
+                    "http_endpoint": "",
+                    "http_slug": "",
+                },
+>>>>>>> 7c2d8b9 (feat(prometheus) Implement HTTP client metrics)
             },
         ),
     ),

--- a/tests/unit/observers/prometheus_tests.py
+++ b/tests/unit/observers/prometheus_tests.py
@@ -58,12 +58,12 @@ class TestException(Exception):
             {
                 "latency_labels": {
                     "http_method": "",
-                    "http_success": "",
+                    "http_success": "false",
                     "http_slug": "",
                 },
                 "requests_labels": {
                     "http_method": "",
-                    "http_success": "",
+                    "http_success": "false",
                     "http_response_code": "",
                     "http_slug": "",
                 },

--- a/tests/unit/observers/prometheus_tests.py
+++ b/tests/unit/observers/prometheus_tests.py
@@ -59,19 +59,16 @@ class TestException(Exception):
                 "latency_labels": {
                     "http_method": "",
                     "http_success": "",
-                    "http_endpoint": "",
                     "http_slug": "",
                 },
                 "requests_labels": {
                     "http_method": "",
                     "http_success": "",
-                    "http_endpoint": "",
                     "http_response_code": "",
                     "http_slug": "",
                 },
                 "active_labels": {
                     "http_method": "",
-                    "http_endpoint": "",
                     "http_slug": "",
                 },
 >>>>>>> 7c2d8b9 (feat(prometheus) Implement HTTP client metrics)

--- a/tests/unit/observers/prometheus_tests.py
+++ b/tests/unit/observers/prometheus_tests.py
@@ -71,7 +71,6 @@ class TestException(Exception):
                     "http_method": "",
                     "http_slug": "",
                 },
->>>>>>> 7c2d8b9 (feat(prometheus) Implement HTTP client metrics)
             },
         ),
     ),


### PR DESCRIPTION
Testing this should be as simple as making sure you configure an internal / external requests client in your context as needed, and then making requests with them.

```
baseplate.configure_context(
    {
        "external": ExternalRequestsClient(client_name="ipinfo.io"),
        "internal": InternalRequestsClient(),
    },
    ...
)
```

```
with baseplate.server_context("test") as context:
    context.external.get('https://ipinfo.io/ip')
    context.external.get('https://ipinfo.io/json')
    context.external.get('https://ipinfo.io/error')
```
And any internal call you want to set up on your end.

You should see something similar to this on `/metrics`:
```
❯ curl -s localhost:6060/metrics
# HELP http_client_latency_seconds Multiprocess metric
# TYPE http_client_latency_seconds histogram
http_client_latency_seconds_sum{http_endpoint="/ip",http_method="GET",http_slug="ipinfo.io",http_success="true"} 0.066207297
http_client_latency_seconds_sum{http_endpoint="/json",http_method="GET",http_slug="ipinfo.io",http_success="true"} 0.020237509
http_client_latency_seconds_sum{http_endpoint="/error",http_method="GET",http_slug="ipinfo.io",http_success="false"} 0.018597764
http_client_latency_seconds_bucket{http_endpoint="/ip",http_method="GET",http_slug="ipinfo.io",http_success="true",le="0.0001"} 0.0
http_client_latency_seconds_bucket{http_endpoint="/ip",http_method="GET",http_slug="ipinfo.io",http_success="true",le="0.00025"} 0.0
http_client_latency_seconds_bucket{http_endpoint="/ip",http_method="GET",http_slug="ipinfo.io",http_success="true",le="0.000625"} 0.0
http_client_latency_seconds_bucket{http_endpoint="/ip",http_method="GET",http_slug="ipinfo.io",http_success="true",le="0.0015625"} 0.0
http_client_latency_seconds_bucket{http_endpoint="/ip",http_method="GET",http_slug="ipinfo.io",http_success="true",le="0.00390625"} 0.0
http_client_latency_seconds_bucket{http_endpoint="/ip",http_method="GET",http_slug="ipinfo.io",http_success="true",le="0.009765625"} 0.0
http_client_latency_seconds_bucket{http_endpoint="/ip",http_method="GET",http_slug="ipinfo.io",http_success="true",le="0.0244140625"} 0.0
http_client_latency_seconds_bucket{http_endpoint="/ip",http_method="GET",http_slug="ipinfo.io",http_success="true",le="0.06103515625"} 0.0
http_client_latency_seconds_bucket{http_endpoint="/ip",http_method="GET",http_slug="ipinfo.io",http_success="true",le="0.152587890625"} 1.0
http_client_latency_seconds_bucket{http_endpoint="/ip",http_method="GET",http_slug="ipinfo.io",http_success="true",le="0.3814697265625"} 1.0
http_client_latency_seconds_bucket{http_endpoint="/ip",http_method="GET",http_slug="ipinfo.io",http_success="true",le="0.95367431640625"} 1.0
http_client_latency_seconds_bucket{http_endpoint="/ip",http_method="GET",http_slug="ipinfo.io",http_success="true",le="2.384185791015625"} 1.0
http_client_latency_seconds_bucket{http_endpoint="/ip",http_method="GET",http_slug="ipinfo.io",http_success="true",le="5.9604644775390625"} 1.0
http_client_latency_seconds_bucket{http_endpoint="/ip",http_method="GET",http_slug="ipinfo.io",http_success="true",le="14.901161193847656"} 1.0
http_client_latency_seconds_bucket{http_endpoint="/ip",http_method="GET",http_slug="ipinfo.io",http_success="true",le="+Inf"} 1.0
http_client_latency_seconds_count{http_endpoint="/ip",http_method="GET",http_slug="ipinfo.io",http_success="true"} 1.0
http_client_latency_seconds_bucket{http_endpoint="/json",http_method="GET",http_slug="ipinfo.io",http_success="true",le="0.0001"} 0.0
http_client_latency_seconds_bucket{http_endpoint="/json",http_method="GET",http_slug="ipinfo.io",http_success="true",le="0.00025"} 0.0
http_client_latency_seconds_bucket{http_endpoint="/json",http_method="GET",http_slug="ipinfo.io",http_success="true",le="0.000625"} 0.0
http_client_latency_seconds_bucket{http_endpoint="/json",http_method="GET",http_slug="ipinfo.io",http_success="true",le="0.0015625"} 0.0
http_client_latency_seconds_bucket{http_endpoint="/json",http_method="GET",http_slug="ipinfo.io",http_success="true",le="0.00390625"} 0.0
http_client_latency_seconds_bucket{http_endpoint="/json",http_method="GET",http_slug="ipinfo.io",http_success="true",le="0.009765625"} 0.0
http_client_latency_seconds_bucket{http_endpoint="/json",http_method="GET",http_slug="ipinfo.io",http_success="true",le="0.0244140625"} 1.0
http_client_latency_seconds_bucket{http_endpoint="/json",http_method="GET",http_slug="ipinfo.io",http_success="true",le="0.06103515625"} 1.0
http_client_latency_seconds_bucket{http_endpoint="/json",http_method="GET",http_slug="ipinfo.io",http_success="true",le="0.152587890625"} 1.0
http_client_latency_seconds_bucket{http_endpoint="/json",http_method="GET",http_slug="ipinfo.io",http_success="true",le="0.3814697265625"} 1.0
http_client_latency_seconds_bucket{http_endpoint="/json",http_method="GET",http_slug="ipinfo.io",http_success="true",le="0.95367431640625"} 1.0
http_client_latency_seconds_bucket{http_endpoint="/json",http_method="GET",http_slug="ipinfo.io",http_success="true",le="2.384185791015625"} 1.0
http_client_latency_seconds_bucket{http_endpoint="/json",http_method="GET",http_slug="ipinfo.io",http_success="true",le="5.9604644775390625"} 1.0
http_client_latency_seconds_bucket{http_endpoint="/json",http_method="GET",http_slug="ipinfo.io",http_success="true",le="14.901161193847656"} 1.0
http_client_latency_seconds_bucket{http_endpoint="/json",http_method="GET",http_slug="ipinfo.io",http_success="true",le="+Inf"} 1.0
http_client_latency_seconds_count{http_endpoint="/json",http_method="GET",http_slug="ipinfo.io",http_success="true"} 1.0
http_client_latency_seconds_bucket{http_endpoint="/error",http_method="GET",http_slug="ipinfo.io",http_success="false",le="0.0001"} 0.0
http_client_latency_seconds_bucket{http_endpoint="/error",http_method="GET",http_slug="ipinfo.io",http_success="false",le="0.00025"} 0.0
http_client_latency_seconds_bucket{http_endpoint="/error",http_method="GET",http_slug="ipinfo.io",http_success="false",le="0.000625"} 0.0
http_client_latency_seconds_bucket{http_endpoint="/error",http_method="GET",http_slug="ipinfo.io",http_success="false",le="0.0015625"} 0.0
http_client_latency_seconds_bucket{http_endpoint="/error",http_method="GET",http_slug="ipinfo.io",http_success="false",le="0.00390625"} 0.0
http_client_latency_seconds_bucket{http_endpoint="/error",http_method="GET",http_slug="ipinfo.io",http_success="false",le="0.009765625"} 0.0
http_client_latency_seconds_bucket{http_endpoint="/error",http_method="GET",http_slug="ipinfo.io",http_success="false",le="0.0244140625"} 1.0
http_client_latency_seconds_bucket{http_endpoint="/error",http_method="GET",http_slug="ipinfo.io",http_success="false",le="0.06103515625"} 1.0
http_client_latency_seconds_bucket{http_endpoint="/error",http_method="GET",http_slug="ipinfo.io",http_success="false",le="0.152587890625"} 1.0
http_client_latency_seconds_bucket{http_endpoint="/error",http_method="GET",http_slug="ipinfo.io",http_success="false",le="0.3814697265625"} 1.0
http_client_latency_seconds_bucket{http_endpoint="/error",http_method="GET",http_slug="ipinfo.io",http_success="false",le="0.95367431640625"} 1.0
http_client_latency_seconds_bucket{http_endpoint="/error",http_method="GET",http_slug="ipinfo.io",http_success="false",le="2.384185791015625"} 1.0
http_client_latency_seconds_bucket{http_endpoint="/error",http_method="GET",http_slug="ipinfo.io",http_success="false",le="5.9604644775390625"} 1.0
http_client_latency_seconds_bucket{http_endpoint="/error",http_method="GET",http_slug="ipinfo.io",http_success="false",le="14.901161193847656"} 1.0
http_client_latency_seconds_bucket{http_endpoint="/error",http_method="GET",http_slug="ipinfo.io",http_success="false",le="+Inf"} 1.0
http_client_latency_seconds_count{http_endpoint="/error",http_method="GET",http_slug="ipinfo.io",http_success="false"} 1.0
# HELP http_client_requests_total Multiprocess metric
# TYPE http_client_requests_total counter
http_client_requests_total{http_endpoint="/ip",http_method="GET",http_response_code="200",http_slug="ipinfo.io",http_success="true"} 1.0
http_client_requests_total{http_endpoint="/json",http_method="GET",http_response_code="200",http_slug="ipinfo.io",http_success="true"} 1.0
http_client_requests_total{http_endpoint="/error",http_method="GET",http_response_code="404",http_slug="ipinfo.io",http_success="false"} 1.0
# HELP http_client_active_requests Multiprocess metric
# TYPE http_client_active_requests gauge
http_client_active_requests{http_endpoint="/ip",http_method="GET",http_slug="ipinfo.io",pid="41861"} 0.0
http_client_active_requests{http_endpoint="/json",http_method="GET",http_slug="ipinfo.io",pid="41861"} 0.0
http_client_active_requests{http_endpoint="/error",http_method="GET",http_slug="ipinfo.io",pid="41861"} 0.0
```