### PR TITLE
[base-22] Add prometheus tagged span observer

### DIFF
--- a/baseplate/__init__.py
+++ b/baseplate/__init__.py
@@ -341,6 +341,10 @@ class Baseplate:
                 )
             )
 
+            from baseplate.observers.prom_metrics_tagged import PromTaggedMetricsBaseplateObserver
+
+            self.register(PromTaggedMetricsBaseplateObserver.from_config(self._app_config))
+
             # If statsd metrics are currently configured, then enable Prometheus metrics simultaneous.
             # Once the migration to Prometheus is complete, then only enable Prometheus metrics.
             from baseplate.observers.prometheus import PrometheusBaseplateObserver

--- a/baseplate/observers/prom_metrics_tagged.py
+++ b/baseplate/observers/prom_metrics_tagged.py
@@ -18,8 +18,7 @@ from baseplate.lib import config
 
 
 class _PrometheusMetrics:
-    def __init__(self, allowlist):
-        print(allowlist)
+    def __init__(self, allowlist: List[str]):
         self.server_rate = Counter(
             "baseplate_server_span_rate", "Baseplate Server Span Counter", allowlist
         )
@@ -113,25 +112,25 @@ class _PromSpanObserver(SpanObserver):
     def on_set_tag(self, key: str, value: Any) -> None:
         self.tags[key] = value
 
-    def default_tags(self):
+    def default_tags(self) -> Dict[str, str]:
         return {k: "" for k in self.allowlist}
 
-    def filtered_tags(self):
+    def filtered_tags(self) -> Dict[str, Any]:
         filtered_tags = {k: v for (k, v) in self.tags.items() if k in self.allowlist}
         return {**self.default_tags(), **filtered_tags}
 
-    def filtered_counters(self):
+    def filtered_counters(self) -> Dict[str, Any]:
         return {k: v for (k, v) in self.counters.items() if k in self.allowlist}
 
-    def runtime(self):
+    def runtime(self) -> float:
         if self.time_started:
             return time() - self.time_started
-        return 0
+        return 0.0
 
 
 class _PromTaggedMetricsServerSpanDummyObserver(SpanObserver):
     # for requests that aren't sampled
-    def __init__(self):
+    def __init__(self) -> None:
         pass
 
     def on_start(self) -> None:

