### PR TITLE
Make a generic span observer for when the protocol is not HTTP or Thrift

### DIFF
--- a/baseplate/__init__.py
+++ b/baseplate/__init__.py
@@ -558,6 +558,7 @@ class Span:
         name: str,
         context: RequestContext,
         baseplate: Optional[Baseplate] = None,
+        component_name: Optional[str] = None,
     ):
         self.trace_id = trace_id
         self.parent_id = parent_id
@@ -569,6 +570,7 @@ class Span:
         self.baseplate = baseplate
         self.component_name: Optional[str] = None
         self.observers: List[SpanObserver] = []
+        self.component_name = component_name
 
     def register(self, observer: SpanObserver) -> None:
         """Register an observer to receive events from this span."""
@@ -730,8 +732,8 @@ class LocalSpan(Span):
                 name,
                 context_copy,
                 self.baseplate,
+                component_name,
             )
-            span.component_name = component_name
         else:
             span = Span(
                 self.trace_id,
@@ -742,6 +744,7 @@ class LocalSpan(Span):
                 name,
                 context_copy,
                 self.baseplate,
+                component_name,
             )
         context_copy.span = span
 

--- a/baseplate/clients/cassandra.py
+++ b/baseplate/clients/cassandra.py
@@ -286,7 +286,7 @@ class CassandraSessionAdapter:
         **kwargs: Any,
     ) -> ResponseFuture:
         trace_name = f"{self.context_name}.execute"
-        span = self.server_span.make_child(trace_name)
+        span = self.server_span.make_child(trace_name, component_name="cassandra_client")
         span.start()
         # TODO: include custom payload
         if isinstance(query, str):
@@ -322,7 +322,7 @@ class CassandraSessionAdapter:
                 pass
 
         trace_name = f"{self.context_name}.prepare"
-        with self.server_span.make_child(trace_name) as span:
+        with self.server_span.make_child(trace_name, component_name="cassandra_client") as span:
             span.set_tag("statement", query)
             prepared = self.session.prepare(query)
             if cache:

--- a/baseplate/clients/kombu.py
+++ b/baseplate/clients/kombu.py
@@ -238,7 +238,7 @@ class _KombuProducer:
             kwargs.setdefault("serializer", self.serializer.name)
 
         trace_name = f"{self.name}.publish"
-        child_span = self.span.make_child(trace_name)
+        child_span = self.span.make_child(trace_name, component_name="kombu_client")
 
         child_span.set_tag("kind", "producer")
         if routing_key:

