### PR TITLE
feat(prometheus): Implement Local Span metrics

### DIFF
--- a/baseplate/lib/prometheus_metrics.py
+++ b/baseplate/lib/prometheus_metrics.py
@@ -343,3 +343,60 @@ def getHTTPSuccessLabel(httpStatusCode: int) -> str:
     The HTTP success label is "true" if the status code is 2xx or 3xx, "false" otherwise.
     """
     return str(200 <= httpStatusCode < 400).lower()
+
+
+# local labels and metrics
+local_span_labels = [
+    "span",
+]
+# Latency histogram of local span
+# buckets are defined above (from 100µs to ~14.9s)
+local_span_latency_seconds = Histogram(
+    "local_span_latency_seconds",
+    "Latency histogram of local span",
+    local_span_labels,
+    buckets=default_latency_buckets,
+)
+
+# Counter counting total local spans started
+local_span_requests_total = Counter(
+    "local_span_requests_total",
+    "Total number of local spans started",
+    local_span_labels,
+)
+
+# Gauge showing current number of local spans
+local_span_active_requests = Gauge(
+    "local_span_active_requests",
+    "Number of active local spans",
+    local_span_labels,
+)
+
+
+class PrometheusLocalSpanMetrics:
+    def __init__(self) -> None:
+        pass
+
+    def latency_seconds_metric(self, tags: Dict) -> Histogram:
+        return local_span_latency_seconds.labels(
+            span=tags.get("span_name", ""),
+        )
+
+    def requests_total_metric(self, tags: Dict) -> Counter:
+        return local_span_requests_total.labels(
+            span=tags.get("span_name", ""),
+        )
+
+    def active_requests_metric(self, tags: Dict) -> Gauge:
+        return local_span_active_requests.labels(
+            span=tags.get("span_name", ""),
+        )
+
+    def get_latency_seconds_metric(self) -> Histogram:
+        return local_span_latency_seconds
+
+    def get_requests_total_metric(self) -> Counter:
+        return local_span_requests_total
+
+    def get_active_requests_metric(self) -> Gauge:
+        return local_span_active_requests

--- a/baseplate/observers/prometheus.py
+++ b/baseplate/observers/prometheus.py
@@ -14,6 +14,7 @@ from baseplate import Span
 from baseplate import SpanObserver
 from baseplate.lib.prometheus_metrics import PrometheusHTTPClientMetrics
 from baseplate.lib.prometheus_metrics import PrometheusHTTPServerMetrics
+from baseplate.lib.prometheus_metrics import PrometheusLocalSpanMetrics
 from baseplate.lib.prometheus_metrics import PrometheusThriftClientMetrics
 from baseplate.lib.prometheus_metrics import PrometheusThriftServerMetrics
 from baseplate.thrift.ttypes import Error
@@ -56,9 +57,6 @@ class PrometheusServerSpanObserver(SpanObserver):
 
     def on_set_tag(self, key: str, value: Any) -> None:
         self.tags[key] = value
-
-    def get_prefix(self) -> str:
-        return f"{self.protocol}_server"
 
     def get_labels(self) -> Dict[str, str]:
         return self.tags
@@ -126,7 +124,7 @@ class PrometheusServerSpanObserver(SpanObserver):
     def on_child_span_created(self, span: Span) -> None:
         observer: Any = None
         if isinstance(span, LocalSpan):
-            observer = PrometheusLocalSpanObserver()
+            observer = PrometheusLocalSpanObserver(span.name)
         else:
             observer = PrometheusClientSpanObserver()
 
@@ -143,9 +141,6 @@ class PrometheusClientSpanObserver(SpanObserver):
 
     def on_set_tag(self, key: str, value: Any) -> None:
         self.tags[key] = value
-
-    def get_prefix(self) -> str:
-        return f"{self.protocol}_client"
 
     def get_labels(self) -> Dict[str, str]:
         return self.tags
@@ -206,7 +201,7 @@ class PrometheusClientSpanObserver(SpanObserver):
     def on_child_span_created(self, span: Span) -> None:
         observer: Optional[SpanObserver] = None
         if isinstance(span, LocalSpan):
-            observer = PrometheusLocalSpanObserver()
+            observer = PrometheusLocalSpanObserver(span.name)
         else:
             observer = PrometheusClientSpanObserver()
 
@@ -214,16 +209,42 @@ class PrometheusClientSpanObserver(SpanObserver):
 
 
 class PrometheusLocalSpanObserver(SpanObserver):
-    def __init__(self) -> None:
-        logger.debug("PrometheusLocalSpanObserver not implemented")
+    def __init__(self, span_name: Optional[str] = None) -> None:
+        self.tags: Dict[str, Any] = {"span_name": span_name if span_name is not None else ""}
+        self.start_time: Optional[int] = None
+        self.metrics: PrometheusLocalSpanMetrics = PrometheusLocalSpanMetrics()
 
-    # Proper implementation for PrometheusLocalSpanObserver will come in a future PR
-    # In the meantime, we need this logic in place to be able to emit http client metrics
-    # when running inside a local span
+    def on_set_tag(self, key: str, value: Any) -> None:
+        self.tags[key] = value
+
+    def get_labels(self) -> Dict[str, Any]:
+        return self.tags
+
+    def on_start(self) -> None:
+        self.start_time = time.perf_counter_ns()
+        self.metrics.active_requests_metric(self.tags).inc()
+
+    def on_incr_tag(self, key: str, delta: float) -> None:
+        pass
+
+    def on_finish(self, exc_info: Optional[_ExcInfo]) -> None:
+        self.tags["success"] = "true"
+        if exc_info is not None:
+            self.tags["exception_type"] = exc_info[1].__class__.__name__
+            self.tags["success"] = "false"
+
+        self.metrics.active_requests_metric(self.tags).dec()
+        self.metrics.requests_total_metric(self.tags).inc()
+        if self.start_time is not None:
+            elapsed_ns = time.perf_counter_ns() - self.start_time
+            self.metrics.latency_seconds_metric(self.tags).observe(
+                elapsed_ns / NANOSECONDS_PER_SECOND
+            )
+
     def on_child_span_created(self, span: Span) -> None:
         observer: Optional[SpanObserver] = None
         if isinstance(span, LocalSpan):
-            observer = PrometheusLocalSpanObserver()
+            observer = PrometheusLocalSpanObserver(span.name)
         else:
             observer = PrometheusClientSpanObserver()
 

--- a/baseplate/observers/prometheus.py
+++ b/baseplate/observers/prometheus.py
@@ -58,6 +58,9 @@ class PrometheusServerSpanObserver(SpanObserver):
     def on_set_tag(self, key: str, value: Any) -> None:
         self.tags[key] = value
 
+    def get_prefix(self) -> str:
+        return f"{self.protocol}_server"
+
     def get_labels(self) -> Dict[str, str]:
         return self.tags
 
@@ -142,6 +145,9 @@ class PrometheusClientSpanObserver(SpanObserver):
     def on_set_tag(self, key: str, value: Any) -> None:
         self.tags[key] = value
 
+    def get_prefix(self) -> str:
+        return f"{self.protocol}_client"
+
     def get_labels(self) -> Dict[str, str]:
         return self.tags
 
@@ -216,6 +222,13 @@ class PrometheusLocalSpanObserver(SpanObserver):
 
     def on_set_tag(self, key: str, value: Any) -> None:
         self.tags[key] = value
+
+    def get_prefix(self) -> str:
+        return f"{self.protocol}_span"
+
+    @property
+    def protocol(self) -> str:
+        return "local"
 
     def get_labels(self) -> Dict[str, Any]:
         return self.tags

--- a/tests/unit/observers/prometheus_tests.py
+++ b/tests/unit/observers/prometheus_tests.py
@@ -128,6 +128,8 @@ def test_observer_metrics(protocol, client_or_server, observer_cls, labels):
 
     observer = observer_cls()
     observer.on_set_tag("protocol", protocol)
+    assert observer.get_prefix() == f"{protocol}_{client_or_server}"
+
     observer.on_start()
     after_start = REGISTRY.get_sample_value(
         f"{protocol}_{client_or_server}_latency_seconds_count", labels.get("latency_labels", "")

--- a/tests/unit/observers/prometheus_tests.py
+++ b/tests/unit/observers/prometheus_tests.py
@@ -10,6 +10,7 @@ from baseplate import ServerSpan
 from baseplate.lib.prometheus_metrics import getHTTPSuccessLabel
 from baseplate.observers.prometheus import PrometheusBaseplateObserver
 from baseplate.observers.prometheus import PrometheusClientSpanObserver
+from baseplate.observers.prometheus import PrometheusLocalSpanObserver
 from baseplate.observers.prometheus import PrometheusServerSpanObserver
 
 
@@ -92,6 +93,22 @@ class TestException(Exception):
                 },
             },
         ),
+        (
+            "local",
+            "span",
+            PrometheusLocalSpanObserver,
+            {
+                "latency_labels": {
+                    "span": "",
+                },
+                "requests_labels": {
+                    "span": "",
+                },
+                "active_labels": {
+                    "span": "",
+                },
+            },
+        ),
     ),
 )
 def test_observer_metrics(protocol, client_or_server, observer_cls, labels):
@@ -111,8 +128,6 @@ def test_observer_metrics(protocol, client_or_server, observer_cls, labels):
 
     observer = observer_cls()
     observer.on_set_tag("protocol", protocol)
-    assert observer.get_prefix() == f"{protocol}_{client_or_server}"
-
     observer.on_start()
     after_start = REGISTRY.get_sample_value(
         f"{protocol}_{client_or_server}_latency_seconds_count", labels.get("latency_labels", "")


### PR DESCRIPTION
## 💸 TL;DR
Implement local span metrics. Per the spec, we are tracking "latency" (time spent in the span), number of active spans, and number of spans ever started. All of these have a single label, which is the name of the span.

## 🧪 Testing Steps / Validation
unit/integration tests are in the PR.
Testing it locally should be as simple as doing something like:
```
with baseplate.server_context("test") as context:
    with context.span.make_child('ipinfo_calls', local=True) as span:
        span.context.external.get('https://ipinfo.io/ip')
        span.context.external.get('https://ipinfo.io/json')
        span.context.external.get('https://ipinfo.io/error')
```
or anything within a child span with `local=True`.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] CI tests (if present) are passing
- [x] Adheres to code style for repo
- [x] Contributor License Agreement (CLA) completed if not a Reddit employee

## Sample output

```bash
❯ curl -s localhost:6060/metrics | grep -i span
# HELP local_span_active_requests Multiprocess metric
# TYPE local_span_active_requests gauge
local_span_active_requests{pid="63302",span="ipinfo_calls"} 0.0
# HELP local_span_latency_seconds Multiprocess metric
# TYPE local_span_latency_seconds histogram
local_span_latency_seconds_sum{span="ipinfo_calls"} 0.225517531
local_span_latency_seconds_bucket{le="0.0001",span="ipinfo_calls"} 0.0
local_span_latency_seconds_bucket{le="0.00025",span="ipinfo_calls"} 0.0
local_span_latency_seconds_bucket{le="0.000625",span="ipinfo_calls"} 0.0
local_span_latency_seconds_bucket{le="0.0015625",span="ipinfo_calls"} 0.0
local_span_latency_seconds_bucket{le="0.00390625",span="ipinfo_calls"} 0.0
local_span_latency_seconds_bucket{le="0.009765625",span="ipinfo_calls"} 0.0
local_span_latency_seconds_bucket{le="0.0244140625",span="ipinfo_calls"} 0.0
local_span_latency_seconds_bucket{le="0.06103515625",span="ipinfo_calls"} 0.0
local_span_latency_seconds_bucket{le="0.152587890625",span="ipinfo_calls"} 0.0
local_span_latency_seconds_bucket{le="0.3814697265625",span="ipinfo_calls"} 1.0
local_span_latency_seconds_bucket{le="0.95367431640625",span="ipinfo_calls"} 1.0
local_span_latency_seconds_bucket{le="2.384185791015625",span="ipinfo_calls"} 1.0
local_span_latency_seconds_bucket{le="5.9604644775390625",span="ipinfo_calls"} 1.0
local_span_latency_seconds_bucket{le="14.901161193847656",span="ipinfo_calls"} 1.0
local_span_latency_seconds_bucket{le="+Inf",span="ipinfo_calls"} 1.0
local_span_latency_seconds_count{span="ipinfo_calls"} 1.0
# HELP local_span_requests_total Multiprocess metric
# TYPE local_span_requests_total counter
local_span_requests_total{span="ipinfo_calls"} 1.0
```