--- a/baseplate/observers/prom_metrics_tagged.py
+++ b/baseplate/observers/prom_metrics_tagged.py
@@ -1,0 +1,199 @@
+from random import random
+from time import time
+from typing import Any
+from typing import Dict
+from typing import Optional
+from typing import List
+
+from prometheus_client import Counter
+from prometheus_client import Histogram
+
+from baseplate import _ExcInfo
+from baseplate import BaseplateObserver
+from baseplate import LocalSpan
+from baseplate import RequestContext
+from baseplate import Span
+from baseplate import SpanObserver
+from baseplate.lib import config
+
+
+class _PrometheusMetrics:
+    def __init__(self, allowlist):
+        print(allowlist)
+        self.server_rate = Counter(
+            "baseplate_server_span_rate", "Baseplate Server Span Counter", allowlist
+        )
+        self.server_latency = Histogram(
+            "baseplate_server_span_latency_seconds", "Baseplate Server Span Latency", allowlist
+        )
+        self.client_rate = Counter(
+            "baseplate_client_span_rate", "Baseplate Client Span Counter", allowlist
+        )
+        self.client_latency = Histogram(
+            "baseplate_client_span_latency_seconds", "Baseplate Client Span Latency", allowlist
+        )
+        self.local_rate = Counter(
+            "baseplate_local_span_rate", "Baseplate Local Span Counter", allowlist
+        )
+        self.local_latency = Histogram(
+            "baseplate_local_span_latency_seconds", "Baseplate Local Span Latency", allowlist
+        )
+
+
+class PromTaggedMetricsBaseplateObserver(BaseplateObserver):
+    """Metrics collecting observer.
+
+    This observer reports metrics on Spans to Prometheus.
+
+    * it tracks the time taken in serving each request.
+    * it adds tags to the metric if they are in the config tag allowlist
+
+    :param cfg: the parsed application config with the tag allowlist
+    """
+
+    def __init__(
+        self, prom_metrics: _PrometheusMetrics, allowlist: List[str], sample_rate: float = 1.0
+    ):
+        self.prom_metrics = prom_metrics
+        self.allowlist = allowlist
+        self.sample_rate = sample_rate
+
+    @classmethod
+    def from_config(cls, raw_config: config.RawConfig) -> "PromTaggedMetricsBaseplateObserver":
+        cfg = config.parse_config(
+            raw_config,
+            {
+                "metrics": {
+                    "allowlist": config.Optional(config.TupleOf(config.String), default=[]),
+                },
+                "metrics_observer": {"sample_rate": config.Optional(config.Percent, default=1.0)},
+                # TODO: make latency buckets configurable?
+            },
+        )
+        allowlist = [*cfg.metrics.allowlist, "client", "endpoint", "success"]
+        return cls(
+            _PrometheusMetrics(allowlist),
+            allowlist=allowlist,
+            sample_rate=cfg.metrics_observer.sample_rate,
+        )
+
+    def on_server_span_created(self, context: RequestContext, server_span: Span) -> None:
+        if self.sample_rate == 1.0 or random() < self.sample_rate:
+            observer: SpanObserver = PromTaggedMetricsServerSpanObserver(
+                self.prom_metrics, server_span, self.allowlist, self.sample_rate
+            )
+        else:
+            observer = _PromTaggedMetricsServerSpanDummyObserver()
+        server_span.register(observer)
+
+
+class _PromSpanObserver(SpanObserver):
+    def __init__(
+        self,
+        prom_metrics: _PrometheusMetrics,
+        server_span: Span,
+        allowlist: List[str],
+        sample_rate: float = 1.0,
+    ):
+        self.prom_metrics = prom_metrics
+        self.span = server_span
+        self.allowlist = allowlist
+        self.tags: Dict[str, Any] = {}
+        self.counters: Dict[str, float] = {}
+        self.sample_rate = sample_rate
+        self.time_started: Optional[float] = None
+
+    def on_start(self) -> None:
+        self.time_started = time()
+        self.tags["endpoint"] = self.span.name
+
+    def on_incr_tag(self, key: str, delta: float) -> None:
+        self.counters[key] = delta
+
+    def on_set_tag(self, key: str, value: Any) -> None:
+        self.tags[key] = value
+
+    def default_tags(self):
+        return {k: "" for k in self.allowlist}
+
+    def filtered_tags(self):
+        filtered_tags = {k: v for (k, v) in self.tags.items() if k in self.allowlist}
+        return {**self.default_tags(), **filtered_tags}
+
+    def filtered_counters(self):
+        return {k: v for (k, v) in self.counters.items() if k in self.allowlist}
+
+    def runtime(self):
+        if self.time_started:
+            return time() - self.time_started
+        return 0
+
+
+class _PromTaggedMetricsServerSpanDummyObserver(SpanObserver):
+    # for requests that aren't sampled
+    def __init__(self):
+        pass
+
+    def on_start(self) -> None:
+        pass
+
+    def on_incr_tag(self, key: str, delta: float) -> None:
+        pass
+
+    def on_finish(self, exc_info: Optional[_ExcInfo]) -> None:
+        pass
+
+    def on_child_span_created(self, span: Span) -> None:
+        pass
+
+
+class PromTaggedMetricsServerSpanObserver(_PromSpanObserver):
+    def on_child_span_created(self, span: Span) -> None:
+        observer: SpanObserver
+        if isinstance(span, LocalSpan):
+            observer = PromTaggedMetricsLocalSpanObserver(
+                self.prom_metrics, span, self.allowlist, self.sample_rate
+            )
+        else:
+            observer = PromTaggedMetricsClientSpanObserver(
+                self.prom_metrics, span, self.allowlist, self.sample_rate
+            )
+        span.register(observer)
+
+    def on_finish(self, exc_info: Optional[_ExcInfo]) -> None:
+        self.prom_metrics.server_latency.labels(**self.filtered_tags()).observe(self.runtime())
+        self.prom_metrics.server_rate.labels(
+            **{**self.filtered_tags(), **self.filtered_counters(), "success": not exc_info}
+        ).inc()
+
+
+class PromTaggedMetricsLocalSpanObserver(_PromSpanObserver):
+    def on_child_span_created(self, span: Span) -> None:
+        observer: SpanObserver
+        if isinstance(span, LocalSpan):
+            observer = PromTaggedMetricsLocalSpanObserver(
+                self.prom_metrics, span, self.allowlist, self.sample_rate
+            )
+        else:
+            observer = PromTaggedMetricsClientSpanObserver(
+                self.prom_metrics, span, self.allowlist, self.sample_rate
+            )
+        span.register(observer)
+
+    def on_finish(self, exc_info: Optional[_ExcInfo]) -> None:
+        self.prom_metrics.local_latency.labels(**self.filtered_tags()).observe(self.runtime())
+        self.prom_metrics.local_rate.labels(
+            **{**self.filtered_tags(), **self.filtered_counters(), "success": not exc_info}
+        ).inc()
+
+
+class PromTaggedMetricsClientSpanObserver(_PromSpanObserver):
+    def on_start(self) -> None:
+        self.time_started = time()
+        self.tags["client"], _, self.tags["endpoint"] = self.span.name.rpartition(".")
+
+    def on_finish(self, exc_info: Optional[_ExcInfo]) -> None:
+        self.prom_metrics.client_latency.labels(**self.filtered_tags()).observe(self.runtime())
+        self.prom_metrics.client_rate.labels(
+            **{**self.filtered_tags(), **self.filtered_counters(), "success": not exc_info}
+        ).inc()

