### PR TITLE
[BASE-21] Align the behavior of the prometheus observer with existing statsd behavior

### DIFF
--- a/baseplate/frameworks/thrift/__init__.py
+++ b/baseplate/frameworks/thrift/__init__.py
@@ -57,7 +57,6 @@ class _ContextAwareHandler:
                 span.set_tag("exception_type", "Error")
                 span.set_tag("thrift.status_code", exc.code)
                 span.set_tag("thrift.status", status)
-                span.set_tag("success", "false")
                 # mark 5xx errors as failures since those are still "unexpected"
                 if 500 <= exc.code < 600:
                     span.finish(exc_info=sys.exc_info())
@@ -66,7 +65,6 @@ class _ContextAwareHandler:
                 raise
             except TException as e:
                 span.set_tag("exception_type", type(e).__name__)
-                span.set_tag("success", "false")
                 # this is an expected exception, as defined in the IDL
                 span.finish()
                 raise

--- a/baseplate/observers/prometheus.py
+++ b/baseplate/observers/prometheus.py
@@ -96,12 +96,10 @@ class PrometheusServerSpanObserver(SpanObserver):
             )
             return
 
+        self.tags["success"] = "true"
         if exc_info is not None:
             self.tags["exception_type"] = exc_info[1].__class__.__name__
             self.tags["success"] = "false"
-
-        if self.tags.get("exception_type", "") == "":
-            self.tags["success"] = "true"
 
         self.metrics.active_requests_metric(self.tags).dec()
         self.metrics.requests_total_metric(self.tags).inc()

--- a/tests/integration/thrift_tests.py
+++ b/tests/integration/thrift_tests.py
@@ -708,7 +708,7 @@ class ThriftPrometheusMetricsTests(GeventPatchedTestCase):
             "protocol": "thrift",
             "thrift.method": "example",
             "exception_type": "ExpectedException",
-            "success": "false",
+            "success": "true",
         }
         self.assertEqual(got_labels, want_labels)
 
@@ -726,7 +726,7 @@ class ThriftPrometheusMetricsTests(GeventPatchedTestCase):
             18,
             3,
             "thrift_server_latency_seconds_bucket",
-            {"thrift_method": "example", "thrift_success": "false", "le": "0.0015625"},
+            {"thrift_method": "example", "thrift_success": "true", "le": "0.0015625"},
             1.0,
         )
         self.assert_correct_metric(
@@ -739,7 +739,7 @@ class ThriftPrometheusMetricsTests(GeventPatchedTestCase):
                 "thrift_baseplate_status_code": "",
                 "thrift_exception_type": "ExpectedException",
                 "thrift_method": "example",
-                "thrift_success": "false",
+                "thrift_success": "true",
             },
             1.0,
         )
@@ -800,7 +800,7 @@ class ThriftPrometheusMetricsTests(GeventPatchedTestCase):
         )
         self.reset_metrics(prom_observer.metrics)
 
-    def test_prom_observer_metrics_baseplate_exc(self):
+    def test_prom_observer_metrics_baseplate_exc_4xx(self):
         """
         If the server returns an baseplate thrift Error, then the = thrift.status_code label and
         thrift.status label should be set.
@@ -823,6 +823,66 @@ class ThriftPrometheusMetricsTests(GeventPatchedTestCase):
             "exception_type": "Error",
             "thrift.status_code": 404,
             "thrift.status": "NOT_FOUND",
+            "success": "true",
+        }
+        self.assertEqual(got_labels, want_labels)
+
+        m = prom_observer.metrics
+        self.assert_correct_metric(
+            m.get_active_requests_metric(),
+            1,
+            0,
+            "thrift_server_active_requests",
+            {"thrift_method": "example"},
+            0.0,
+        )
+        self.assert_correct_metric(
+            m.get_latency_seconds_metric(),
+            18,
+            3,
+            "thrift_server_latency_seconds_bucket",
+            {"thrift_method": "example", "thrift_success": "true", "le": "0.0015625"},
+            1.0,
+        )
+        self.assert_correct_metric(
+            m.get_requests_total_metric(),
+            2,
+            0,
+            "thrift_server_requests_total",
+            {
+                "thrift_baseplate_status": "NOT_FOUND",
+                "thrift_baseplate_status_code": "404",
+                "thrift_exception_type": "Error",
+                "thrift_method": "example",
+                "thrift_success": "true",
+            },
+            1.0,
+        )
+        self.reset_metrics(prom_observer.metrics)
+
+    def test_prom_observer_metrics_baseplate_exc_5xx(self):
+        """
+        If the server returns an baseplate thrift Error, then the = thrift.status_code label and
+        thrift.status label should be set.
+        """
+
+        class Handler(TestService.Iface):
+            def example(self, context):
+                raise Error(ErrorCode.SERVICE_UNAVAILABLE, "foo is unavailable")
+
+        prom_observer = PrometheusServerSpanObserver()
+        with serve_thrift(Handler(), TestService, prom_observer) as server:
+            with raw_thrift_client(server.endpoint, TestService) as client:
+                with self.assertRaises(Error):
+                    client.example()
+
+        got_labels = prom_observer.get_labels()
+        want_labels = {
+            "protocol": "thrift",
+            "thrift.method": "example",
+            "exception_type": "Error",
+            "thrift.status_code": 503,
+            "thrift.status": "SERVICE_UNAVAILABLE",
             "success": "false",
         }
         self.assertEqual(got_labels, want_labels)
@@ -850,8 +910,8 @@ class ThriftPrometheusMetricsTests(GeventPatchedTestCase):
             0,
             "thrift_server_requests_total",
             {
-                "thrift_baseplate_status": "NOT_FOUND",
-                "thrift_baseplate_status_code": "404",
+                "thrift_baseplate_status": "SERVICE_UNAVAILABLE",
+                "thrift_baseplate_status_code": "503",
                 "thrift_exception_type": "Error",
                 "thrift_method": "example",
                 "thrift_success": "false",


### PR DESCRIPTION
1/ TException were reported as success under statsd, but as failure for
prometheus. Now both report as success.

2/ Errors with status code other than 5xx were reported as success under
statsd, but as failure for prometheus. now both report as success.


Closes # BASE-21

## 🧪 Testing Steps / Validation
unit / integration tests

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] CI tests (if present) are passing
- [x] Adheres to code style for repo
- [x] Contributor License Agreement (CLA) completed if not a Reddit employee
