### PR TITLE
feat(Span): Allow span to be created with tags in a context manager

### DIFF
--- a/baseplate/__init__.py
+++ b/baseplate/__init__.py
@@ -670,6 +670,20 @@ class Span:
         """Return a child Span whose parent is this Span."""
         raise NotImplementedError
 
+    def with_tags(self, tags: Dict[str, Any]) -> "Span":
+        """Declare a set of tags to be added to a span before starting it in the context manager.
+
+        Can be used as follow:
+        tags = {...}
+        with self.span.make_child("...").with_tags(tags) as span:
+            ...
+
+        :param tags: Dict of tags to be set on the span at creation time.
+        `"""
+        for k, v in tags.items():
+            self.set_tag(k, v)
+        return self
+
 
 class ParentSpanAlreadyFinishedError(Exception):
     def __init__(self) -> None:

--- a/tests/unit/core_tests.py
+++ b/tests/unit/core_tests.py
@@ -152,6 +152,26 @@ class SpanTests(unittest.TestCase):
             self.assertEqual(mock_observer.on_start.call_count, 1)
         self.assertEqual(mock_observer.on_finish.call_count, 1)
 
+    def test_context_with_tags(self):
+        mock_observer = mock.Mock(spec=SpanObserver)
+
+        span = make_test_span()
+        span.register(mock_observer)
+
+        tags = {
+            "k1": "v1",
+            "k2": "v2",
+        }
+        with span.with_tags(tags) as span:
+            self.assertEqual(mock_observer.on_start.call_count, 1)
+            mock_observer.on_set_tag.assert_has_calls(
+                [
+                    mock.call("k1", "v1"),
+                    mock.call("k2", "v2"),
+                ]
+            )
+        self.assertEqual(mock_observer.on_finish.call_count, 1)
+
     def test_context_with_exception(self):
         mock_observer = mock.Mock(spec=SpanObserver)
 


### PR DESCRIPTION
This is relevant to https://github.com/reddit/baseplate.py/pull/663.

As the title says, the goal is to be able to define Spans with a list of tags before the Span itself is started.