### PR TITLE
fix(metrics): pass by class reference rather than instantiated class DEVX-585

### DIFF
--- a/baseplate/lib/thrift_pool.py
+++ b/baseplate/lib/thrift_pool.py
@@ -105,7 +105,7 @@ def thrift_pool_from_config(
     options = parser.parse(prefix[:-1], app_config)
 
     if options.fifo_queue:
-        kwargs.setdefault("queue_cls", queue.Queue())
+        kwargs.setdefault("queue_cls", queue.Queue)
     if options.size is not None:
         kwargs.setdefault("size", options.size)
     if options.max_age is not None:
@@ -160,7 +160,7 @@ class ThriftConnectionPool:
         timeout: float = 1,
         max_connection_attempts: int = 3,
         protocol_factory: TProtocolFactory = _DEFAULT_PROTOCOL_FACTORY,
-        queue_cls: ProtocolPool = queue.LifoQueue(),
+        queue_cls: ProtocolPool = queue.LifoQueue,
     ):
         self.endpoint = endpoint
         self.max_age = max_age
@@ -170,7 +170,7 @@ class ThriftConnectionPool:
 
         self.size = size
 
-        self.pool = queue_cls
+        self.pool = queue_cls()
         for _ in range(size):
             self.pool.put(None)
 

--- a/baseplate/lib/thrift_pool.py
+++ b/baseplate/lib/thrift_pool.py
@@ -23,6 +23,7 @@ import time
 from typing import Any
 from typing import Generator
 from typing import Optional
+from typing import Type
 from typing import TYPE_CHECKING
 
 from thrift.protocol import THeaderProtocol
@@ -42,7 +43,7 @@ logger = logging.getLogger(__name__)
 
 
 if TYPE_CHECKING:
-    ProtocolPool = queue.Queue[TProtocolBase]  # pylint: disable=unsubscriptable-object
+    ProtocolPool = Type[queue.Queue[TProtocolBase]]  # pylint: disable=unsubscriptable-object
 else:
     ProtocolPool = queue.Queue
 

--- a/tests/unit/lib/thrift_pool_tests.py
+++ b/tests/unit/lib/thrift_pool_tests.py
@@ -310,7 +310,7 @@ class ThriftConnectionPoolTests(unittest.TestCase):
             def get(self, *args, **kwargs):
                 raise Exception
 
-        pool = thrift_pool.ThriftConnectionPool(EXAMPLE_ENDPOINT, queue_cls=PatchedLifoQueue())
+        pool = thrift_pool.ThriftConnectionPool(EXAMPLE_ENDPOINT, queue_cls=PatchedLifoQueue)
 
         with self.assertRaises(Exception):
             with pool.connection() as _:


### PR DESCRIPTION

## 🧪 Testing Steps / Validation
I pulled the local package into a local pip install into moderators, which exhibited the problem, then added some logging to confirm that the qsize != size at which point it was obvious that they were all sharing one queue. 

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] CI tests (if present) are passing
- [x] Adheres to code style for repo
- [ ] Contributor License Agreement (CLA) completed if not a Reddit employee