--- a/baseplate/clients/memcache/__init__.py
+++ b/baseplate/clients/memcache/__init__.py
@@ -332,7 +332,7 @@ class MonitoredMemcacheConnection:
 
         """
         trace_name = f"{self.context_name}.{method_name}"
-        span = self.server_span.make_child(trace_name)
+        span = self.server_span.make_child(trace_name, component_name="memcache_client")
         span.set_tag("method", method_name)
         return span
 

--- a/baseplate/clients/redis.py
+++ b/baseplate/clients/redis.py
@@ -163,7 +163,7 @@ class MonitoredRedisConnection(redis.StrictRedis):
         command = args[0]
         trace_name = f"{self.context_name}.{command}"
 
-        with self.server_span.make_child(trace_name):
+        with self.server_span.make_child(trace_name, component_name="redis_client"):
             return super().execute_command(command, *args[1:], **kwargs)
 
     # pylint: disable=arguments-differ
@@ -211,7 +211,7 @@ class MonitoredRedisPipeline(Pipeline):
 
     # pylint: disable=arguments-differ
     def execute(self, **kwargs: Any) -> Any:
-        with self.server_span.make_child(self.trace_name):
+        with self.server_span.make_child(self.trace_name, component_name="redis_pipeline_client"):
             return super().execute(**kwargs)
 
 

--- a/baseplate/clients/redis_cluster.py
+++ b/baseplate/clients/redis_cluster.py
@@ -430,7 +430,7 @@ class MonitoredClusterRedisConnection(rediscluster.RedisCluster):
         command = args[0]
         trace_name = f"{self.context_name}.{command}"
 
-        with self.server_span.make_child(trace_name):
+        with self.server_span.make_child(trace_name, component_name="rediscluster_client"):
             res = super().execute_command(command, *args[1:], **kwargs)
 
         self.hot_key_tracker.maybe_track_key_usage(list(args))
@@ -487,5 +487,5 @@ class MonitoredClusterRedisPipeline(ClusterPipeline):
 
     # pylint: disable=arguments-differ
     def execute(self, **kwargs: Any) -> Any:
-        with self.server_span.make_child(self.trace_name):
+        with self.server_span.make_child(self.trace_name, component_name="rediscluster_client"):
             return super().execute(**kwargs)

--- a/baseplate/clients/requests.py
+++ b/baseplate/clients/requests.py
@@ -210,7 +210,7 @@ class BaseplateSession:
             "http.url": request.url,
             "http.slug": self.client_name if self.client_name is not None else self.name,
         }
-        with self.span.make_child(f"{self.name}.request").with_tags(tags) as span:
+        with self.span.make_child(f"{self.name}.request", component_name="http_client").with_tags(tags) as span:
             self._add_span_context(span, request)
 
             # we cannot re-use the same session every time because sessions re-use the same

--- a/baseplate/clients/requests.py
+++ b/baseplate/clients/requests.py
@@ -210,7 +210,9 @@ class BaseplateSession:
             "http.url": request.url,
             "http.slug": self.client_name if self.client_name is not None else self.name,
         }
-        with self.span.make_child(f"{self.name}.request", component_name="http_client").with_tags(tags) as span:
+        with self.span.make_child(f"{self.name}.request", component_name="http_client").with_tags(
+            tags
+        ) as span:
             self._add_span_context(span, request)
 
             # we cannot re-use the same session every time because sessions re-use the same

--- a/baseplate/clients/sqlalchemy.py
+++ b/baseplate/clients/sqlalchemy.py
@@ -225,7 +225,7 @@ class SQLAlchemyEngineContextFactory(ContextFactory):
         server_span = conn._execution_options["server_span"]
 
         trace_name = f"{context_name}.execute"
-        span = server_span.make_child(trace_name)
+        span = server_span.make_child(trace_name, component_name="sql_client")
         span.set_tag("statement", statement[:1021] + "..." if len(statement) > 1024 else statement)
         span.start()
 

--- a/baseplate/clients/thrift.py
+++ b/baseplate/clients/thrift.py
@@ -170,7 +170,7 @@ def _build_thrift_proxy_method(name: str) -> Callable[..., Any]:
         for time_remaining in self.retry_policy:
             try:
                 with self.pool.connection() as prot:
-                    span = self.server_span.make_child(trace_name)
+                    span = self.server_span.make_child(trace_name, component_name="thrift_client")
                     span.set_tag("slug", self.namespace)
 
                     client = self.client_cls(prot)

--- a/baseplate/frameworks/queue_consumer/kafka.py
+++ b/baseplate/frameworks/queue_consumer/kafka.py
@@ -64,7 +64,7 @@ class KafkaConsumerWorker(PumpWorker):
         while not self.stopped:
             context = self.baseplate.make_context_object()
             with self.baseplate.make_server_span(context, f"{self.name}.pump") as span:
-                with span.make_child("kafka.consume"):
+                with span.make_child("kafka.consume", component_name="kafka_client"):
                     messages = self.consumer.consume(num_messages=self.batch_size, timeout=0)
 
                 if not messages:
@@ -77,7 +77,7 @@ class KafkaConsumerWorker(PumpWorker):
                     time.sleep(1)
                     continue
 
-                with span.make_child("kafka.work_queue_put"):
+                with span.make_child("kafka.work_queue_put", component_name="kafka_client"):
                     for message in messages:
                         self.work_queue.put(message)
 
@@ -399,7 +399,7 @@ class InOrderConsumerFactory(_BaseKafkaQueueConsumerFactory):
                 message.partition(),
                 message.offset(),
             )
-            with context.span.make_child("kafka.commit"):
+            with context.span.make_child("kafka.commit", component_name="kafka_client"):
                 self.consumer.commit(message=message, asynchronous=False)
 
         return KafkaMessageHandler(

--- a/baseplate/lib/prometheus_metrics.py
+++ b/baseplate/lib/prometheus_metrics.py
@@ -32,6 +32,7 @@ default_size_buckets = [
 
 generic_metrics = {}
 
+
 class PrometheusHTTPClientMetrics:
     prefix = "http_client"
 
@@ -381,6 +382,7 @@ def getHTTPSuccessLabel(httpStatusCode: int) -> str:
     """
     return str(200 <= httpStatusCode < 400).lower()
 
