### PR TITLE
Make Kazoo work without gevent (for example in sidecars)

### DIFF
--- a/baseplate/lib/live_data/zookeeper.py
+++ b/baseplate/lib/live_data/zookeeper.py
@@ -1,5 +1,6 @@
 """Helpers for interacting with ZooKeeper."""
 import time
+
 from typing import Optional
 
 import gevent
@@ -66,7 +67,6 @@ def zookeeper_client_from_config(
     else:
         handler = None
         sleep_func = time.sleep
-
 
     return KazooClient(
         cfg.hosts,

--- a/baseplate/lib/live_data/zookeeper.py
+++ b/baseplate/lib/live_data/zookeeper.py
@@ -3,8 +3,6 @@ import time
 
 from typing import Optional
 
-import gevent
-
 from kazoo.client import KazooClient
 from kazoo.handlers.gevent import SequentialGeventHandler
 
@@ -59,14 +57,11 @@ def zookeeper_client_from_config(
         credentials = secrets.get_simple(path)
         auth_data.append(("digest", credentials.decode("utf8")))
 
-    # Kazoo requires different parameters depending on whether
-    # we are using gevent or not.
+    # Kazoo needs to use a different handler with gevent.
     if gevent_is_patched():
         handler = SequentialGeventHandler()
-        sleep_func = gevent.sleep
     else:
         handler = None
-        sleep_func = time.sleep
 
     return KazooClient(
         cfg.hosts,
@@ -95,6 +90,6 @@ def zookeeper_client_from_config(
             backoff=2,  # exponential backoff
             max_jitter=1,  # maximum amount to jitter sleeptimes
             max_delay=60,  # never wait longer than this
-            sleep_func=sleep_func,
+            sleep_func=time.sleep,
         ),
     )

--- a/baseplate/lib/live_data/zookeeper.py
+++ b/baseplate/lib/live_data/zookeeper.py
@@ -10,7 +10,7 @@ from kazoo.handlers.gevent import SequentialGeventHandler
 
 from baseplate.lib import config
 from baseplate.lib.secrets import SecretsStore
-from baseplate.server.monkey import is_gevent_patched
+from baseplate.server.monkey import gevent_is_patched
 
 
 def zookeeper_client_from_config(
@@ -61,7 +61,7 @@ def zookeeper_client_from_config(
 
     # Kazoo requires different parameters depending on whether
     # we are using gevent or not.
-    if is_gevent_patched():
+    if gevent_is_patched():
         handler = SequentialGeventHandler()
         sleep_func = gevent.sleep
     else:

--- a/baseplate/lib/live_data/zookeeper.py
+++ b/baseplate/lib/live_data/zookeeper.py
@@ -1,6 +1,4 @@
 """Helpers for interacting with ZooKeeper."""
-import time
-
 from typing import Optional
 
 from kazoo.client import KazooClient
@@ -90,6 +88,5 @@ def zookeeper_client_from_config(
             backoff=2,  # exponential backoff
             max_jitter=1,  # maximum amount to jitter sleeptimes
             max_delay=60,  # never wait longer than this
-            sleep_func=time.sleep,
         ),
     )

--- a/baseplate/server/monkey.py
+++ b/baseplate/server/monkey.py
@@ -13,7 +13,6 @@ def patch_stdlib_queues() -> None:
     monkey.patch_module(queue, gevent.queue, items=["Queue", "LifoQueue", "PriorityQueue"])
 
 
-def is_gevent_patched():
-    """Has any gevent patching has occurred?
-    """
+def is_gevent_patched() -> bool:
+    """Has any gevent patching has occurred?"""
     return monkey.saved

--- a/baseplate/server/monkey.py
+++ b/baseplate/server/monkey.py
@@ -13,6 +13,6 @@ def patch_stdlib_queues() -> None:
     monkey.patch_module(queue, gevent.queue, items=["Queue", "LifoQueue", "PriorityQueue"])
 
 
-def is_gevent_patched() -> bool:
+def gevent_is_patched() -> bool:
     """Has any gevent patching has occurred?"""
-    return monkey.saved
+    return bool(monkey.saved)

--- a/baseplate/server/monkey.py
+++ b/baseplate/server/monkey.py
@@ -14,5 +14,5 @@ def patch_stdlib_queues() -> None:
 
 
 def gevent_is_patched() -> bool:
-    """Has any gevent patching has occurred?"""
+    """Returns true if gevent is patched, otherwise returns false."""
     return bool(monkey.saved)

--- a/baseplate/server/monkey.py
+++ b/baseplate/server/monkey.py
@@ -1,4 +1,4 @@
-from gevent.monkey import patch_module
+from gevent import monkey
 
 
 def patch_stdlib_queues() -> None:
@@ -10,4 +10,10 @@ def patch_stdlib_queues() -> None:
     import queue
     import gevent.queue
 
-    patch_module(queue, gevent.queue, items=["Queue", "LifoQueue", "PriorityQueue"])
+    monkey.patch_module(queue, gevent.queue, items=["Queue", "LifoQueue", "PriorityQueue"])
+
+
+def is_gevent_patched():
+    """Has any gevent patching has occurred?
+    """
+    return monkey.saved

--- a/tests/integration/live_data/zookeeper_tests.py
+++ b/tests/integration/live_data/zookeeper_tests.py
@@ -63,7 +63,7 @@ class ZooKeeperHandlerWithPatchingTests(unittest.TestCase):
         assert isinstance(client.handler, SequentialThreadingHandler)
 
     @mock.patch("baseplate.lib.live_data.zookeeper.gevent_is_patched", return_value=True)
-    def test_create_client_uses_gevent_handler_when_gevent_patched(self):
+    def test_create_client_uses_gevent_handler_when_gevent_patched(self, mock_gevent_is_patched):
         patched_default_values = tuple(
             gevent.sleep if value is time.sleep else value
             for value in KazooRetry.__init__.__defaults__

--- a/tests/integration/live_data/zookeeper_tests.py
+++ b/tests/integration/live_data/zookeeper_tests.py
@@ -68,7 +68,10 @@ class ZooKeeperHandlerWithPatchingTests(unittest.TestCase):
         )
         assert isinstance(client.handler, SequentialThreadingHandler)
 
-    @mock.patch("time.sleep", gevent.sleep)
+    @mock.patch(
+        "kazoo.retry.KazooRetry.__init__.__defaults__",
+        (1, 0.1, 2, 0.4, 60.0, True, gevent.sleep, None, None),
+    )
     def test_create_client_uses_gevent_handler_when_gevent_patched(self):
         # We patch `socket` just to make sure that the gevent handler is chosen,
         # nothing is special about `socket` in particular. We don't just use

--- a/tests/integration/requests_tests.py
+++ b/tests/integration/requests_tests.py
@@ -28,6 +28,7 @@ def gevent_socket():
         import socket
 
         importlib.reload(socket)
+        gevent.monkey.saved.clear()
 
 
 @pytest.fixture

--- a/tests/integration/thrift_tests.py
+++ b/tests/integration/thrift_tests.py
@@ -134,6 +134,7 @@ class GeventPatchedTestCase(unittest.TestCase):
         import socket
 
         reload(socket)
+        gevent.monkey.saved.clear()
 
 
 class ThriftTraceHeaderTests(GeventPatchedTestCase):

--- a/tests/unit/server/monkey_tests.py
+++ b/tests/unit/server/monkey_tests.py
@@ -5,7 +5,7 @@ import unittest
 import gevent.monkey
 import gevent.queue
 
-from baseplate.server.monkey import is_gevent_patched
+from baseplate.server.monkey import gevent_is_patched
 from baseplate.server.monkey import patch_stdlib_queues
 
 
@@ -19,9 +19,9 @@ class MonkeyPatchTests(unittest.TestCase):
         assert queue.LifoQueue is not gevent.queue.LifoQueue
 
     def test_is_gevent_patched(self):
-        assert not is_gevent_patched()
+        assert not gevent_is_patched()
         patch_stdlib_queues()
-        assert is_gevent_patched()
+        assert gevent_is_patched()
         importlib.reload(queue)
         gevent.monkey.saved.clear()
-        assert not is_gevent_patched()
+        assert not gevent_is_patched()

--- a/tests/unit/server/monkey_tests.py
+++ b/tests/unit/server/monkey_tests.py
@@ -4,6 +4,7 @@ import unittest
 
 import gevent.queue
 
+from baseplate.server.monkey import is_gevent_patched
 from baseplate.server.monkey import patch_stdlib_queues
 
 
@@ -14,3 +15,9 @@ class MonkeyPatchTests(unittest.TestCase):
         assert queue.LifoQueue is gevent.queue.LifoQueue
         importlib.reload(queue)
         assert queue.LifoQueue is not gevent.queue.LifoQueue
+
+    def test_is_gevent_patched(self):
+        assert not is_gevent_patched()
+        patch_stdlib_queues()
+        assert is_gevent_patched()
+        importlib.reload(queue)

--- a/tests/unit/server/monkey_tests.py
+++ b/tests/unit/server/monkey_tests.py
@@ -2,6 +2,7 @@ import importlib
 import queue
 import unittest
 
+import gevent.monkey
 import gevent.queue
 
 from baseplate.server.monkey import is_gevent_patched
@@ -14,6 +15,7 @@ class MonkeyPatchTests(unittest.TestCase):
         patch_stdlib_queues()
         assert queue.LifoQueue is gevent.queue.LifoQueue
         importlib.reload(queue)
+        gevent.monkey.saved.clear()
         assert queue.LifoQueue is not gevent.queue.LifoQueue
 
     def test_is_gevent_patched(self):
@@ -21,3 +23,5 @@ class MonkeyPatchTests(unittest.TestCase):
         patch_stdlib_queues()
         assert is_gevent_patched()
         importlib.reload(queue)
+        gevent.monkey.saved.clear()
+        assert not is_gevent_patched()

--- a/tests/unit/server/monkey_tests.py
+++ b/tests/unit/server/monkey_tests.py
@@ -10,18 +10,16 @@ from baseplate.server.monkey import patch_stdlib_queues
 
 
 class MonkeyPatchTests(unittest.TestCase):
+    def tearDown(self):
+        importlib.reload(queue)
+        gevent.monkey.saved.clear()
+
     def test_patch_stdlib_queues(self):
         assert queue.LifoQueue is not gevent.queue.LifoQueue
         patch_stdlib_queues()
         assert queue.LifoQueue is gevent.queue.LifoQueue
-        importlib.reload(queue)
-        gevent.monkey.saved.clear()
-        assert queue.LifoQueue is not gevent.queue.LifoQueue
 
     def test_is_gevent_patched(self):
         assert not gevent_is_patched()
         patch_stdlib_queues()
         assert gevent_is_patched()
-        importlib.reload(queue)
-        gevent.monkey.saved.clear()
-        assert not gevent_is_patched()


### PR DESCRIPTION
## 💸 TL;DR
KazooClient needs to be initialized differently depending on whether we are using gevent or not. We don't use gevent in sidecars so need to make sure KazooClient works without gevent.

## 📜 Details
In #659 we updated Kazoo to use `SequentialGeventHandler` for compatibility with gevent. Unfortunately this handler silently fails if we are not using gevent.

Sidecars do _not_ use gevent as they don't use entrypoint scripts that patch (such as `baseplate-serve`), instead being ran directly (`python -m baseplate.sidecars.live_data_watcher some_config.ini`). I'm not sure if this is intentional or an oversight.

This PR detects if gevent patching has occurred and initializes KazooClient accordingly.

## 🧪 Testing Steps / Validation
* This change has been tested on an internal service that was experiencing the above issue when updating to the latest baseplate version.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] CI tests (if present) are passing
- [x] Adheres to code style for repo
- [x] Contributor License Agreement (CLA) completed if not a Reddit employee
