### PR TITLE
add thrift client metrics

### DIFF
--- a/baseplate/clients/thrift.py
+++ b/baseplate/clients/thrift.py
@@ -168,12 +168,16 @@ def _build_thrift_proxy_method(name: str) -> Callable[..., Any]:
         last_error = None
 
         for time_remaining in self.retry_policy:
-            span = self.server_span.make_child(trace_name)
-            span.set_tag("slug", self.namespace)
-            span.start()
-
             try:
                 with self.pool.connection() as prot:
+                    span = self.server_span.make_child(trace_name)
+                    span.set_tag("slug", self.namespace)
+
+                    client = self.client_cls(prot)
+                    method = getattr(client, name)
+                    span.set_tag("method", method.__name__)
+                    span.start()
+
                     baseplate = span.baseplate
                     if baseplate:
                         service_name = baseplate.service_name
@@ -208,9 +212,6 @@ def _build_thrift_proxy_method(name: str) -> Callable[..., Any]:
                     if edge_context:
                         prot.trans.set_header(b"Edge-Request", edge_context)
 
-                    client = self.client_cls(prot)
-                    method = getattr(client, name)
-                    span.set_tag("method", method)
                     result = method(*args, **kwargs)
             except TTransportException as exc:
                 # the connection failed for some reason, retry if able

--- a/baseplate/clients/thrift.py
+++ b/baseplate/clients/thrift.py
@@ -169,6 +169,7 @@ def _build_thrift_proxy_method(name: str) -> Callable[..., Any]:
 
         for time_remaining in self.retry_policy:
             span = self.server_span.make_child(trace_name)
+            span.set_tag("slug", self.namespace)
             span.start()
 
             try:
@@ -209,6 +210,7 @@ def _build_thrift_proxy_method(name: str) -> Callable[..., Any]:
 
                     client = self.client_cls(prot)
                     method = getattr(client, name)
+                    span.set_tag("method", method)
                     result = method(*args, **kwargs)
             except TTransportException as exc:
                 # the connection failed for some reason, retry if able

--- a/baseplate/lib/prometheus_metrics.py
+++ b/baseplate/lib/prometheus_metrics.py
@@ -95,7 +95,7 @@ thrift_client_active_gauge = Gauge(
     "thrift_client_active_requests", "Current in-flight requests", ["thrift_slug", "thrift_method"]
 )
 