--- a/baseplate/observers/prom_metrics_tagged.py
+++ b/baseplate/observers/prom_metrics_tagged.py
@@ -2,8 +2,8 @@ from random import random
 from time import time
 from typing import Any
 from typing import Dict
-from typing import Optional
 from typing import List
+from typing import Optional
 
 from prometheus_client import Counter
 from prometheus_client import Histogram

--- a/baseplate/observers/prom_metrics_tagged.py
+++ b/baseplate/observers/prom_metrics_tagged.py
@@ -17,38 +17,25 @@ from baseplate import SpanObserver
 from baseplate.lib import config
 
 
-DEFAULT_LABELS = ["client", "endpoint", "success"]
-
-
 class _PrometheusMetrics:
     def __init__(self, allowlist: List[str]):
-        prefix = "baseplate"
-        extra_labels = set(allowlist) - set(DEFAULT_LABELS)
-        suffix = f"_w_{'_'.join(extra_labels)}" if len(extra_labels) > 0 else ""
-
         self.server_rate = Counter(
-            f"{prefix}_server_span_rate{suffix}_total", "Baseplate Server Span Counter", allowlist
+            "baseplate_server_span_rate", "Baseplate Server Span Counter", allowlist
         )
         self.server_latency = Histogram(
-            f"{prefix}_server_span_latency{suffix}_seconds",
-            "Baseplate Server Span Latency",
-            allowlist,
+            "baseplate_server_span_latency_seconds", "Baseplate Server Span Latency", allowlist
         )
         self.client_rate = Counter(
-            f"{prefix}_client_span_rate{suffix}_total", "Baseplate Client Span Counter", allowlist
+            "baseplate_client_span_rate", "Baseplate Client Span Counter", allowlist
         )
         self.client_latency = Histogram(
-            f"{prefix}_client_span_latency{suffix}_seconds",
-            "Baseplate Client Span Latency",
-            allowlist,
+            "baseplate_client_span_latency_seconds", "Baseplate Client Span Latency", allowlist
         )
         self.local_rate = Counter(
-            f"{prefix}_local_span_rate{suffix}_total", "Baseplate Local Span Counter", allowlist
+            "baseplate_local_span_rate", "Baseplate Local Span Counter", allowlist
         )
         self.local_latency = Histogram(
-            f"{prefix}_local_span_latency{suffix}_seconds",
-            "Baseplate Local Span Latency",
-            allowlist,
+            "baseplate_local_span_latency_seconds", "Baseplate Local Span Latency", allowlist
         )
 
 
@@ -82,8 +69,7 @@ class PromTaggedMetricsBaseplateObserver(BaseplateObserver):
                 # TODO: make latency buckets configurable?
             },
         )
