### PR TITLE
[BASE-34] Add prometheus metrics for cassandra client

### DIFF
--- a/baseplate/clients/cassandra.py
+++ b/baseplate/clients/cassandra.py
@@ -337,7 +337,7 @@ class CassandraSessionAdapter:
         **kwargs: Any,
     ) -> ResponseFuture:
         prom_labels = CassandraPrometheusLabels(
-            cassandra_contact_points=",".join(self.cluster.contact_points),
+            cassandra_contact_points=",".join(sorted(self.cluster.contact_points)),
             cassandra_keyspace=self.session.keyspace,
             cassandra_query_name=query_name if query_name is not None else "",
         )

--- a/tests/unit/clients/cassandra_tests.py
+++ b/tests/unit/clients/cassandra_tests.py
@@ -109,9 +109,10 @@ class CassandraSessionAdapterTests(unittest.TestCase):
 
     def test_execute_async_prom_metrics(self):
         self.session.keyspace = "keyspace"  # mocking keyspace name
+        # hostnames purposefully out of order :-)
         self.session.cluster.contact_points = [
-            "hostname1",
             "hostname2",
+            "hostname1",
         ]  # mocking cluster contact points
         self.adapter.execute_async("SELECT foo from bar;")
 


### PR DESCRIPTION
Closes #BASE-34

## 🧪 Testing Steps / Validation
Manual testing + unit

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] CI tests (if present) are passing
- [x] Adheres to code style for repo
- [x] Contributor License Agreement (CLA) completed if not a Reddit employee

## Manual test:
```
[...]
"cass_local": CassandraClient("mykeyspace"),
[...]
with baseplate.server_context('http_client') as context:
    with context.span.make_child('cassandra', local=True, component_name='myKeySpace') as span:
        logger.error(span.context)
        for row in span.context.cass_local.execute("DESCRIBE keyspaces;"):
            logger.error(row)
        try:
            span.context.cass_local.execute("SELECT 1;", query_name="failure")
        except:
            pass
        for row in span.context.cass_local.execute_async("DESCRIBE keyspaces;").result():
            logger.warning(row)

```

