### PR TITLE
[BASE-61] Implement Kombu AMQP consumer prometheus metrics

### DIFF
--- a/baseplate/frameworks/queue_consumer/kombu.py
+++ b/baseplate/frameworks/queue_consumer/kombu.py
@@ -34,7 +34,7 @@ from baseplate.server.queue_consumer import QueueConsumerFactory
 class AmqpConsumerPrometheusLabels(NamedTuple):
     amqp_address: str
     amqp_virtual_host: str
-    amqp_exchange: str
+    amqp_exchange_name: str
     amqp_routing_key: str
 
 
@@ -136,7 +136,7 @@ class KombuMessageHandler(MessageHandler):
         prometheus_labels = AmqpConsumerPrometheusLabels(
             amqp_address=message.channel.connection.client.host,  # note: localhost will be translated to 127.0.0.1 by the library
             amqp_virtual_host=message.channel.connection.client.virtual_host,
-            amqp_exchange=message.delivery_info.get("exchange", ""),
+            amqp_exchange_name=message.delivery_info.get("exchange", ""),
             amqp_routing_key=message.delivery_info.get("routing_key", ""),
         )
         AMQP_ACTIVE_MESSAGES.labels(**prometheus_labels._asdict()).inc()

--- a/tests/unit/frameworks/queue_consumer/kombu_tests.py
+++ b/tests/unit/frameworks/queue_consumer/kombu_tests.py
@@ -7,10 +7,15 @@ import kombu
 import pytest
 
 from gevent.server import StreamServer
+from prometheus_client import REGISTRY
 
 from baseplate import Baseplate
 from baseplate import RequestContext
 from baseplate import ServerSpan
+from baseplate.frameworks.queue_consumer.kombu import AMQP_ACTIVE_MESSAGES
+from baseplate.frameworks.queue_consumer.kombu import AMQP_PROCESSED_TOTAL
+from baseplate.frameworks.queue_consumer.kombu import AMQP_PROCESSING_TIME
+from baseplate.frameworks.queue_consumer.kombu import AmqpConsumerPrometheusLabels
 from baseplate.frameworks.queue_consumer.kombu import FatalMessageHandlerError
 from baseplate.frameworks.queue_consumer.kombu import KombuConsumerWorker
 from baseplate.frameworks.queue_consumer.kombu import KombuMessageHandler
@@ -47,8 +52,13 @@ def name():
 
 
 class TestKombuMessageHandler:
+    def setup(self):
+        AMQP_PROCESSING_TIME.clear()
+        AMQP_PROCESSED_TOTAL.clear()
+        AMQP_ACTIVE_MESSAGES.clear()
+
     @pytest.fixture
-    def message(self):
+    def message(self, connection):
         msg = mock.Mock(spec=kombu.Message)
         msg.delivery_info = {
             "routing_key": "routing-key",
@@ -56,28 +66,70 @@ class TestKombuMessageHandler:
             "delivery_tag": "delivery-tag",
             "exchange": "exchange",
         }
+        msg.channel.connection.client = connection
         msg.decode.return_value = {"foo": "bar"}
         return msg
 
     def test_handle(self, context, span, baseplate, name, message):
         handler_fn = mock.Mock()
         handler = KombuMessageHandler(baseplate, name, handler_fn)