-
-        allowlist = [*cfg.metrics.allowlist, *DEFAULT_LABELS]
+        allowlist = [*cfg.metrics.allowlist, "client", "endpoint", "success"]
         return cls(
             _PrometheusMetrics(allowlist),
             allowlist=allowlist,

--- a/baseplate/observers/prom_metrics_tagged.py
+++ b/baseplate/observers/prom_metrics_tagged.py
@@ -17,25 +17,38 @@ from baseplate import SpanObserver
 from baseplate.lib import config
 
 
+DEFAULT_LABELS = ["client", "endpoint", "success"]
+
+
 class _PrometheusMetrics:
     def __init__(self, allowlist: List[str]):
+        prefix = "baseplate"
+        extra_labels = set(allowlist) - set(DEFAULT_LABELS)
+        suffix = f"_w_{'_'.join(extra_labels)}" if len(extra_labels) > 0 else ""
+
         self.server_rate = Counter(
-            "baseplate_server_span_rate", "Baseplate Server Span Counter", allowlist
+            f"{prefix}_server_span_rate{suffix}_total", "Baseplate Server Span Counter", allowlist
         )
         self.server_latency = Histogram(
-            "baseplate_server_span_latency_seconds", "Baseplate Server Span Latency", allowlist
+            f"{prefix}_server_span_latency{suffix}_seconds",
+            "Baseplate Server Span Latency",
+            allowlist,
         )
         self.client_rate = Counter(
-            "baseplate_client_span_rate", "Baseplate Client Span Counter", allowlist
+            f"{prefix}_client_span_rate{suffix}_total", "Baseplate Client Span Counter", allowlist
         )
         self.client_latency = Histogram(
-            "baseplate_client_span_latency_seconds", "Baseplate Client Span Latency", allowlist
+            f"{prefix}_client_span_latency{suffix}_seconds",
+            "Baseplate Client Span Latency",
+            allowlist,
         )
         self.local_rate = Counter(
-            "baseplate_local_span_rate", "Baseplate Local Span Counter", allowlist
+            f"{prefix}_local_span_rate{suffix}_total", "Baseplate Local Span Counter", allowlist
         )
         self.local_latency = Histogram(
-            "baseplate_local_span_latency_seconds", "Baseplate Local Span Latency", allowlist
+            f"{prefix}_local_span_latency{suffix}_seconds",
+            "Baseplate Local Span Latency",
+            allowlist,
         )
 
 
@@ -69,7 +82,8 @@ class PromTaggedMetricsBaseplateObserver(BaseplateObserver):
                 # TODO: make latency buckets configurable?
             },
         )
