### PR TITLE
Add database client metrics

### DIFF
--- a/baseplate/clients/sqlalchemy.py
+++ b/baseplate/clients/sqlalchemy.py
@@ -226,6 +226,7 @@ class SQLAlchemyEngineContextFactory(ContextFactory):
 
         trace_name = f"{context_name}.execute"
         span = server_span.make_child(trace_name)
+        span.set_tag("protocol", "sqlalchemy")
         span.set_tag("statement", statement[:1021] + "..." if len(statement) > 1024 else statement)
         span.start()
 

--- a/baseplate/lib/prometheus_metrics.py
+++ b/baseplate/lib/prometheus_metrics.py
@@ -438,3 +438,59 @@ class PrometheusLocalSpanMetrics:
     @classmethod
     def get_active_requests_metric(cls) -> Gauge:
         return cls.active_requests
+
+
+class PrometheusSQLAlchemyClientMetrics:
+    prefix = "database_client"
+
+    labels = [
+        "statement",
+    ]
+
+    # Latency histogram of HTTP calls made by clients
+    # buckets are defined above (from 100µs to ~14.9s)
+    latency_seconds = Histogram(
+        f"{prefix}_latency_seconds",
+        "Latency histogram of database calls made by client",
+        labels,
+        buckets=default_latency_buckets,
+    )
+    # Counter counting total HTTP requests started by a given client
+    requests_total = Counter(
+        f"{prefix}_requests_total",
+        "Total number of database requests started by a given client",
+        labels,
+    )
+    # Gauge showing current number of active requests by a given client
+    active_requests = Gauge(
+        f"{prefix}_active_requests",
+        "Number of active requests for a given client",
+        labels,
+    )
+
+    def __init__(self) -> None:
+        pass
+
+    @classmethod
+    def latency_seconds_metric(cls, tags: Dict[str, Any]) -> Histogram:
+        return cls.latency_seconds.labels(statement=tags.get("statement", ""))
+
+    @classmethod
+    def requests_total_metric(cls, tags: Dict[str, Any]) -> Counter:
+        return cls.requests_total.labels(statement=tags.get("statement", ""))
+
+    @classmethod
+    def active_requests_metric(cls, tags: Dict[str, Any]) -> Gauge:
+        return cls.active_requests.labels(statement=tags.get("statement", ""))
+
+    @classmethod
+    def get_latency_seconds_metric(cls) -> Histogram:
+        return cls.latency_seconds
+
+    @classmethod
+    def get_requests_total_metric(cls) -> Counter:
+        return cls.requests_total
+
+    @classmethod
+    def get_active_requests_metric(cls) -> Gauge:
+        return cls.active_requests

--- a/baseplate/observers/prometheus.py
+++ b/baseplate/observers/prometheus.py
@@ -137,7 +137,11 @@ class PrometheusClientSpanObserver(SpanObserver):
         self.tags: Dict[str, Any] = {}
         self.start_time: Optional[int] = None
         self.metrics: Optional[
-            Union[PrometheusHTTPClientMetrics, PrometheusThriftClientMetrics]
+            Union[
+                PrometheusHTTPClientMetrics,
+                PrometheusThriftClientMetrics,
+                PrometheusSQLAlchemyClientMetrics,
+            ]
         ] = None
 
     def on_set_tag(self, key: str, value: Any) -> None:

--- a/baseplate/observers/prometheus.py
+++ b/baseplate/observers/prometheus.py
@@ -15,6 +15,7 @@ from baseplate import SpanObserver
 from baseplate.lib.prometheus_metrics import PrometheusHTTPClientMetrics
 from baseplate.lib.prometheus_metrics import PrometheusHTTPServerMetrics
 from baseplate.lib.prometheus_metrics import PrometheusLocalSpanMetrics
+from baseplate.lib.prometheus_metrics import PrometheusSQLAlchemyClientMetrics
 from baseplate.lib.prometheus_metrics import PrometheusThriftClientMetrics
 from baseplate.lib.prometheus_metrics import PrometheusThriftServerMetrics
 from baseplate.thrift.ttypes import Error
