### PR TITLE
[BASE-20][BASE-44] fixes for thrift client metrics

### DIFF
--- a/baseplate/clients/thrift.py
+++ b/baseplate/clients/thrift.py
@@ -167,17 +167,17 @@ def _build_thrift_proxy_method(name: str) -> Callable[..., Any]:
         trace_name = f"{self.namespace}.{name}"
         last_error = None
 
-        with self.pool.connection() as prot:
-            span = self.server_span.make_child(trace_name)
-            span.set_tag("protocol", "thrift")
-            span.set_tag("slug", self.namespace)
+        for time_remaining in self.retry_policy:
+            with self.pool.connection() as prot:
+                span = self.server_span.make_child(trace_name)
+                span.set_tag("protocol", "thrift")
+                span.set_tag("slug", self.namespace)
 
-            client = self.client_cls(prot)
-            method = getattr(client, name)
-            span.set_tag("method", method.__name__)
-            span.start()
+                client = self.client_cls(prot)
+                method = getattr(client, name)
+                span.set_tag("method", method.__name__)
+                span.start()
 
-            for time_remaining in self.retry_policy:
                 try:
                     baseplate = span.baseplate
                     if baseplate:

--- a/tests/integration/thrift_tests.py
+++ b/tests/integration/thrift_tests.py
@@ -872,9 +872,6 @@ class ThriftPrometheusMetricsTests(GeventPatchedTestCase):
         handler = Handler()
 
         prom_observer = PrometheusClientSpanObserver()
-        # This normally called when a child span is created in
-        # PrometheusServerSpanObserver, we're skipping that
-        prom_observer.on_set_tag("protocol", "thrift")
 
         with serve_thrift(handler, TestService) as server:
             with baseplate_thrift_client(server.endpoint, TestService, prom_observer) as context:


### PR DESCRIPTION
<!-- If this pull request closes an issue, please mention the issue number below -->
Closes [#BASE-20](https://reddit.atlassian.net/browse/BASE-20)
Closes [#BASE-44](https://reddit.atlassian.net/browse/BASE-44)


## 💸 TL;DR

* set protocol on thrift client

fixing observer ignoring thrift client metrics

* ensure span is started before handling request

when an exception was encountered before the span was started (e.g. remote thrift server is down), an
additional exception was raised by the `_call_thrift_method` exception handler, as it expected the span to have been started.

this changes the semantics of the latency graph, as it now includes every retry of a request!


## 📜 Details

Example error w stacktrace:

```{"message": "Unexpected exception in handler", "funcName": "process_example", "lineno": 163, "module": "AltTextService", "name": "root", "pathname": "/src/alt_text/alt_text_thrift/AltTextService.py", "process": 7, "processName": "MainProcess", "thread": 140516595254944, "threadName": "7037294429657837072", "exc_info": "Traceback (most recent call last):\n  File \"/usr/local/lib/venv/lib/python3.9/site-packages/baseplate/clients/thrift.py\", line 172, in _call_thrift_method\n    with self.pool.connection() as prot:\n  File \"/usr/local/lib/python3.9/contextlib.py\", line 119, in __enter__\n    return next(self.gen)\n  File \"/usr/local/lib/venv/lib/python3.9/site-packages/baseplate/lib/thrift_pool.py\", line 237, in connection\n    prot = self._create_connection()\n  File \"/usr/local/lib/venv/lib/python3.9/site-packages/baseplate/lib/thrift_pool.py\", line 202, in _create_connection\n    raise TTransportException(\nthrift.transport.TTransport.TTransportException: giving up after multiple attempts to connect\n\nDuring handling of the above exception, another exception occurred:\n\nTraceback (most recent call last):\n  File \"/src/alt_text/alt_text_thrift/AltTextService.py\", line 154, in process_example\n    result.success = self._handler.example()\n  File \"/usr/local/lib/venv/lib/python3.9/site-packages/baseplate/frameworks/thrift/__init__.py\", line 48, in call_with_context\n    result = handler_fn(self.context, *args, **kwargs)\n  File \"/src/alt_text/handlers.py\", line 37, in example\n    result = are_strings_good(context, [\"something something\"])\n  File \"/src/alt_text/goodcontent.py\", line 28, in are_strings_good\n    response = goodcontent_svc.are_strings_good(request)\n  File \"/usr/local/lib/venv/lib/python3.9/site-packages/baseplate/clients/thrift.py\", line 218, in _call_thrift_method\n    span.finish(exc_info=sys.exc_info())\nUnboundLocalError: local variable 'span' referenced before assignment", "level": "ERROR", "traceID": "7037294429657837072"}```

Example output:
```
# HELP thrift_client_latency_seconds Multiprocess metric
# TYPE thrift_client_latency_seconds histogram
thrift_client_latency_seconds_sum{thrift_slug="goodcontent",thrift_success="true"} 0.005589752999999999
thrift_client_latency_seconds_bucket{le="0.0001",thrift_slug="goodcontent",thrift_success="true"} 0.0
thrift_client_latency_seconds_bucket{le="0.00025",thrift_slug="goodcontent",thrift_success="true"} 0.0
thrift_client_latency_seconds_bucket{le="0.000625",thrift_slug="goodcontent",thrift_success="true"} 0.0
thrift_client_latency_seconds_bucket{le="0.0015625",thrift_slug="goodcontent",thrift_success="true"} 0.0
thrift_client_latency_seconds_bucket{le="0.00390625",thrift_slug="goodcontent",thrift_success="true"} 3.0
thrift_client_latency_seconds_bucket{le="0.009765625",thrift_slug="goodcontent",thrift_success="true"} 3.0
thrift_client_latency_seconds_bucket{le="0.0244140625",thrift_slug="goodcontent",thrift_success="true"} 3.0
thrift_client_latency_seconds_bucket{le="0.06103515625",thrift_slug="goodcontent",thrift_success="true"} 3.0
thrift_client_latency_seconds_bucket{le="0.152587890625",thrift_slug="goodcontent",thrift_success="true"} 3.0
thrift_client_latency_seconds_bucket{le="0.3814697265625",thrift_slug="goodcontent",thrift_success="true"} 3.0
thrift_client_latency_seconds_bucket{le="0.95367431640625",thrift_slug="goodcontent",thrift_success="true"} 3.0
thrift_client_latency_seconds_bucket{le="2.384185791015625",thrift_slug="goodcontent",thrift_success="true"} 3.0
thrift_client_latency_seconds_bucket{le="5.9604644775390625",thrift_slug="goodcontent",thrift_success="true"} 3.0
thrift_client_latency_seconds_bucket{le="14.901161193847656",thrift_slug="goodcontent",thrift_success="true"} 3.0
thrift_client_latency_seconds_bucket{le="+Inf",thrift_slug="goodcontent",thrift_success="true"} 3.0
thrift_client_latency_seconds_count{thrift_slug="goodcontent",thrift_success="true"} 3.0
# HELP thrift_server_latency_seconds Multiprocess metric
# TYPE thrift_server_latency_seconds histogram
thrift_server_latency_seconds_sum{thrift_method="example",thrift_success="true"} 0.090386687
thrift_server_latency_seconds_sum{thrift_method="is_healthy",thrift_success="true"} 0.013437850000000003
thrift_server_latency_seconds_sum{thrift_method="example",thrift_success="false"} 2.094433138
thrift_server_latency_seconds_bucket{le="0.0001",thrift_method="example",thrift_success="true"} 0.0
thrift_server_latency_seconds_bucket{le="0.00025",thrift_method="example",thrift_success="true"} 0.0
thrift_server_latency_seconds_bucket{le="0.000625",thrift_method="example",thrift_success="true"} 0.0
thrift_server_latency_seconds_bucket{le="0.0015625",thrift_method="example",thrift_success="true"} 0.0
thrift_server_latency_seconds_bucket{le="0.00390625",thrift_method="example",thrift_success="true"} 0.0
thrift_server_latency_seconds_bucket{le="0.009765625",thrift_method="example",thrift_success="true"} 2.0
thrift_server_latency_seconds_bucket{le="0.0244140625",thrift_method="example",thrift_success="true"} 2.0
thrift_server_latency_seconds_bucket{le="0.06103515625",thrift_method="example",thrift_success="true"} 2.0
thrift_server_latency_seconds_bucket{le="0.152587890625",thrift_method="example",thrift_success="true"} 3.0
thrift_server_latency_seconds_bucket{le="0.3814697265625",thrift_method="example",thrift_success="true"} 3.0
thrift_server_latency_seconds_bucket{le="0.95367431640625",thrift_method="example",thrift_success="true"} 3.0
thrift_server_latency_seconds_bucket{le="2.384185791015625",thrift_method="example",thrift_success="true"} 3.0
thrift_server_latency_seconds_bucket{le="5.9604644775390625",thrift_method="example",thrift_success="true"} 3.0
thrift_server_latency_seconds_bucket{le="14.901161193847656",thrift_method="example",thrift_success="true"} 3.0
thrift_server_latency_seconds_bucket{le="+Inf",thrift_method="example",thrift_success="true"} 3.0
thrift_server_latency_seconds_count{thrift_method="example",thrift_success="true"} 3.0
thrift_server_latency_seconds_bucket{le="0.0001",thrift_method="is_healthy",thrift_success="true"} 7.0
thrift_server_latency_seconds_bucket{le="0.00025",thrift_method="is_healthy",thrift_success="true"} 79.0
thrift_server_latency_seconds_bucket{le="0.000625",thrift_method="is_healthy",thrift_success="true"} 82.0
thrift_server_latency_seconds_bucket{le="0.0015625",thrift_method="is_healthy",thrift_success="true"} 82.0
thrift_server_latency_seconds_bucket{le="0.00390625",thrift_method="is_healthy",thrift_success="true"} 82.0
thrift_server_latency_seconds_bucket{le="0.009765625",thrift_method="is_healthy",thrift_success="true"} 82.0
thrift_server_latency_seconds_bucket{le="0.0244140625",thrift_method="is_healthy",thrift_success="true"} 82.0
thrift_server_latency_seconds_bucket{le="0.06103515625",thrift_method="is_healthy",thrift_success="true"} 82.0
thrift_server_latency_seconds_bucket{le="0.152587890625",thrift_method="is_healthy",thrift_success="true"} 82.0
thrift_server_latency_seconds_bucket{le="0.3814697265625",thrift_method="is_healthy",thrift_success="true"} 82.0
thrift_server_latency_seconds_bucket{le="0.95367431640625",thrift_method="is_healthy",thrift_success="true"} 82.0
thrift_server_latency_seconds_bucket{le="2.384185791015625",thrift_method="is_healthy",thrift_success="true"} 82.0
thrift_server_latency_seconds_bucket{le="5.9604644775390625",thrift_method="is_healthy",thrift_success="true"} 82.0
thrift_server_latency_seconds_bucket{le="14.901161193847656",thrift_method="is_healthy",thrift_success="true"} 82.0
thrift_server_latency_seconds_bucket{le="+Inf",thrift_method="is_healthy",thrift_success="true"} 82.0
thrift_server_latency_seconds_count{thrift_method="is_healthy",thrift_success="true"} 82.0
thrift_server_latency_seconds_bucket{le="0.0001",thrift_method="example",thrift_success="false"} 0.0
thrift_server_latency_seconds_bucket{le="0.00025",thrift_method="example",thrift_success="false"} 0.0
thrift_server_latency_seconds_bucket{le="0.000625",thrift_method="example",thrift_success="false"} 0.0
thrift_server_latency_seconds_bucket{le="0.0015625",thrift_method="example",thrift_success="false"} 0.0
thrift_server_latency_seconds_bucket{le="0.00390625",thrift_method="example",thrift_success="false"} 0.0
thrift_server_latency_seconds_bucket{le="0.009765625",thrift_method="example",thrift_success="false"} 0.0
thrift_server_latency_seconds_bucket{le="0.0244140625",thrift_method="example",thrift_success="false"} 0.0
thrift_server_latency_seconds_bucket{le="0.06103515625",thrift_method="example",thrift_success="false"} 1.0
thrift_server_latency_seconds_bucket{le="0.152587890625",thrift_method="example",thrift_success="false"} 2.0
thrift_server_latency_seconds_bucket{le="0.3814697265625",thrift_method="example",thrift_success="false"} 2.0
thrift_server_latency_seconds_bucket{le="0.95367431640625",thrift_method="example",thrift_success="false"} 2.0
thrift_server_latency_seconds_bucket{le="2.384185791015625",thrift_method="example",thrift_success="false"} 4.0
thrift_server_latency_seconds_bucket{le="5.9604644775390625",thrift_method="example",thrift_success="false"} 4.0
thrift_server_latency_seconds_bucket{le="14.901161193847656",thrift_method="example",thrift_success="false"} 4.0
thrift_server_latency_seconds_bucket{le="+Inf",thrift_method="example",thrift_success="false"} 4.0
thrift_server_latency_seconds_count{thrift_method="example",thrift_success="false"} 4.0
# HELP bp_thrift_pool_max_size Multiprocess metric
# TYPE bp_thrift_pool_max_size gauge
bp_thrift_pool_max_size{client_cls="type",pid="7"} 0.0
# HELP bp_thrift_pool_active_connections Multiprocess metric
# TYPE bp_thrift_pool_active_connections gauge
bp_thrift_pool_active_connections{client_cls="type",pid="7"} 0.0
# HELP bp_redis_pool_max_size Multiprocess metric
# TYPE bp_redis_pool_max_size gauge
bp_redis_pool_max_size{pid="7",pool="redis"} 0.0
# HELP bp_redis_pool_idle_connections Multiprocess metric
# TYPE bp_redis_pool_idle_connections gauge
bp_redis_pool_idle_connections{pid="7",pool="redis"} 0.0
# HELP bp_redis_pool_active_connections Multiprocess metric
# TYPE bp_redis_pool_active_connections gauge
bp_redis_pool_active_connections{pid="7",pool="redis"} 0.0
# HELP bp_sqlalchemy_pool_max_size Multiprocess metric
# TYPE bp_sqlalchemy_pool_max_size gauge
bp_sqlalchemy_pool_max_size{pid="7",pool="sqlalchemy"} 0.0
# HELP bp_sqlalchemy_pool_idle_connections Multiprocess metric
# TYPE bp_sqlalchemy_pool_idle_connections gauge
bp_sqlalchemy_pool_idle_connections{pid="7",pool="sqlalchemy"} 0.0
# HELP bp_sqlalchemy_pool_active_connections Multiprocess metric
# TYPE bp_sqlalchemy_pool_active_connections gauge
bp_sqlalchemy_pool_active_connections{pid="7",pool="sqlalchemy"} 0.0
# HELP bp_sqlalchemy_pool_overflow_connections Multiprocess metric
# TYPE bp_sqlalchemy_pool_overflow_connections gauge
bp_sqlalchemy_pool_overflow_connections{pid="7",pool="sqlalchemy"} 0.0
# HELP thrift_server_active_requests Multiprocess metric
# TYPE thrift_server_active_requests gauge
thrift_server_active_requests{pid="7",thrift_method="example"} 0.0
thrift_server_active_requests{pid="7",thrift_method="is_healthy"} 0.0
# HELP thrift_client_active_requests Multiprocess metric
# TYPE thrift_client_active_requests gauge
thrift_client_active_requests{pid="7",thrift_method="are_strings_good",thrift_slug="goodcontent"} 0.0
# HELP thrift_client_requests_total Multiprocess metric
# TYPE thrift_client_requests_total counter
thrift_client_requests_total{thrift_baseplate_status="",thrift_baseplate_status_code="",thrift_exception_type="",thrift_slug="goodcontent",thrift_success="true"} 3.0
# HELP thrift_server_requests_total Multiprocess metric
# TYPE thrift_server_requests_total counter
thrift_server_requests_total{thrift_baseplate_status="",thrift_baseplate_status_code="",thrift_exception_type="",thrift_method="example",thrift_success="true"} 3.0
thrift_server_requests_total{thrift_baseplate_status="",thrift_baseplate_status_code="",thrift_exception_type="",thrift_method="is_healthy",thrift_success="true"} 82.0
thrift_server_requests_total{thrift_baseplate_status="",thrift_baseplate_status_code="",thrift_exception_type="TTransportException",thrift_method="example",thrift_success="false"} 2.0
thrift_server_requests_total{thrift_baseplate_status="",thrift_baseplate_status_code="",thrift_exception_type="ServerTimeout",thrift_method="example",thrift_success="false"} 2.0

```

## 🧪 Testing Steps / Validation

## ✅ Checks
- [x] CI tests (if present) are passing
- [x] Adheres to code style for repo
- [ ] Contributor License Agreement (CLA) completed if not a Reddit employee