-        allowlist = [*cfg.metrics.allowlist, "client", "endpoint", "success"]
+
+        allowlist = [*cfg.metrics.allowlist, *DEFAULT_LABELS]
         return cls(
             _PrometheusMetrics(allowlist),
             allowlist=allowlist,


### PR DESCRIPTION
## 💸 TL;DR
Prometheus version of the StatsD metrics_tagged. If tagged metrics are enabled it will emit basic metrics, then more if you explicitly enable a tags (like "statement" for the sqlalchemy client). Configuration is shared with StatsD metrics_tagged.  Should have parity with what's currently sent to wavefront for spans.


## 📜 Details

example output:

```
baseplate_server_span_latency_seconds_sum{client="",endpoint="is_healthy",success=""} 0.012034416198730469
baseplate_server_span_latency_seconds_sum{client="",endpoint="example",success=""} 0.08535456657409668
baseplate_server_span_latency_seconds_bucket{client="",endpoint="is_healthy",le="0.005",success=""} 78.0
baseplate_server_span_latency_seconds_bucket{client="",endpoint="is_healthy",le="0.01",success=""} 78.0
baseplate_server_span_latency_seconds_bucket{client="",endpoint="is_healthy",le="0.025",success=""} 78.0
baseplate_server_span_latency_seconds_bucket{client="",endpoint="is_healthy",le="0.05",success=""} 78.0
baseplate_server_span_latency_seconds_bucket{client="",endpoint="is_healthy",le="0.075",success=""} 78.0
baseplate_server_span_latency_seconds_bucket{client="",endpoint="is_healthy",le="0.1",success=""} 78.0
baseplate_server_span_latency_seconds_bucket{client="",endpoint="is_healthy",le="0.25",success=""} 78.0
baseplate_server_span_latency_seconds_bucket{client="",endpoint="is_healthy",le="0.5",success=""} 78.0
baseplate_server_span_latency_seconds_bucket{client="",endpoint="is_healthy",le="0.75",success=""} 78.0
baseplate_server_span_latency_seconds_bucket{client="",endpoint="is_healthy",le="1.0",success=""} 78.0
baseplate_server_span_latency_seconds_bucket{client="",endpoint="is_healthy",le="2.5",success=""} 78.0
baseplate_server_span_latency_seconds_bucket{client="",endpoint="is_healthy",le="5.0",success=""} 78.0
baseplate_server_span_latency_seconds_bucket{client="",endpoint="is_healthy",le="7.5",success=""} 78.0
baseplate_server_span_latency_seconds_bucket{client="",endpoint="is_healthy",le="10.0",success=""} 78.0
baseplate_server_span_latency_seconds_bucket{client="",endpoint="is_healthy",le="+Inf",success=""} 78.0
baseplate_server_span_latency_seconds_count{client="",endpoint="is_healthy",success=""} 78.0
baseplate_server_span_latency_seconds_bucket{client="",endpoint="example",le="0.005",success=""} 0.0
baseplate_server_span_latency_seconds_bucket{client="",endpoint="example",le="0.01",success=""} 0.0
baseplate_server_span_latency_seconds_bucket{client="",endpoint="example",le="0.025",success=""} 0.0
baseplate_server_span_latency_seconds_bucket{client="",endpoint="example",le="0.05",success=""} 0.0
baseplate_server_span_latency_seconds_bucket{client="",endpoint="example",le="0.075",success=""} 0.0
baseplate_server_span_latency_seconds_bucket{client="",endpoint="example",le="0.1",success=""} 1.0
baseplate_server_span_latency_seconds_bucket{client="",endpoint="example",le="0.25",success=""} 1.0
baseplate_server_span_latency_seconds_bucket{client="",endpoint="example",le="0.5",success=""} 1.0
baseplate_server_span_latency_seconds_bucket{client="",endpoint="example",le="0.75",success=""} 1.0
baseplate_server_span_latency_seconds_bucket{client="",endpoint="example",le="1.0",success=""} 1.0
baseplate_server_span_latency_seconds_bucket{client="",endpoint="example",le="2.5",success=""} 1.0
baseplate_server_span_latency_seconds_bucket{client="",endpoint="example",le="5.0",success=""} 1.0
baseplate_server_span_latency_seconds_bucket{client="",endpoint="example",le="7.5",success=""} 1.0
baseplate_server_span_latency_seconds_bucket{client="",endpoint="example",le="10.0",success=""} 1.0
baseplate_server_span_latency_seconds_bucket{client="",endpoint="example",le="+Inf",success=""} 1.0
baseplate_server_span_latency_seconds_count{client="",endpoint="example",success=""} 1.0
baseplate_client_span_latency_seconds_sum{client="redis",endpoint="MGET",success=""} 0.010667800903320312
baseplate_client_span_latency_seconds_sum{client="database",endpoint="execute",success=""} 0.00124359130859375
baseplate_client_span_latency_seconds_sum{client="goodcontent",endpoint="are_strings_good",success=""} 0.0019712448120117188
baseplate_client_span_latency_seconds_bucket{client="redis",endpoint="MGET",le="0.005",success=""} 0.0
baseplate_client_span_latency_seconds_bucket{client="redis",endpoint="MGET",le="0.01",success=""} 0.0
baseplate_client_span_latency_seconds_bucket{client="redis",endpoint="MGET",le="0.025",success=""} 1.0
baseplate_client_span_latency_seconds_bucket{client="redis",endpoint="MGET",le="0.05",success=""} 1.0
baseplate_client_span_latency_seconds_bucket{client="redis",endpoint="MGET",le="0.075",success=""} 1.0
baseplate_client_span_latency_seconds_bucket{client="redis",endpoint="MGET",le="0.1",success=""} 1.0
baseplate_client_span_latency_seconds_bucket{client="redis",endpoint="MGET",le="0.25",success=""} 1.0
baseplate_client_span_latency_seconds_bucket{client="redis",endpoint="MGET",le="0.5",success=""} 1.0
baseplate_client_span_latency_seconds_bucket{client="redis",endpoint="MGET",le="0.75",success=""} 1.0
baseplate_client_span_latency_seconds_bucket{client="redis",endpoint="MGET",le="1.0",success=""} 1.0
baseplate_client_span_latency_seconds_bucket{client="redis",endpoint="MGET",le="2.5",success=""} 1.0
baseplate_client_span_latency_seconds_bucket{client="redis",endpoint="MGET",le="5.0",success=""} 1.0
baseplate_client_span_latency_seconds_bucket{client="redis",endpoint="MGET",le="7.5",success=""} 1.0
baseplate_client_span_latency_seconds_bucket{client="redis",endpoint="MGET",le="10.0",success=""} 1.0
baseplate_client_span_latency_seconds_bucket{client="redis",endpoint="MGET",le="+Inf",success=""} 1.0
baseplate_client_span_latency_seconds_count{client="redis",endpoint="MGET",success=""} 1.0
baseplate_client_span_latency_seconds_bucket{client="database",endpoint="execute",le="0.005",success=""} 1.0
baseplate_client_span_latency_seconds_bucket{client="database",endpoint="execute",le="0.01",success=""} 1.0
baseplate_client_span_latency_seconds_bucket{client="database",endpoint="execute",le="0.025",success=""} 1.0
baseplate_client_span_latency_seconds_bucket{client="database",endpoint="execute",le="0.05",success=""} 1.0
baseplate_client_span_latency_seconds_bucket{client="database",endpoint="execute",le="0.075",success=""} 1.0
baseplate_client_span_latency_seconds_bucket{client="database",endpoint="execute",le="0.1",success=""} 1.0
baseplate_client_span_latency_seconds_bucket{client="database",endpoint="execute",le="0.25",success=""} 1.0
baseplate_client_span_latency_seconds_bucket{client="database",endpoint="execute",le="0.5",success=""} 1.0
baseplate_client_span_latency_seconds_bucket{client="database",endpoint="execute",le="0.75",success=""} 1.0
baseplate_client_span_latency_seconds_bucket{client="database",endpoint="execute",le="1.0",success=""} 1.0
baseplate_client_span_latency_seconds_bucket{client="database",endpoint="execute",le="2.5",success=""} 1.0
baseplate_client_span_latency_seconds_bucket{client="database",endpoint="execute",le="5.0",success=""} 1.0
baseplate_client_span_latency_seconds_bucket{client="database",endpoint="execute",le="7.5",success=""} 1.0
baseplate_client_span_latency_seconds_bucket{client="database",endpoint="execute",le="10.0",success=""} 1.0
baseplate_client_span_latency_seconds_bucket{client="database",endpoint="execute",le="+Inf",success=""} 1.0
baseplate_client_span_latency_seconds_count{client="database",endpoint="execute",success=""} 1.0
baseplate_client_span_latency_seconds_bucket{client="goodcontent",endpoint="are_strings_good",le="0.005",success=""} 1.0
baseplate_client_span_latency_seconds_bucket{client="goodcontent",endpoint="are_strings_good",le="0.01",success=""} 1.0
baseplate_client_span_latency_seconds_bucket{client="goodcontent",endpoint="are_strings_good",le="0.025",success=""} 1.0
baseplate_client_span_latency_seconds_bucket{client="goodcontent",endpoint="are_strings_good",le="0.05",success=""} 1.0
baseplate_client_span_latency_seconds_bucket{client="goodcontent",endpoint="are_strings_good",le="0.075",success=""} 1.0
baseplate_client_span_latency_seconds_bucket{client="goodcontent",endpoint="are_strings_good",le="0.1",success=""} 1.0
baseplate_client_span_latency_seconds_bucket{client="goodcontent",endpoint="are_strings_good",le="0.25",success=""} 1.0
baseplate_client_span_latency_seconds_bucket{client="goodcontent",endpoint="are_strings_good",le="0.5",success=""} 1.0
baseplate_client_span_latency_seconds_bucket{client="goodcontent",endpoint="are_strings_good",le="0.75",success=""} 1.0
baseplate_client_span_latency_seconds_bucket{client="goodcontent",endpoint="are_strings_good",le="1.0",success=""} 1.0
baseplate_client_span_latency_seconds_bucket{client="goodcontent",endpoint="are_strings_good",le="2.5",success=""} 1.0
baseplate_client_span_latency_seconds_bucket{client="goodcontent",endpoint="are_strings_good",le="5.0",success=""} 1.0
baseplate_client_span_latency_seconds_bucket{client="goodcontent",endpoint="are_strings_good",le="7.5",success=""} 1.0
baseplate_client_span_latency_seconds_bucket{client="goodcontent",endpoint="are_strings_good",le="10.0",success=""} 1.0
baseplate_client_span_latency_seconds_bucket{client="goodcontent",endpoint="are_strings_good",le="+Inf",success=""} 1.0
baseplate_client_span_latency_seconds_count{client="goodcontent",endpoint="are_strings_good",success=""} 1.0
baseplate_server_span_rate_total{client="",endpoint="is_healthy",success="True"} 78.0
baseplate_server_span_rate_total{client="",endpoint="example",success="True"} 1.0
baseplate_client_span_rate_total{client="redis",endpoint="MGET",success="True"} 1.0
baseplate_client_span_rate_total{client="database",endpoint="execute",success="True"} 1.0
baseplate_client_span_rate_total{client="goodcontent",endpoint="are_strings_good",success="True"} 1.0
```

## 🧪 Testing Steps / Validation
<!-- add details on how this PR has been tested, include reproductions and screenshots where applicable -->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] CI tests (if present) are passing
- [ ] Adheres to code style for repo
- [ ] Contributor License Agreement (CLA) completed if not a Reddit employee