-thrift_client_latency_historygram = Histogram(
+thrift_client_latency_histogram = Histogram(
     "thrift_client_latency_seconds",
     "Latency of thrift client requests",
     ["thrift_slug", "thrift_success"],
@@ -110,7 +110,7 @@ thrift_client_requests_counter = Counter(
         "thrift_success",
         "thrift_exception_type",
         "thrift_baseplate_status",
-        "thrift_status_code",
+        "thrift_baseplate_status_code",
     ],
 )
 
@@ -121,19 +121,31 @@ class PrometheusThriftClientMetrics:
 
     def active_requests_metric(self, tags: Dict) -> Gauge:
         return thrift_client_active_gauge.labels(
-            thrift_slug=tags.get("slug"), thrift_method=tags.get("method")
+            thrift_slug=tags.get("slug", ""), thrift_method=tags.get("method", "")
         )
 
     def requests_total_metric(self, tags: Dict) -> Counter:
         return thrift_client_requests_counter.labels(
-            thrift_slug=tags.get("slug"),
-            thrift_success=tags.get("success"),
-            thrift_exception_type=tags.get("exception_type"),
-            thrift_baseplate_status=tags.get("thrift_status"),
-            thrift_status_code=tags.get("thrift_status_code"),
+            thrift_slug=tags.get("slug", ""),
+            thrift_success=tags.get("success", ""),
+            thrift_exception_type=tags.get("exception_type", ""),
+            thrift_baseplate_status=tags.get("thrift_status", ""),
+            thrift_baseplate_status_code=tags.get("thrift_status_code", ""),
         )
 
     def latency_seconds_metric(self, tags: Dict) -> Histogram:
-        return thrift_client_latency_historygram.labels(
-            thrift_slug=tags.get("slug"), thrift_success=tags.get("success")
+        return thrift_client_latency_histogram.labels(
+            thrift_slug=tags.get("slug", ""), thrift_success=tags.get("success", "")
         )
+
+    def get_latency_seconds_metric(self) -> Histogram:
+        """Return the latency_seconds metrics"""
+        return thrift_client_latency_histogram
+
+    def get_requests_total_metric(self) -> Counter:
+        """Return the requests_total metrics"""
+        return thrift_client_requests_counter
+
+    def get_active_requests_metric(self) -> Gauge:
+        """Return the active_requests metrics"""
+        return thrift_client_active_gauge

--- a/baseplate/lib/prometheus_metrics.py
+++ b/baseplate/lib/prometheus_metrics.py
@@ -47,11 +47,13 @@ thrift_server_latency_seconds = Histogram(
     thrift_server_latency_labels,
     buckets=default_latency_buckets,
 )
+
 thrift_server_requests_total = Counter(
     "thrift_server_requests_total",
     "Total RPC request count",
     thrift_server_requests_total_labels,
 )
+
 thrift_server_active_requests = Gauge(
     "thrift_server_active_requests",
     "The number of in-flight requests being handled by the service",
@@ -98,6 +100,7 @@ class PrometheusThriftServerMetrics:
         """Return the active_requests metrics"""
         return thrift_server_active_requests
 
+
 thrift_client_active_gauge = Gauge(
     "thrift_client_active_requests", "Current in-flight requests", ["thrift_slug", "thrift_method"]
 )
@@ -106,7 +109,7 @@ thrift_client_latency_histogram = Histogram(
     "thrift_client_latency_seconds",
     "Latency of thrift client requests",
     ["thrift_slug", "thrift_success"],
-    buckets=default_buckets,
+    buckets=default_latency_buckets,
 )
 
 thrift_client_requests_counter = Counter(
@@ -156,6 +159,7 @@ class PrometheusThriftClientMetrics:
     def get_active_requests_metric(self) -> Gauge:
         """Return the active_requests metrics"""
         return thrift_client_active_gauge
+
 
 # http server labels and metrics
 http_server_histogram_labels = [

--- a/baseplate/lib/prometheus_metrics.py
+++ b/baseplate/lib/prometheus_metrics.py
@@ -1,4 +1,5 @@
-from typing import Any, Dict
+from typing import Any
+from typing import Dict
 
 from prometheus_client import Counter
 from prometheus_client import Gauge
@@ -109,7 +110,7 @@ thrift_client_requests_counter = Counter(
         "thrift_success",
         "thrift_exception_type",
         "thrift_baseplate_status",
-        "thfit_status_code",
+        "thrift_status_code",
     ],
 )
 
@@ -118,13 +119,21 @@ class PrometheusThriftClientMetrics:
     def __init__(self) -> None:
         pass
 
-    # TODO tags. labels is variadic
-
     def active_requests_metric(self, tags: Dict) -> Gauge:
-        return thrift_client_active_gauge.labels(thrift_slug=None, thrift_method=None)
+        return thrift_client_active_gauge.labels(
+            thrift_slug=tags.get("slug"), thrift_method=tags.get("method")
+        )
 
     def requests_total_metric(self, tags: Dict) -> Counter:
-        return thrift_client_requests_counter.labels(tags)
+        return thrift_client_requests_counter.labels(
+            thrift_slug=tags.get("slug"),
+            thrift_success=tags.get("success"),
+            thrift_exception_type=tags.get("exception_type"),
+            thrift_baseplate_status=tags.get("thrift_status"),
+            thrift_status_code=tags.get("thrift_status_code"),
+        )
 
     def latency_seconds_metric(self, tags: Dict) -> Histogram:
-        return thrift_client_latency_historygram.labels(tags)
+        return thrift_client_latency_historygram.labels(
+            thrift_slug=tags.get("slug"), thrift_success=tags.get("success")
+        )

--- a/baseplate/lib/prometheus_metrics.py
+++ b/baseplate/lib/prometheus_metrics.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, Dict
 
 from prometheus_client import Counter
 from prometheus_client import Gauge
@@ -14,7 +14,7 @@ start = 0.0001
 factor = 2.5
 count = 14
 # creates 14 buckets from 100us ~ 14.9s.
-default_buckets = [start * factor ** i for i in range(count)]
+default_buckets = [start * factor**i for i in range(count)]
 
 
 # thrift server labels
@@ -88,3 +88,43 @@ class PrometheusThriftServerMetrics:
     def get_active_requests_metric(self) -> Gauge:
         """Return the active_requests metrics"""
         return thrift_server_active_requests
+
+
+thrift_client_active_gauge = Gauge(
+    "thrift_client_active_requests", "Current in-flight requests", ["thrift_slug", "thrift_method"]
+)
+
+thrift_client_latency_historygram = Histogram(
+    "thrift_client_latency_seconds",
+    "Latency of thrift client requests",
+    ["thrift_slug", "thrift_success"],
+    buckets=default_buckets,
+)
+
+thrift_client_requests_counter = Counter(
+    "thrift_client_requests_total",
+    "Total number of outgoing requests",
+    [
+        "thrift_slug",
+        "thrift_success",
+        "thrift_exception_type",
+        "thrift_baseplate_status",
+        "thfit_status_code",
+    ],
+)
+
+
+class PrometheusThriftClientMetrics:
+    def __init__(self) -> None:
+        pass
+
+    # TODO tags. labels is variadic
+
+    def active_requests_metric(self, tags: Dict) -> Gauge:
+        return thrift_client_active_gauge.labels(thrift_slug=None, thrift_method=None)
+
+    def requests_total_metric(self, tags: Dict) -> Counter:
+        return thrift_client_requests_counter.labels(tags)
+
+    def latency_seconds_metric(self, tags: Dict) -> Histogram:
+        return thrift_client_latency_historygram.labels(tags)

--- a/baseplate/observers/prometheus.py
+++ b/baseplate/observers/prometheus.py
@@ -12,9 +12,10 @@ from baseplate import LocalSpan
 from baseplate import RequestContext
 from baseplate import Span
 from baseplate import SpanObserver
-from baseplate.lib.prometheus_metrics import PrometheusThriftClientMetrics
 from baseplate.lib.prometheus_metrics import PrometheusHTTPServerMetrics
+from baseplate.lib.prometheus_metrics import PrometheusThriftClientMetrics
 from baseplate.lib.prometheus_metrics import PrometheusThriftServerMetrics
+from baseplate.thrift.ttypes import Error
 from baseplate.thrift.ttypes import ErrorCode
 
 
@@ -99,7 +100,6 @@ class PrometheusServerSpanObserver(SpanObserver):
             self.tags["success"] = "true"
 
         self.metrics.active_requests_metric(self.tags).dec()
-        print("aaAAAaa")
         self.metrics.requests_total_metric(self.tags).inc()
 
         if self.start_time is not None:
@@ -185,7 +185,7 @@ class PrometheusClientSpanObserver(SpanObserver):
             exc = exc_info[1]
             self.tags["exception_type"] = exc.__class__.__name__
             self.tags["success"] = "false"
-            if self.protocol == "thrift":  # TODO this breaks some test that assumes all the labels
+            if self.protocol == "thrift" and isinstance(exc, Error):
                 self.tags["thrift_status_code"] = exc.code
                 self.tags["thrift_status"] = ErrorCode()._VALUES_TO_NAMES.get(exc.code, "")
 

--- a/baseplate/observers/prometheus.py
+++ b/baseplate/observers/prometheus.py
@@ -91,17 +91,14 @@ class PrometheusServerSpanObserver(SpanObserver):
             return
 
         if exc_info is not None:
-            exc = exc_info[1]
-            self.tags["exception_type"] = exc.__class__.__name__
+            self.tags["exception_type"] = exc_info[1].__class__.__name__
             self.tags["success"] = "false"
-            if self.protocol == "thrift":  # TODO this breaks some test that assumes all the labels
-                self.tags["thrift_status_code"] = exc.code
-                self.tags["thrift_status"] = ErrorCode()._VALUES_TO_NAMES.get(exc.code, "")
 
         if self.tags.get("exception_type", "") == "":
             self.tags["success"] = "true"
 
         self.metrics.active_requests_metric(self.tags).dec()
+        print("aaAAAaa")
         self.metrics.requests_total_metric(self.tags).inc()
         if self.start_time is not None:
             elapsed_ns = time.perf_counter_ns() - self.start_time
@@ -173,8 +170,12 @@ class PrometheusClientSpanObserver(SpanObserver):
 
         self.tags["success"] = "true"
         if exc_info is not None:
-            self.tags["exception_type"] = exc_info[1].__class__.__name__
+            exc = exc_info[1]
+            self.tags["exception_type"] = exc.__class__.__name__
             self.tags["success"] = "false"
+            if self.protocol == "thrift":  # TODO this breaks some test that assumes all the labels
+                self.tags["thrift_status_code"] = exc.code
+                self.tags["thrift_status"] = ErrorCode()._VALUES_TO_NAMES.get(exc.code, "")
 
         self.metrics.active_requests_metric(self.tags).dec()
         self.metrics.requests_total_metric(self.tags).inc()

--- a/tests/integration/thrift_tests.py
+++ b/tests/integration/thrift_tests.py
@@ -590,20 +590,22 @@ class ThriftHealthcheck(GeventPatchedTestCase):
                 self.assertEqual(handler.probe, IsHealthyProbe.LIVENESS)
 
 
-class ThriftClientMetricsTest(GeventPatchedTestCase):
-    def assert_correct_metric(
-        self, metric, want_count, want_sample, want_name, want_labels, want_value
-    ):
-        m = metric.collect()
-        self.assertEqual(len(m), 1)
-        self.assertEqual(len(m[0].samples), want_count)
-        sample = m[0].samples[want_sample]
-        got_name = sample[0]
-        self.assertEqual(got_name, want_name)
-        got_labels = sample[1]
-        self.assertEqual(got_labels, want_labels)
-        got_value = sample[2]
-        self.assertEqual(got_value, want_value)
+class ThriftErrorReplacementTests(GeventPatchedTestCase):
+    def test_server_replaces_unhandled_errors(self):
+        """The server span should atart/stop appropriately."""
+
+        class Handler(TestService.Iface):
+            def example(self, context):
+                raise Exception("foo")
+
+        handler = Handler()
+
+        server_span_observer = mock.Mock(spec=ServerSpanObserver)
+        with serve_thrift(handler, TestService, server_span_observer) as server:
+            with raw_thrift_client(server.endpoint, TestService) as client:
+                with self.assertRaises(Error) as exc_info:
+                    client.example()
+        self.assertEqual(exc_info.exception.code, ErrorCode.INTERNAL_SERVER_ERROR)
 
 
 class ThriftPrometheusMetricsTests(GeventPatchedTestCase):

--- a/tests/integration/thrift_tests.py
+++ b/tests/integration/thrift_tests.py
@@ -592,7 +592,7 @@ class ThriftHealthcheck(GeventPatchedTestCase):
 
 class ThriftErrorReplacementTests(GeventPatchedTestCase):
     def test_server_replaces_unhandled_errors(self):
-        """The server span should atart/stop appropriately."""
+        """The server span should start/stop appropriately."""
 
         class Handler(TestService.Iface):
             def example(self, context):

--- a/tests/integration/thrift_tests.py
+++ b/tests/integration/thrift_tests.py
@@ -909,5 +909,5 @@ class ThriftPrometheusMetricsTests(GeventPatchedTestCase):
             3,
             "thrift_client_latency_seconds_bucket",
             {"thrift_slug": "example_service", "thrift_success": "true", "le": "0.0015625"},
-            0.0,
+            1.0,
         )

--- a/tests/integration/thrift_tests.py
+++ b/tests/integration/thrift_tests.py
@@ -908,8 +908,8 @@ class ThriftPrometheusMetricsTests(GeventPatchedTestCase):
         self.assert_correct_metric(
             prom_observer.metrics.get_latency_seconds_metric(),
             18,
-            3,
+            14,
             "thrift_client_latency_seconds_bucket",
-            {"thrift_slug": "example_service", "thrift_success": "true", "le": "0.0015625"},
+            {"thrift_slug": "example_service", "thrift_success": "true", "le": "+Inf"},
             1.0,
         )

--- a/tests/unit/observers/prometheus_tests.py
+++ b/tests/unit/observers/prometheus_tests.py
@@ -53,6 +53,9 @@ class TestException(Exception):
                     "thrift_slug": "",
                     "thrift_method": "",
                 },
+            },
+        ),
+        (
             "http",
             "server",
             PrometheusServerSpanObserver,

--- a/tests/unit/observers/prometheus_tests.py
+++ b/tests/unit/observers/prometheus_tests.py
@@ -8,6 +8,7 @@ from prometheus_client import REGISTRY
 
 from baseplate import ServerSpan
 from baseplate.observers.prometheus import PrometheusBaseplateObserver
+from baseplate.observers.prometheus import PrometheusClientSpanObserver
 from baseplate.observers.prometheus import PrometheusServerSpanObserver
 
 
@@ -32,6 +33,25 @@ class TestException(Exception):
                     "thrift_baseplate_status_code": "",
                 },
                 "active_labels": {"thrift_method": ""},