+
 class PrometheusGenericSpanMetrics:
     prefix = "generic"
 
@@ -471,6 +473,7 @@ class PrometheusLocalSpanMetrics(PrometheusGenericSpanMetrics):
         labels,
     )
 
+
 def get_metrics_for_prefix(prefix: str) -> PrometheusGenericSpanMetrics:
     if prefix not in generic_metrics:
         # local labels and metrics
@@ -479,9 +482,9 @@ def get_metrics_for_prefix(prefix: str) -> PrometheusGenericSpanMetrics:
         ]
         generic_metrics[prefix] = type(
             f"PrometheusGenericSpanMetrics<{prefix}>",
-            (PrometheusGenericSpanMetrics, ),
+            (PrometheusGenericSpanMetrics,),
             {
-                "prefix":prefix,
+                "prefix": prefix,
                 # Reset the class attributes to avoid having the same prefix in the metric names
                 "labels": labels,
                 "latency_seconds": Histogram(
@@ -499,8 +502,8 @@ def get_metrics_for_prefix(prefix: str) -> PrometheusGenericSpanMetrics:
                     f"{prefix}_active_requests",
                     "Number of active local spans",
                     labels,
-                )
-            }
+                ),
+            },
         )
         logger.info(f"Created new metrics class for prefix {prefix}")
     return generic_metrics[prefix]

--- a/baseplate/lib/prometheus_metrics.py
+++ b/baseplate/lib/prometheus_metrics.py
@@ -2,7 +2,6 @@ import logging
 
 from typing import Any
 from typing import Dict
-from typing import Optional
 
 from prometheus_client import Counter
 from prometheus_client import Gauge

--- a/baseplate/lib/prometheus_metrics.py
+++ b/baseplate/lib/prometheus_metrics.py
@@ -445,34 +445,6 @@ class PrometheusGenericSpanMetrics:
         return cls.active_requests
 
 
-class PrometheusLocalSpanMetrics(PrometheusGenericSpanMetrics):
-    prefix = "local"
-
-    # local labels and metrics
-    labels = [
-        "span",
-    ]
-
-    latency_seconds = Histogram(
-        f"{prefix}_latency_seconds",
-        "Latency histogram of local span",
-        labels,
-        buckets=default_latency_buckets,
-    )
-    # Counter counting total local spans started
-    requests_total = Counter(
-        f"{prefix}_requests_total",
-        "Total number of local spans started",
-        labels,
-    )
-    # Gauge showing current number of local spans
-    active_requests = Gauge(
-        f"{prefix}_active_requests",
-        "Number of active local spans",
-        labels,
-    )
-
-
 def get_metrics_for_prefix(prefix: str) -> PrometheusGenericSpanMetrics:
     if prefix not in generic_metrics:
         # local labels and metrics
@@ -488,18 +460,18 @@ def get_metrics_for_prefix(prefix: str) -> PrometheusGenericSpanMetrics:
                 "labels": labels,
                 "latency_seconds": Histogram(
                     f"{prefix}_latency_seconds",
-                    "Latency histogram of local span",
+                    f"Latency histogram of {prefix} span",
                     labels,
                     buckets=default_latency_buckets,
                 ),
                 "requests_total": Counter(
                     f"{prefix}_requests_total",
-                    "Total number of local spans started",
+                    f"Total number of {prefix} spans started",
                     labels,
                 ),
                 "active_requests": Gauge(
                     f"{prefix}_active_requests",
-                    "Number of active local spans",
+                    f"Number of active {prefix} spans",
                     labels,
                 ),
             },

--- a/baseplate/lib/prometheus_metrics.py
+++ b/baseplate/lib/prometheus_metrics.py
@@ -446,7 +446,7 @@ class PrometheusGenericSpanMetrics:
 
 class PrometheusLocalSpanMetrics(PrometheusGenericSpanMetrics):
     prefix = "local"