@@ -154,6 +155,8 @@ class PrometheusClientSpanObserver(SpanObserver):
             self.metrics = PrometheusHTTPClientMetrics()
         elif self.protocol == "thrift":
             self.metrics = PrometheusThriftClientMetrics()
+        elif self.protocol == "sqlalchemy":
+            self.metrics = PrometheusSQLAlchemyClientMetrics()
         else:
             logger.debug(
                 "No valid protocol set for Prometheus metric collection, metrics won't be collected. Expected 'http' or 'thrift' protocol. Actual protocol: %s",


### PR DESCRIPTION
<!-- If this pull request closes an issue, please mention the issue number below -->
Closes [#BASE-30](https://reddit.atlassian.net/browse/BASE-30)

## 💸 TL;DR
<!-- What's the three sentence summary of purpose of the PR -->

Add database client latency and success graph. LMK if this is the correct approach to #BASE-22 or if we're taking a more generic one. 

## 📜 Details
```
...
# HELP database_client_latency_seconds Multiprocess metric
# TYPE database_client_latency_seconds histogram
database_client_latency_seconds_sum{statement="select 1"} 0.001254722
database_client_latency_seconds_bucket{le="0.0001",statement="select 1"} 0.0
database_client_latency_seconds_bucket{le="0.00025",statement="select 1"} 0.0
database_client_latency_seconds_bucket{le="0.000625",statement="select 1"} 0.0
database_client_latency_seconds_bucket{le="0.0015625",statement="select 1"} 1.0
database_client_latency_seconds_bucket{le="0.00390625",statement="select 1"} 1.0
database_client_latency_seconds_bucket{le="0.009765625",statement="select 1"} 1.0
database_client_latency_seconds_bucket{le="0.0244140625",statement="select 1"} 1.0
database_client_latency_seconds_bucket{le="0.06103515625",statement="select 1"} 1.0
database_client_latency_seconds_bucket{le="0.152587890625",statement="select 1"} 1.0
database_client_latency_seconds_bucket{le="0.3814697265625",statement="select 1"} 1.0
database_client_latency_seconds_bucket{le="0.95367431640625",statement="select 1"} 1.0
database_client_latency_seconds_bucket{le="2.384185791015625",statement="select 1"} 1.0
database_client_latency_seconds_bucket{le="5.9604644775390625",statement="select 1"} 1.0
database_client_latency_seconds_bucket{le="14.901161193847656",statement="select 1"} 1.0
database_client_latency_seconds_bucket{le="+Inf",statement="select 1"} 1.0
database_client_latency_seconds_count{statement="select 1"} 1.0
...
# HELP bp_sqlalchemy_pool_max_size Multiprocess metric
# TYPE bp_sqlalchemy_pool_max_size gauge
bp_sqlalchemy_pool_max_size{pid="7",pool="sqlalchemy"} 0.0
# HELP bp_sqlalchemy_pool_idle_connections Multiprocess metric
# TYPE bp_sqlalchemy_pool_idle_connections gauge
bp_sqlalchemy_pool_idle_connections{pid="7",pool="sqlalchemy"} 0.0
# HELP bp_sqlalchemy_pool_active_connections Multiprocess metric
# TYPE bp_sqlalchemy_pool_active_connections gauge
bp_sqlalchemy_pool_active_connections{pid="7",pool="sqlalchemy"} 0.0
# HELP bp_sqlalchemy_pool_overflow_connections Multiprocess metric
# TYPE bp_sqlalchemy_pool_overflow_connections gauge
bp_sqlalchemy_pool_overflow_connections{pid="7",pool="sqlalchemy"} 0.0
# HELP thrift_server_active_requests Multiprocess metric
# TYPE thrift_server_active_requests gauge
...
# HELP database_client_active_requests Multiprocess metric
# TYPE database_client_active_requests gauge
database_client_active_requests{pid="7",statement="select 1"} 0.0
...
# HELP database_client_requests_total Multiprocess metric
# TYPE database_client_requests_total counter
database_client_requests_total{statement="select 1"} 1.0```
```

## 🧪 Testing Steps / Validation
<!-- add details on how this PR has been tested, include reproductions and screenshots where applicable -->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] CI tests (if present) are passing
- [ ] Adheres to code style for repo
- [ ] Contributor License Agreement (CLA) completed if not a Reddit employee