-        handler.handle(message)
-        baseplate.make_context_object.assert_called_once()
-        baseplate.make_server_span.assert_called_once_with(context, name)
-        baseplate.make_server_span().__enter__.assert_called_once()
-        span.set_tag.assert_has_calls(
-            [
-                mock.call("kind", "consumer"),
-                mock.call("amqp.routing_key", "routing-key"),
-                mock.call("amqp.consumer_tag", "consumer-tag"),
-                mock.call("amqp.delivery_tag", "delivery-tag"),
-                mock.call("amqp.exchange", "exchange"),
-            ],
-            any_order=True,
+        prom_labels = AmqpConsumerPrometheusLabels(
+            amqp_address="hostname:port",
+            amqp_virtual_host="/",
+            amqp_exchange="exchange",
+            amqp_routing_key="routing-key",
         )
-        handler_fn.assert_called_once_with(context, message.decode(), message)
-        message.ack.assert_called_once()
+        mock_manager = mock.Mock()
+        with mock.patch.object(
+            AMQP_ACTIVE_MESSAGES.labels(**prom_labels._asdict()),
+            "inc",
+            wraps=AMQP_ACTIVE_MESSAGES.labels(**prom_labels._asdict()).inc,
+        ) as active_inc_spy_method:
+            mock_manager.attach_mock(active_inc_spy_method, "inc")
+            with mock.patch.object(
+                AMQP_ACTIVE_MESSAGES.labels(**prom_labels._asdict()),
+                "dec",
+                wraps=AMQP_ACTIVE_MESSAGES.labels(**prom_labels._asdict()).dec,
+            ) as active_dec_spy_method:
+                mock_manager.attach_mock(active_dec_spy_method, "dec")
+                handler.handle(message)
+
+                baseplate.make_context_object.assert_called_once()
+                baseplate.make_server_span.assert_called_once_with(context, name)
+                baseplate.make_server_span().__enter__.assert_called_once()
+                span.set_tag.assert_has_calls(
+                    [
+                        mock.call("kind", "consumer"),
+                        mock.call("amqp.routing_key", "routing-key"),
+                        mock.call("amqp.consumer_tag", "consumer-tag"),
+                        mock.call("amqp.delivery_tag", "delivery-tag"),
+                        mock.call("amqp.exchange", "exchange"),
+                    ],
+                    any_order=True,
+                )
+                handler_fn.assert_called_once_with(context, message.decode(), message)
+                message.ack.assert_called_once()
+                assert (
+                    REGISTRY.get_sample_value(
+                        f"{AMQP_PROCESSING_TIME._name}_bucket",
+                        {**prom_labels._asdict(), **{"amqp_success": "true", "le": "+Inf"}},
+                    )
+                    == 1
+                )
+                assert (
+                    REGISTRY.get_sample_value(
+                        f"{AMQP_PROCESSED_TOTAL._name}_total",
+                        {**prom_labels._asdict(), **{"amqp_success": "true"}},
+                    )
+                    == 1
+                )
+                assert (
+                    REGISTRY.get_sample_value(
+                        f"{AMQP_ACTIVE_MESSAGES._name}", prom_labels._asdict()
+                    )
+                    == 0
+                )
+                assert mock_manager.mock_calls == [mock.call.inc(), mock.call.dec()]
 
     @pytest.mark.parametrize(
         "err,expectation",
@@ -90,10 +142,52 @@ class TestKombuMessageHandler:
         def handler_fn(ctx, body, msg):
             raise err
 
-        handler = KombuMessageHandler(baseplate, name, handler_fn)
-        with expectation:
-            handler.handle(message)
-        message.requeue.assert_called_once()
+        prom_labels = AmqpConsumerPrometheusLabels(
+            amqp_address="hostname:port",
+            amqp_virtual_host="/",
+            amqp_exchange="exchange",
+            amqp_routing_key="routing-key",
+        )
+        mock_manager = mock.Mock()
+        with mock.patch.object(
+            AMQP_ACTIVE_MESSAGES.labels(**prom_labels._asdict()),
+            "inc",
+            wraps=AMQP_ACTIVE_MESSAGES.labels(**prom_labels._asdict()).inc,
+        ) as active_inc_spy_method:
+            mock_manager.attach_mock(active_inc_spy_method, "inc")
+            with mock.patch.object(
+                AMQP_ACTIVE_MESSAGES.labels(**prom_labels._asdict()),
+                "dec",
+                wraps=AMQP_ACTIVE_MESSAGES.labels(**prom_labels._asdict()).dec,
+            ) as active_dec_spy_method:
+                mock_manager.attach_mock(active_dec_spy_method, "dec")
+                handler = KombuMessageHandler(baseplate, name, handler_fn)
+                with expectation:
+                    handler.handle(message)
+                message.requeue.assert_called_once()
+
+                assert (
+                    REGISTRY.get_sample_value(
+                        f"{AMQP_PROCESSING_TIME._name}_bucket",
+                        {**prom_labels._asdict(), **{"amqp_success": "false", "le": "+Inf"}},
+                    )
+                    == 1
+                )
+                assert (
+                    REGISTRY.get_sample_value(
+                        f"{AMQP_PROCESSED_TOTAL._name}_total",
+                        {**prom_labels._asdict(), **{"amqp_success": "false"}},
+                    )
+                    == 1
+                )
+                assert (
+                    REGISTRY.get_sample_value(
+                        f"{AMQP_ACTIVE_MESSAGES._name}", prom_labels._asdict()
+                    )
+                    == 0
+                )
+                # we need to assert that not only the end result is 0, but that we increased and then decreased to that value
+                assert mock_manager.mock_calls == [mock.call.inc(), mock.call.dec()]
 
     @pytest.mark.parametrize(
         "err,expectation",
@@ -110,17 +204,60 @@ class TestKombuMessageHandler:
 
         error_handler_fn = mock.Mock()
 
-        handler = KombuMessageHandler(baseplate, name, handler_fn, error_handler_fn)
-        with expectation:
-            handler.handle(message)
-        error_handler_fn.assert_called_once_with(context, message.decode(), message, err)
-        message.ack.assert_not_called()
-        message.requeue.assert_not_called()
+        prom_labels = AmqpConsumerPrometheusLabels(
+            amqp_address="hostname:port",
+            amqp_virtual_host="/",
+            amqp_exchange="exchange",
+            amqp_routing_key="routing-key",
+        )
+        mock_manager = mock.Mock()
+        with mock.patch.object(
+            AMQP_ACTIVE_MESSAGES.labels(**prom_labels._asdict()),
+            "inc",
+            wraps=AMQP_ACTIVE_MESSAGES.labels(**prom_labels._asdict()).inc,
+        ) as active_inc_spy_method:
+            mock_manager.attach_mock(active_inc_spy_method, "inc")
+            with mock.patch.object(
+                AMQP_ACTIVE_MESSAGES.labels(**prom_labels._asdict()),
+                "dec",
+                wraps=AMQP_ACTIVE_MESSAGES.labels(**prom_labels._asdict()).dec,
+            ) as active_dec_spy_method:
+                mock_manager.attach_mock(active_dec_spy_method, "dec")
+
+                handler = KombuMessageHandler(baseplate, name, handler_fn, error_handler_fn)
+                with expectation:
+                    handler.handle(message)
+                error_handler_fn.assert_called_once_with(context, message.decode(), message, err)
+                message.ack.assert_not_called()
+                message.requeue.assert_not_called()
+
+                assert (
+                    REGISTRY.get_sample_value(
+                        f"{AMQP_PROCESSING_TIME._name}_bucket",
+                        {**prom_labels._asdict(), **{"amqp_success": "false", "le": "+Inf"}},
+                    )
+                    == 1
+                )
+                assert (
+                    REGISTRY.get_sample_value(
+                        f"{AMQP_PROCESSED_TOTAL._name}_total",
+                        {**prom_labels._asdict(), **{"amqp_success": "false"}},
+                    )
+                    == 1
+                )
+                assert (
+                    REGISTRY.get_sample_value(
+                        f"{AMQP_ACTIVE_MESSAGES._name}", prom_labels._asdict()
+                    )
+                    == 0
+                )
+                # we need to assert that not only the end result is 0, but that we increased and then decreased to that value
+                assert mock_manager.mock_calls == [mock.call.inc(), mock.call.dec()]
 
 
 @pytest.fixture
 def connection():
-    return mock.Mock(spec=kombu.Connection)
+    return mock.Mock(spec=kombu.Connection, virtual_host="/", host="hostname:port")
 
 
 @pytest.fixture

--- a/tests/unit/frameworks/queue_consumer/kombu_tests.py
+++ b/tests/unit/frameworks/queue_consumer/kombu_tests.py
@@ -76,7 +76,7 @@ class TestKombuMessageHandler:
         prom_labels = AmqpConsumerPrometheusLabels(
             amqp_address="hostname:port",
             amqp_virtual_host="/",
-            amqp_exchange="exchange",
+            amqp_exchange_name="exchange",
             amqp_routing_key="routing-key",
         )
         mock_manager = mock.Mock()
@@ -145,7 +145,7 @@ class TestKombuMessageHandler:
         prom_labels = AmqpConsumerPrometheusLabels(
             amqp_address="hostname:port",
             amqp_virtual_host="/",
-            amqp_exchange="exchange",
+            amqp_exchange_name="exchange",
             amqp_routing_key="routing-key",
         )
         mock_manager = mock.Mock()
@@ -207,7 +207,7 @@ class TestKombuMessageHandler:
         prom_labels = AmqpConsumerPrometheusLabels(
             amqp_address="hostname:port",
             amqp_virtual_host="/",
-            amqp_exchange="exchange",
+            amqp_exchange_name="exchange",
             amqp_routing_key="routing-key",
         )
         mock_manager = mock.Mock()


### PR DESCRIPTION
## 🧪 Testing Steps / Validation
```
# HELP amqp_consumer_messages_processed_total Multiprocess metric
# TYPE amqp_consumer_messages_processed_total counter
amqp_consumer_messages_processed_total{amqp_address="my_endpoint:5672",amqp_exchange="test",amqp_routing_key="123",amqp_success="true",amqp_virtual_host="/"} 2.0
# HELP amqp_consumer_message_processing_time_seconds Multiprocess metric
# TYPE amqp_consumer_message_processing_time_seconds histogram
amqp_consumer_message_processing_time_seconds_sum{amqp_address="my_endpoint:5672",amqp_exchange="test",amqp_routing_key="123",amqp_success="true",amqp_virtual_host="/"} 1.0073855299999999
amqp_consumer_message_processing_time_seconds_bucket{amqp_address="my_endpoint:5672",amqp_exchange="test",amqp_routing_key="123",amqp_success="true",amqp_virtual_host="/",le="0.0001"} 0.0
amqp_consumer_message_processing_time_seconds_bucket{amqp_address="my_endpoint:5672",amqp_exchange="test",amqp_routing_key="123",amqp_success="true",amqp_virtual_host="/",le="0.00025"} 0.0
amqp_consumer_message_processing_time_seconds_bucket{amqp_address="my_endpoint:5672",amqp_exchange="test",amqp_routing_key="123",amqp_success="true",amqp_virtual_host="/",le="0.000625"} 0.0
amqp_consumer_message_processing_time_seconds_bucket{amqp_address="my_endpoint:5672",amqp_exchange="test",amqp_routing_key="123",amqp_success="true",amqp_virtual_host="/",le="0.0015625"} 0.0
amqp_consumer_message_processing_time_seconds_bucket{amqp_address="my_endpoint:5672",amqp_exchange="test",amqp_routing_key="123",amqp_success="true",amqp_virtual_host="/",le="0.00390625"} 0.0
amqp_consumer_message_processing_time_seconds_bucket{amqp_address="my_endpoint:5672",amqp_exchange="test",amqp_routing_key="123",amqp_success="true",amqp_virtual_host="/",le="0.009765625"} 0.0
amqp_consumer_message_processing_time_seconds_bucket{amqp_address="my_endpoint:5672",amqp_exchange="test",amqp_routing_key="123",amqp_success="true",amqp_virtual_host="/",le="0.0244140625"} 0.0
amqp_consumer_message_processing_time_seconds_bucket{amqp_address="my_endpoint:5672",amqp_exchange="test",amqp_routing_key="123",amqp_success="true",amqp_virtual_host="/",le="0.06103515625"} 0.0
amqp_consumer_message_processing_time_seconds_bucket{amqp_address="my_endpoint:5672",amqp_exchange="test",amqp_routing_key="123",amqp_success="true",amqp_virtual_host="/",le="0.152587890625"} 0.0
amqp_consumer_message_processing_time_seconds_bucket{amqp_address="my_endpoint:5672",amqp_exchange="test",amqp_routing_key="123",amqp_success="true",amqp_virtual_host="/",le="0.3814697265625"} 0.0
amqp_consumer_message_processing_time_seconds_bucket{amqp_address="my_endpoint:5672",amqp_exchange="test",amqp_routing_key="123",amqp_success="true",amqp_virtual_host="/",le="0.95367431640625"} 2.0
amqp_consumer_message_processing_time_seconds_bucket{amqp_address="my_endpoint:5672",amqp_exchange="test",amqp_routing_key="123",amqp_success="true",amqp_virtual_host="/",le="2.384185791015625"} 2.0
amqp_consumer_message_processing_time_seconds_bucket{amqp_address="my_endpoint:5672",amqp_exchange="test",amqp_routing_key="123",amqp_success="true",amqp_virtual_host="/",le="5.9604644775390625"} 2.0
amqp_consumer_message_processing_time_seconds_bucket{amqp_address="my_endpoint:5672",amqp_exchange="test",amqp_routing_key="123",amqp_success="true",amqp_virtual_host="/",le="14.901161193847656"} 2.0
amqp_consumer_message_processing_time_seconds_bucket{amqp_address="my_endpoint:5672",amqp_exchange="test",amqp_routing_key="123",amqp_success="true",amqp_virtual_host="/",le="+Inf"} 2.0
amqp_consumer_message_processing_time_seconds_count{amqp_address="my_endpoint:5672",amqp_exchange="test",amqp_routing_key="123",amqp_success="true",amqp_virtual_host="/"} 2.0
# HELP amqp_consumer_active_messages Multiprocess metric
# TYPE amqp_consumer_active_messages gauge
amqp_consumer_active_messages{amqp_address="my_endpoint:5672",amqp_exchange="test",amqp_routing_key="123",amqp_virtual_host="/",pid="43989"} 0.0
```

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] CI tests (if present) are passing
- [x] Adheres to code style for repo
- [x] Contributor License Agreement (CLA) completed if not a Reddit employee