metrics
```
# HELP cassandra_client_requests_active Multiprocess metric
# TYPE cassandra_client_requests_active gauge
cassandra_client_requests_active{cassandra_contact_points="localhost",cassandra_keyspace="mykeyspace",cassandra_query_name="",pid="67962"} 0.0
cassandra_client_requests_active{cassandra_contact_points="localhost",cassandra_keyspace="mykeyspace",cassandra_query_name="failure",pid="67962"} 0.0
# HELP cassandra_client_requests_total Multiprocess metric
# TYPE cassandra_client_requests_total counter
cassandra_client_requests_total{cassandra_contact_points="localhost",cassandra_keyspace="mykeyspace",cassandra_query_name="",cassandra_success="true"} 2.0
cassandra_client_requests_total{cassandra_contact_points="localhost",cassandra_keyspace="mykeyspace",cassandra_query_name="failure",cassandra_success="false"} 1.0
# HELP cassandra_client_latency_seconds Multiprocess metric
# TYPE cassandra_client_latency_seconds histogram
cassandra_client_latency_seconds_sum{cassandra_contact_points="localhost",cassandra_keyspace="mykeyspace",cassandra_query_name="",cassandra_success="true"} 0.004405794999999824
cassandra_client_latency_seconds_sum{cassandra_contact_points="localhost",cassandra_keyspace="mykeyspace",cassandra_query_name="failure",cassandra_success="false"} 0.0018226910000000984
cassandra_client_latency_seconds_bucket{cassandra_contact_points="localhost",cassandra_keyspace="mykeyspace",cassandra_query_name="",cassandra_success="true",le="0.0001"} 0.0
cassandra_client_latency_seconds_bucket{cassandra_contact_points="localhost",cassandra_keyspace="mykeyspace",cassandra_query_name="",cassandra_success="true",le="0.00025"} 0.0
cassandra_client_latency_seconds_bucket{cassandra_contact_points="localhost",cassandra_keyspace="mykeyspace",cassandra_query_name="",cassandra_success="true",le="0.000625"} 0.0
cassandra_client_latency_seconds_bucket{cassandra_contact_points="localhost",cassandra_keyspace="mykeyspace",cassandra_query_name="",cassandra_success="true",le="0.0015625"} 0.0
cassandra_client_latency_seconds_bucket{cassandra_contact_points="localhost",cassandra_keyspace="mykeyspace",cassandra_query_name="",cassandra_success="true",le="0.00390625"} 2.0
cassandra_client_latency_seconds_bucket{cassandra_contact_points="localhost",cassandra_keyspace="mykeyspace",cassandra_query_name="",cassandra_success="true",le="0.009765625"} 2.0
cassandra_client_latency_seconds_bucket{cassandra_contact_points="localhost",cassandra_keyspace="mykeyspace",cassandra_query_name="",cassandra_success="true",le="0.0244140625"} 2.0
cassandra_client_latency_seconds_bucket{cassandra_contact_points="localhost",cassandra_keyspace="mykeyspace",cassandra_query_name="",cassandra_success="true",le="0.06103515625"} 2.0
cassandra_client_latency_seconds_bucket{cassandra_contact_points="localhost",cassandra_keyspace="mykeyspace",cassandra_query_name="",cassandra_success="true",le="0.152587890625"} 2.0
cassandra_client_latency_seconds_bucket{cassandra_contact_points="localhost",cassandra_keyspace="mykeyspace",cassandra_query_name="",cassandra_success="true",le="0.3814697265625"} 2.0
cassandra_client_latency_seconds_bucket{cassandra_contact_points="localhost",cassandra_keyspace="mykeyspace",cassandra_query_name="",cassandra_success="true",le="0.95367431640625"} 2.0
cassandra_client_latency_seconds_bucket{cassandra_contact_points="localhost",cassandra_keyspace="mykeyspace",cassandra_query_name="",cassandra_success="true",le="2.384185791015625"} 2.0
cassandra_client_latency_seconds_bucket{cassandra_contact_points="localhost",cassandra_keyspace="mykeyspace",cassandra_query_name="",cassandra_success="true",le="5.9604644775390625"} 2.0
cassandra_client_latency_seconds_bucket{cassandra_contact_points="localhost",cassandra_keyspace="mykeyspace",cassandra_query_name="",cassandra_success="true",le="14.901161193847656"} 2.0
cassandra_client_latency_seconds_bucket{cassandra_contact_points="localhost",cassandra_keyspace="mykeyspace",cassandra_query_name="",cassandra_success="true",le="+Inf"} 2.0
cassandra_client_latency_seconds_count{cassandra_contact_points="localhost",cassandra_keyspace="mykeyspace",cassandra_query_name="",cassandra_success="true"} 2.0
cassandra_client_latency_seconds_bucket{cassandra_contact_points="localhost",cassandra_keyspace="mykeyspace",cassandra_query_name="failure",cassandra_success="false",le="0.0001"} 0.0
cassandra_client_latency_seconds_bucket{cassandra_contact_points="localhost",cassandra_keyspace="mykeyspace",cassandra_query_name="failure",cassandra_success="false",le="0.00025"} 0.0
cassandra_client_latency_seconds_bucket{cassandra_contact_points="localhost",cassandra_keyspace="mykeyspace",cassandra_query_name="failure",cassandra_success="false",le="0.000625"} 0.0
cassandra_client_latency_seconds_bucket{cassandra_contact_points="localhost",cassandra_keyspace="mykeyspace",cassandra_query_name="failure",cassandra_success="false",le="0.0015625"} 0.0
cassandra_client_latency_seconds_bucket{cassandra_contact_points="localhost",cassandra_keyspace="mykeyspace",cassandra_query_name="failure",cassandra_success="false",le="0.00390625"} 1.0
cassandra_client_latency_seconds_bucket{cassandra_contact_points="localhost",cassandra_keyspace="mykeyspace",cassandra_query_name="failure",cassandra_success="false",le="0.009765625"} 1.0
cassandra_client_latency_seconds_bucket{cassandra_contact_points="localhost",cassandra_keyspace="mykeyspace",cassandra_query_name="failure",cassandra_success="false",le="0.0244140625"} 1.0
cassandra_client_latency_seconds_bucket{cassandra_contact_points="localhost",cassandra_keyspace="mykeyspace",cassandra_query_name="failure",cassandra_success="false",le="0.06103515625"} 1.0
cassandra_client_latency_seconds_bucket{cassandra_contact_points="localhost",cassandra_keyspace="mykeyspace",cassandra_query_name="failure",cassandra_success="false",le="0.152587890625"} 1.0
cassandra_client_latency_seconds_bucket{cassandra_contact_points="localhost",cassandra_keyspace="mykeyspace",cassandra_query_name="failure",cassandra_success="false",le="0.3814697265625"} 1.0
cassandra_client_latency_seconds_bucket{cassandra_contact_points="localhost",cassandra_keyspace="mykeyspace",cassandra_query_name="failure",cassandra_success="false",le="0.95367431640625"} 1.0
cassandra_client_latency_seconds_bucket{cassandra_contact_points="localhost",cassandra_keyspace="mykeyspace",cassandra_query_name="failure",cassandra_success="false",le="2.384185791015625"} 1.0
cassandra_client_latency_seconds_bucket{cassandra_contact_points="localhost",cassandra_keyspace="mykeyspace",cassandra_query_name="failure",cassandra_success="false",le="5.9604644775390625"} 1.0
cassandra_client_latency_seconds_bucket{cassandra_contact_points="localhost",cassandra_keyspace="mykeyspace",cassandra_query_name="failure",cassandra_success="false",le="14.901161193847656"} 1.0
cassandra_client_latency_seconds_bucket{cassandra_contact_points="localhost",cassandra_keyspace="mykeyspace",cassandra_query_name="failure",cassandra_success="false",le="+Inf"} 1.0
cassandra_client_latency_seconds_count{cassandra_contact_points="localhost",cassandra_keyspace="mykeyspace",cassandra_query_name="failure",cassandra_success="false"} 1.0
```