+            },
+        ),
+        (
+            "thrift",
+            "client",
+            PrometheusClientSpanObserver,
+            {
+                "latency_labels": {"thrift_slug": "", "thrift_success": "true"},
+                "requests_labels": {
+                    "thrift_slug": "",
+                    "thrift_success": "true",
+                    "thrift_exception_type": "",
+                    "thrift_baseplate_status": "",
+                    "thrift_baseplate_status_code": "",
+                },
+                "active_labels": {
+                    "thrift_slug": "",
+                    "thrift_method": "",
+                },
             },
         ),
     ),


### PR DESCRIPTION
<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #OBS-34.

## 💸 TL;DR
<!-- What's the three sentence summary of purpose of the PR -->
This adds metrics as per baseplate.spec to the thrift client. `PrometheusClientSpanObserver` is mostly nicked from/shared with the HTTP client metrics, which still is an open PR.

## 📜 Details
https://github.snooguts.net/reddit/baseplate.spec/blob/master/component-apis/prom-metrics.md

[Jira](https://reddit.atlassian.net/browse/OBS-48)

## 🧪 Testing Steps / Validation
If anyone could walk me through how to run this with a real thrift client and server, I'd be very grateful.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] CI tests (if present) are passing
- [ ] Adheres to code style for repo
- [ ] Contributor License Agreement (CLA) completed if not a Reddit employee