-    
+
     # local labels and metrics
     labels = [
         "span",

--- a/baseplate/lib/prometheus_metrics.py
+++ b/baseplate/lib/prometheus_metrics.py
@@ -377,8 +377,11 @@ def getHTTPSuccessLabel(httpStatusCode: int) -> str:
     return str(200 <= httpStatusCode < 400).lower()
 
 
-class PrometheusLocalSpanMetrics:
-    prefix = "local_span"
+class PrometheusGenericSpanMetrics:
+    prefix = None
+    
+    def __init__(self, prefix: str = "local_span") -> None:
+        self.prefix = prefix
 
     # local labels and metrics
     labels = [

--- a/baseplate/lib/prometheus_metrics.py
+++ b/baseplate/lib/prometheus_metrics.py
@@ -1,10 +1,14 @@
+import logging
+
 from typing import Any
 from typing import Dict
+from typing import Optional
 
 from prometheus_client import Counter
 from prometheus_client import Gauge
 from prometheus_client import Histogram
 
+logger = logging.getLogger(__name__)
 
 # default_latency_buckets creates the default bucket values for time based histogram metrics.
 # we want this to match the baseplate.go default_buckets, ref: https://github.com/reddit/baseplate.go/blob/master/prometheusbp/metrics.go.
@@ -26,6 +30,7 @@ default_size_buckets = [
     default_size_start * default_size_factor ** i for i in range(default_size_count)
 ]
 
+generic_metrics = {}
 
 class PrometheusHTTPClientMetrics:
     prefix = "http_client"
@@ -376,12 +381,8 @@ def getHTTPSuccessLabel(httpStatusCode: int) -> str:
     """
     return str(200 <= httpStatusCode < 400).lower()
 
-
 class PrometheusGenericSpanMetrics:
-    prefix = None
-    
-    def __init__(self, prefix: str = "local_span") -> None:
-        self.prefix = prefix
+    prefix = "generic"
 
     # local labels and metrics
     labels = [
@@ -441,3 +442,65 @@ class PrometheusGenericSpanMetrics:
     @classmethod
     def get_active_requests_metric(cls) -> Gauge:
         return cls.active_requests
+
+
+class PrometheusLocalSpanMetrics(PrometheusGenericSpanMetrics):
+    prefix = "local"
+    
+    # local labels and metrics
+    labels = [
+        "span",
+    ]
+
+    latency_seconds = Histogram(
+        f"{prefix}_latency_seconds",
+        "Latency histogram of local span",
+        labels,
+        buckets=default_latency_buckets,
+    )
+    # Counter counting total local spans started
+    requests_total = Counter(
+        f"{prefix}_requests_total",
+        "Total number of local spans started",
+        labels,
+    )
+    # Gauge showing current number of local spans
+    active_requests = Gauge(
+        f"{prefix}_active_requests",
+        "Number of active local spans",
+        labels,
+    )
+
+def get_metrics_for_prefix(prefix: str) -> PrometheusGenericSpanMetrics:
+    if prefix not in generic_metrics:
+        # local labels and metrics
+        labels = [
+            "span",
+        ]
+        generic_metrics[prefix] = type(
+            f"PrometheusGenericSpanMetrics<{prefix}>",
+            (PrometheusGenericSpanMetrics, ),
+            {
+                "prefix":prefix,
+                # Reset the class attributes to avoid having the same prefix in the metric names
+                "labels": labels,
+                "latency_seconds": Histogram(
+                    f"{prefix}_latency_seconds",
+                    "Latency histogram of local span",
+                    labels,
+                    buckets=default_latency_buckets,
+                ),
+                "requests_total": Counter(
+                    f"{prefix}_requests_total",
+                    "Total number of local spans started",
+                    labels,
+                ),
+                "active_requests": Gauge(
+                    f"{prefix}_active_requests",
+                    "Number of active local spans",
+                    labels,
+                )
+            }
+        )
+        logger.info(f"Created new metrics class for prefix {prefix}")
+    return generic_metrics[prefix]

--- a/baseplate/lib/prometheus_metrics.py
+++ b/baseplate/lib/prometheus_metrics.py
@@ -504,5 +504,5 @@ def get_metrics_for_prefix(prefix: str) -> PrometheusGenericSpanMetrics:
                 ),
             },
         )
-        logger.info("Created new metrics class for prefix {}" % prefix)
+        logger.info("Created new metrics class for prefix %s", prefix)
     return generic_metrics[prefix]

--- a/baseplate/lib/prometheus_metrics.py
+++ b/baseplate/lib/prometheus_metrics.py
@@ -504,5 +504,5 @@ def get_metrics_for_prefix(prefix: str) -> PrometheusGenericSpanMetrics:
                 ),
             },
         )
-        logger.info("Created new metrics class for prefix %s", prefix)
-    return generic_metrics[prefix]
+        logger.debug("Created new metrics class for prefix %s", prefix)
+    return generic_metrics[prefix] # type: ignore

--- a/baseplate/lib/prometheus_metrics.py
+++ b/baseplate/lib/prometheus_metrics.py
@@ -504,5 +504,5 @@ def get_metrics_for_prefix(prefix: str) -> PrometheusGenericSpanMetrics:
                 ),
             },
         )
-        logger.info(f"Created new metrics class for prefix {prefix}")
+        logger.info("Created new metrics class for prefix {}" % prefix)
     return generic_metrics[prefix]

--- a/baseplate/lib/prometheus_metrics.py
+++ b/baseplate/lib/prometheus_metrics.py
@@ -505,4 +505,4 @@ def get_metrics_for_prefix(prefix: str) -> PrometheusGenericSpanMetrics:
             },
         )
         logger.debug("Created new metrics class for prefix %s", prefix)
-    return generic_metrics[prefix] # type: ignore
+    return generic_metrics[prefix]  # type: ignore

--- a/baseplate/observers/prometheus.py
+++ b/baseplate/observers/prometheus.py
@@ -146,7 +146,7 @@ class PrometheusClientSpanObserver(SpanObserver):
             Union[
                 PrometheusHTTPClientMetrics,
                 PrometheusThriftClientMetrics,
-                PrometheusGenericSpanMetrics
+                PrometheusGenericSpanMetrics,
             ]
         ] = None
         self.prefix = prefix or "client"

--- a/baseplate/observers/prometheus.py
+++ b/baseplate/observers/prometheus.py
@@ -138,7 +138,7 @@ class PrometheusServerSpanObserver(SpanObserver):
 class PrometheusClientSpanObserver(SpanObserver):
     prefix = None
 
-    def __init__(self, prefix: Optional[str] = "client") -> None:
+    def __init__(self, prefix: Optional[str] = "generic_client") -> None:
         self.tags: Dict[str, Any] = {}
         self.start_time: Optional[int] = None
         self.metrics: Optional[
@@ -148,7 +148,7 @@ class PrometheusClientSpanObserver(SpanObserver):
                 PrometheusGenericSpanMetrics,
             ]
         ] = None
-        self.prefix = prefix or "client"
+        self.prefix = prefix or "generic_client"
 
     def on_set_tag(self, key: str, value: Any) -> None:
         self.tags[key] = value

--- a/baseplate/observers/prometheus.py
+++ b/baseplate/observers/prometheus.py
@@ -263,7 +263,7 @@ class PrometheusLocalSpanObserver(SpanObserver):
     def on_child_span_created(self, span: Span) -> None:
         observer: Optional[SpanObserver] = None
         if isinstance(span, LocalSpan):
-            observer = PrometheusLocalSpanObserver(prefix=span.component_name, span_name=span.name)
+            observer = PrometheusLocalSpanObserver(span_name=span.name)
         else:
             observer = PrometheusClientSpanObserver(prefix=span.component_name)
 

--- a/baseplate/observers/prometheus.py
+++ b/baseplate/observers/prometheus.py
@@ -14,9 +14,9 @@ from baseplate import Span
 from baseplate import SpanObserver
 from baseplate.lib.prometheus_metrics import get_metrics_for_prefix
 from baseplate.lib.prometheus_metrics import PrometheusGenericSpanMetrics
-from baseplate.lib.prometheus_metrics import PrometheusLocalSpanMetrics
 from baseplate.lib.prometheus_metrics import PrometheusHTTPClientMetrics
 from baseplate.lib.prometheus_metrics import PrometheusHTTPServerMetrics
+from baseplate.lib.prometheus_metrics import PrometheusLocalSpanMetrics
 from baseplate.lib.prometheus_metrics import PrometheusThriftClientMetrics
 from baseplate.lib.prometheus_metrics import PrometheusThriftServerMetrics
 from baseplate.thrift.ttypes import Error

--- a/baseplate/observers/prometheus.py
+++ b/baseplate/observers/prometheus.py
@@ -79,7 +79,7 @@ class PrometheusServerSpanObserver(SpanObserver):
                 "Unknown protocol %s. Expected 'http' or 'thrift' protocol.",
                 self.protocol,
             )
-            self.metrics = get_metrics_for_prefix(self.span.name)
+            self.metrics = get_metrics_for_prefix(self.span.name if self.span else "generic_server")
 
     def on_start(self) -> None:
         self.set_metrics_by_protocol()
@@ -171,7 +171,7 @@ class PrometheusClientSpanObserver(SpanObserver):
                 "Unknown protocol %s. Expected 'http' or 'thrift' protocol.",
                 self.protocol,
             )
-            self.metrics = get_metrics_for_prefix(self.prefix)
+            self.metrics = get_metrics_for_prefix(self.prefix if self.prefix else "generic_client")
 
     def on_start(self) -> None:
         self.set_metrics_by_protocol()
@@ -227,7 +227,7 @@ class PrometheusLocalSpanObserver(SpanObserver):
         self.tags: Dict[str, Any] = {"span_name": span_name if span_name is not None else ""}
         self.start_time: Optional[int] = None
 
-        self.metrics: PrometheusLocalSpanMetrics = PrometheusLocalSpanMetrics()
+        self.metrics: PrometheusGenericSpanMetrics = get_metrics_for_prefix(self.prefix)
 
     def on_set_tag(self, key: str, value: Any) -> None:
         self.tags[key] = value

--- a/baseplate/observers/prometheus.py
+++ b/baseplate/observers/prometheus.py
@@ -16,7 +16,6 @@ from baseplate.lib.prometheus_metrics import get_metrics_for_prefix
 from baseplate.lib.prometheus_metrics import PrometheusGenericSpanMetrics
 from baseplate.lib.prometheus_metrics import PrometheusHTTPClientMetrics
 from baseplate.lib.prometheus_metrics import PrometheusHTTPServerMetrics
-from baseplate.lib.prometheus_metrics import PrometheusLocalSpanMetrics
 from baseplate.lib.prometheus_metrics import PrometheusThriftClientMetrics
 from baseplate.lib.prometheus_metrics import PrometheusThriftServerMetrics
 from baseplate.thrift.ttypes import Error

--- a/baseplate/observers/prometheus.py
+++ b/baseplate/observers/prometheus.py
@@ -12,9 +12,9 @@ from baseplate import LocalSpan
 from baseplate import RequestContext
 from baseplate import Span
 from baseplate import SpanObserver
+from baseplate.lib.prometheus_metrics import PrometheusGenericSpanMetrics
 from baseplate.lib.prometheus_metrics import PrometheusHTTPClientMetrics
 from baseplate.lib.prometheus_metrics import PrometheusHTTPServerMetrics
-from baseplate.lib.prometheus_metrics import PrometheusGenericSpanMetrics
 from baseplate.lib.prometheus_metrics import PrometheusThriftClientMetrics
 from baseplate.lib.prometheus_metrics import PrometheusThriftServerMetrics
 from baseplate.thrift.ttypes import Error
@@ -264,4 +264,3 @@ class PrometheusGenericSpanObserver(PrometheusLocalSpanObserver):
     @property
     def protocol(self) -> str:
         return "generic"
-

--- a/baseplate/observers/prometheus.py
+++ b/baseplate/observers/prometheus.py
@@ -75,7 +75,7 @@ class PrometheusServerSpanObserver(SpanObserver):
             self.metrics = PrometheusHTTPServerMetrics()
         else:
             logger.debug(
-                "Unknown protocol %s. Expected 'http' or 'thrift' protocol.",
+                "Unknown protocol %s. 'http' and 'thrift' are supported.",
                 self.protocol,
             )
             self.metrics = get_metrics_for_prefix(self.span.name if self.span else "generic_server")
@@ -167,7 +167,7 @@ class PrometheusClientSpanObserver(SpanObserver):
             self.metrics = PrometheusThriftClientMetrics()
         else:
             logger.debug(
-                "Unknown protocol %s. Expected 'http' or 'thrift' protocol.",
+                "Unknown protocol %s. 'http' and 'thrift' are supported.",
                 self.protocol,
             )
             self.metrics = get_metrics_for_prefix(self.prefix if self.prefix else "generic_client")

--- a/baseplate/observers/prometheus.py
+++ b/baseplate/observers/prometheus.py
@@ -138,7 +138,7 @@ class PrometheusServerSpanObserver(SpanObserver):
 class PrometheusClientSpanObserver(SpanObserver):
     prefix = None
 
-    def __init__(self, prefix: Optional[str]) -> None:
+    def __init__(self, prefix: Optional[str] = "client") -> None:
         self.tags: Dict[str, Any] = {}
         self.start_time: Optional[int] = None
         self.metrics: Optional[

--- a/tests/integration/requests_tests.py
+++ b/tests/integration/requests_tests.py
@@ -269,12 +269,10 @@ def test_prometheus_http_client_metrics_inside_local_span(method, http_server):
     logger.info("Registered observer with baseplate.")
 
     # we need to clear metrics between test runs from the parametrize annotations
-    REGISTRY._names_to_collectors["http_client_requests_total"].clear()
-    REGISTRY._names_to_collectors["http_client_latency_seconds"].clear()
-    REGISTRY._names_to_collectors["http_client_active_requests"].clear()
-    REGISTRY._names_to_collectors["local_span_latency_seconds"].clear()
-    REGISTRY._names_to_collectors["local_span_requests_total"].clear()
-    REGISTRY._names_to_collectors["local_span_active_requests"].clear()
+    for collector_name in REGISTRY._names_to_collectors:
+        reg = REGISTRY._names_to_collectors[collector_name]
+        if hasattr(reg, "clear") and callable(getattr(reg, "clear")):
+            REGISTRY._names_to_collectors[collector_name].clear()
 
     with baseplate.server_context("test") as context:
         with context.span.make_child("local", local=True) as span:
@@ -320,7 +318,7 @@ def test_prometheus_http_client_metrics_inside_local_span(method, http_server):
 
     # checking that we got the local span metrics we expected
     local_span_latency_seconds = REGISTRY._names_to_collectors[
-        "local_span_latency_seconds"
+        "local_latency_seconds"
     ].collect()
     assert len(local_span_latency_seconds) == 1
     assert (
@@ -333,14 +331,14 @@ def test_prometheus_http_client_metrics_inside_local_span(method, http_server):
     local_span_latency_seconds_count = local_span_latency_seconds[0].samples[15]
     assert local_span_latency_seconds_count.value == 1
 
-    local_span_requests_total = REGISTRY._names_to_collectors["local_span_requests_total"].collect()
+    local_span_requests_total = REGISTRY._names_to_collectors["local_requests_total"].collect()
     assert len(local_span_requests_total) == 1
     assert len(local_span_requests_total[0].samples) == 2  # _total and _created
     local_span_requests_total_total = local_span_requests_total[0].samples[0]
     assert local_span_requests_total_total.value == 1
 
     local_span_active_requests = REGISTRY._names_to_collectors[
-        "local_span_active_requests"
+        "local_active_requests"
     ].collect()
     assert len(local_span_active_requests) == 1
     assert len(local_span_active_requests[0].samples) == 1

--- a/tests/integration/requests_tests.py
+++ b/tests/integration/requests_tests.py
@@ -317,9 +317,7 @@ def test_prometheus_http_client_metrics_inside_local_span(method, http_server):
     assert http_client_active_requests_samples.value == 0
 
     # checking that we got the local span metrics we expected
-    local_span_latency_seconds = REGISTRY._names_to_collectors[
-        "local_latency_seconds"
-    ].collect()
+    local_span_latency_seconds = REGISTRY._names_to_collectors["local_latency_seconds"].collect()
     assert len(local_span_latency_seconds) == 1
     assert (
         len(local_span_latency_seconds[0].samples) == 18
@@ -337,9 +335,7 @@ def test_prometheus_http_client_metrics_inside_local_span(method, http_server):
     local_span_requests_total_total = local_span_requests_total[0].samples[0]
     assert local_span_requests_total_total.value == 1
 
-    local_span_active_requests = REGISTRY._names_to_collectors[
-        "local_active_requests"
-    ].collect()
+    local_span_active_requests = REGISTRY._names_to_collectors["local_active_requests"].collect()
     assert len(local_span_active_requests) == 1
     assert len(local_span_active_requests[0].samples) == 1
     local_span_active_requests_samples = local_span_active_requests[0].samples[0]

--- a/tests/unit/observers/prometheus_tests.py
+++ b/tests/unit/observers/prometheus_tests.py
@@ -95,7 +95,7 @@ class TestException(Exception):
         ),
         (
             "local",
-            "span",
+            None,
             PrometheusLocalSpanObserver,
             {
                 "latency_labels": {
@@ -112,17 +112,21 @@ class TestException(Exception):
     ),
 )
 def test_observer_metrics(protocol, client_or_server, observer_cls, labels):
+    prefix = protocol
+    if client_or_server is not None:
+        prefix = f"{protocol}_{client_or_server}"
+
     before_start = REGISTRY.get_sample_value(
-        f"{protocol}_{client_or_server}_latency_seconds_count", labels.get("latency_labels", "")
+        f"{prefix}_latency_seconds_count", labels.get("latency_labels", "")
     )
 
     assert before_start is None
     before_start = REGISTRY.get_sample_value(
-        f"{protocol}_{client_or_server}_requests_total", labels.get("requests_labels", "")
+        f"{prefix}_requests_total", labels.get("requests_labels", "")
     )
     assert before_start is None
     before_start = REGISTRY.get_sample_value(
-        f"{protocol}_{client_or_server}_active_requests", labels.get("active_labels", "")
+        f"{prefix}_active_requests", labels.get("active_labels", "")
     )
     assert before_start is None
 
@@ -130,31 +134,32 @@ def test_observer_metrics(protocol, client_or_server, observer_cls, labels):
     observer.on_set_tag("protocol", protocol)
 
     observer.on_start()
-    assert observer.metrics.prefix == f"{protocol}_{client_or_server}"
+
+    assert observer.metrics.prefix == f"{prefix}"
     after_start = REGISTRY.get_sample_value(
-        f"{protocol}_{client_or_server}_latency_seconds_count", labels.get("latency_labels", "")
+        f"{prefix}_latency_seconds_count", labels.get("latency_labels", "")
     )
     assert after_start is None
     after_start = REGISTRY.get_sample_value(
-        f"{protocol}_{client_or_server}_requests_total", labels.get("requests_labels", "")
+        f"{prefix}_requests_total", labels.get("requests_labels", "")
     )
     assert after_start is None
     after_start = REGISTRY.get_sample_value(
-        f"{protocol}_{client_or_server}_active_requests", labels.get("active_labels", "")
+        f"{prefix}_active_requests", labels.get("active_labels", "")
     )
     assert after_start == 1.0
 
     observer.on_finish(None)
     after_done = REGISTRY.get_sample_value(
-        f"{protocol}_{client_or_server}_latency_seconds_count", labels.get("latency_labels", "")
+        f"{prefix}_latency_seconds_count", labels.get("latency_labels", "")
     )
     assert after_done == 1.0
     after_done = REGISTRY.get_sample_value(
-        f"{protocol}_{client_or_server}_requests_total", labels.get("requests_labels", "")
+        f"{prefix}_requests_total", labels.get("requests_labels", "")
     )
     assert after_done == 1.0
     after_done = REGISTRY.get_sample_value(
-        f"{protocol}_{client_or_server}_active_requests", labels.get("active_labels", "")
+        f"{prefix}_active_requests", labels.get("active_labels", "")
     )
     assert after_done == 0.0
 


### PR DESCRIPTION
Adds generic observers for spans that existed in old metrics style to

* silence errors about metrics not tracking properly
* get the most use out of it on release without too much customization

Note: This also changes `local_span_...` to `local_...`
^ I didn't see anything in baseplate spec or prometheus docs about this. I personally don't like naming it 2x (it's already implied to be a span).