### PR TITLE
[base-32] instrument sqlalchemy client

### DIFF
--- a/baseplate/clients/sqlalchemy.py
+++ b/baseplate/clients/sqlalchemy.py
@@ -206,7 +206,9 @@ class SQLAlchemyEngineContextFactory(ContextFactory):
         pool = self.engine.pool
         if isinstance(pool, QueuePool):
             self.max_connections_gauge.labels(name).set_function(pool.size)
-            self.checked_out_connections_gauge.labels(name).set_function(pool.checkedout + pool.overflow)
+            self.checked_out_connections_gauge.labels(name).set_function(
+                pool.checkedout + pool.overflow
+            )
 
     def report_runtime_metrics(self, batch: metrics.Client) -> None:
         pool = self.engine.pool

--- a/baseplate/clients/sqlalchemy.py
+++ b/baseplate/clients/sqlalchemy.py
@@ -160,7 +160,7 @@ class SQLAlchemyEngineContextFactory(ContextFactory):
 
     """
 
-    PROM_PREFIX = "databasebp"
+    PROM_PREFIX = "sql"
     PROM_POOL_PREFIX = f"{PROM_PREFIX}_pool"
     PROM_POOL_LABELS = ["pool"]
 


### PR DESCRIPTION
Closes BASE-32

## 💸 TL;DR
adds latency and rate metrics to database client

## 📜 Details

example:

```
databasebp_latency_seconds_sum{database="alt_text",host="postgresql",success="true"} 0.0013580322265625
databasebp_latency_seconds_bucket{database="alt_text",host="postgresql",le="0.005",success="true"} 1.0
databasebp_latency_seconds_bucket{database="alt_text",host="postgresql",le="0.01",success="true"} 1.0
databasebp_latency_seconds_bucket{database="alt_text",host="postgresql",le="0.025",success="true"} 1.0
databasebp_latency_seconds_bucket{database="alt_text",host="postgresql",le="0.05",success="true"} 1.0
databasebp_latency_seconds_bucket{database="alt_text",host="postgresql",le="0.075",success="true"} 1.0
databasebp_latency_seconds_bucket{database="alt_text",host="postgresql",le="0.1",success="true"} 1.0
databasebp_latency_seconds_bucket{database="alt_text",host="postgresql",le="0.25",success="true"} 1.0
databasebp_latency_seconds_bucket{database="alt_text",host="postgresql",le="0.5",success="true"} 1.0
databasebp_latency_seconds_bucket{database="alt_text",host="postgresql",le="0.75",success="true"} 1.0
databasebp_latency_seconds_bucket{database="alt_text",host="postgresql",le="1.0",success="true"} 1.0
databasebp_latency_seconds_bucket{database="alt_text",host="postgresql",le="2.5",success="true"} 1.0
databasebp_latency_seconds_bucket{database="alt_text",host="postgresql",le="5.0",success="true"} 1.0
databasebp_latency_seconds_bucket{database="alt_text",host="postgresql",le="7.5",success="true"} 1.0
databasebp_latency_seconds_bucket{database="alt_text",host="postgresql",le="10.0",success="true"} 1.0
databasebp_latency_seconds_bucket{database="alt_text",host="postgresql",le="+Inf",success="true"} 1.0
databasebp_latency_seconds_count{database="alt_text",host="postgresql",success="true"} 1.0
databasebp_pool_max_size{pid="7",pool="sqlalchemy"} 0.0
databasebp_pool_idle_connections{pid="7",pool="sqlalchemy"} 0.0
databasebp_pool_active_connections{pid="7",pool="sqlalchemy"} 0.0
databasebp_pool_overflow_connections{pid="7",pool="sqlalchemy"} 0.0
databasebp_requests_total{database="alt_text",host="postgresql",success="true"} 1.0
```


## 🧪 Testing Steps / Validation
<!-- add details on how this PR has been tested, include reproductions and screenshots where applicable -->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] CI tests (if present) are passing
- [ ] Adheres to code style for repo
- [ ] Contributor License Agreement (CLA) completed if not a Reddit employee
