### PR TITLE
[BASE-60] Implement prometheus metric for kafka queue consumer

### DIFF
--- a/baseplate/frameworks/queue_consumer/kafka.py
+++ b/baseplate/frameworks/queue_consumer/kafka.py
@@ -8,6 +8,7 @@ from typing import Any
 from typing import Callable
 from typing import Dict
 from typing import List
+from typing import NamedTuple
 from typing import Optional
 from typing import Sequence
 from typing import TYPE_CHECKING
@@ -15,9 +16,13 @@ from typing import TYPE_CHECKING
 import confluent_kafka
 
 from gevent.server import StreamServer
+from prometheus_client import Counter
+from prometheus_client import Gauge
+from prometheus_client import Histogram
 
 from baseplate import Baseplate
 from baseplate import RequestContext
+from baseplate.lib.prometheus_metrics import default_latency_buckets
 from baseplate.server.queue_consumer import HealthcheckCallback
 from baseplate.server.queue_consumer import make_simple_healthchecker
 from baseplate.server.queue_consumer import MessageHandler
@@ -36,6 +41,31 @@ logger = logging.getLogger(__name__)
 
 KafkaMessageDeserializer = Callable[[bytes], Any]
 Handler = Callable[[RequestContext, Any, confluent_kafka.Message], None]
+
+
+class KafkaConsumerPrometheusLabels(NamedTuple):
+    kafka_address: str
+    kafka_topic: str
+
+
+KAFKA_PROCESSING_TIME = Histogram(
+    "kafka_consumer_message_processing_time_seconds",
+    "latency histogram of how long it takes to process a message",
+    KafkaConsumerPrometheusLabels._fields + ("kafka_success",),
+    buckets=default_latency_buckets,
+)
+
+KAFKA_PROCESSED_TOTAL = Counter(
+    "kafka_consumer_messages_processed_total",
+    "total count of messages processed by this host",
+    KafkaConsumerPrometheusLabels._fields + ("kafka_success",),
+)
+
+KAFKA_ACTIVE_MESSAGES = Gauge(
+    "kafka_consumer_active_messages",
+    "gauge that reflects the number of messages currently being processed",
+    KafkaConsumerPrometheusLabels._fields,
+)
 
 
 class KafkaConsumerWorker(PumpWorker):
@@ -99,14 +129,26 @@ class KafkaMessageHandler(MessageHandler):
         handler_fn: Handler,
         message_unpack_fn: KafkaMessageDeserializer,
         on_success_fn: Optional[Handler] = None,
+        bootstrap_servers: str = "",
     ):
         self.baseplate = baseplate
         self.name = name
         self.handler_fn = handler_fn
         self.message_unpack_fn = message_unpack_fn
         self.on_success_fn = on_success_fn
+        # as far as I can tell, there is no way to extract the bootstrap servers from the
+        # consumer or the message itself. So wee need to have it passed from the parent
+        self.bootstrap_servers = bootstrap_servers
 
     def handle(self, message: confluent_kafka.Message) -> None:
+        logger.error("handling stuff")
+        prom_labels = KafkaConsumerPrometheusLabels(
+            kafka_address=self.bootstrap_servers,
+            kafka_topic=message.topic() if message.topic() is not None else "",
+        )
+        prom_success = "true"
+        start_time = time.perf_counter()
+        KAFKA_ACTIVE_MESSAGES.labels(**prom_labels._asdict()).inc()
         context = self.baseplate.make_context_object()
         try:
             # We place the call to ``baseplate.make_server_span`` inside the
@@ -115,6 +157,7 @@ class KafkaMessageHandler(MessageHandler):
             with self.baseplate.make_server_span(context, f"{self.name}.handler") as span:
                 error = message.error()
                 if error:
+                    prom_success = "false"
                     # this isn't a real message, but is an error from Kafka
                     raise ValueError(f"KafkaError: {error.str()}")
 
@@ -134,6 +177,7 @@ class KafkaMessageHandler(MessageHandler):
                 try:
                     data = self.message_unpack_fn(blob)
                 except Exception:
+                    prom_success = "false"
                     logger.error("skipping invalid message")
                     context.span.incr_tag(f"{self.name}.{topic}.invalid_message")
                     return
@@ -158,6 +202,7 @@ class KafkaMessageHandler(MessageHandler):
 
                 context.metrics.gauge(f"{self.name}.{topic}.offset.{partition}").replace(offset)
         except Exception:
+            prom_success = "false"
             # let this exception crash the server so we'll stop processing messages
             # and won't commit offsets. when the server restarts it will get
             # this message again and try to process it.
@@ -165,6 +210,13 @@ class KafkaMessageHandler(MessageHandler):
                 "Unhandled error while trying to process a message, terminating the server"
             )
             raise
+        finally:
+            logger.error(prom_labels)
+            KAFKA_PROCESSING_TIME.labels(
+                **prom_labels._asdict(), kafka_success=prom_success
+            ).observe(time.perf_counter() - start_time)
+            KAFKA_PROCESSED_TOTAL.labels(**prom_labels._asdict(), kafka_success=prom_success).inc()
+            KAFKA_ACTIVE_MESSAGES.labels(**prom_labels._asdict()).dec()
 
 
 class _BaseKafkaQueueConsumerFactory(QueueConsumerFactory):
@@ -177,6 +229,7 @@ class _BaseKafkaQueueConsumerFactory(QueueConsumerFactory):
         kafka_consume_batch_size: int = 1,
         message_unpack_fn: KafkaMessageDeserializer = json.loads,
         health_check_fn: Optional[HealthcheckCallback] = None,
+        bootstrap_servers: str = "",
     ):
         """`_BaseKafkaQueueConsumerFactory` constructor.
 
@@ -191,6 +244,8 @@ class _BaseKafkaQueueConsumerFactory(QueueConsumerFactory):
             and returns the message in the format the handler expects. Defaults to `json.loads`.
         :param health_check_fn: A `baseplate.server.queue_consumer.HealthcheckCallback`
             function that can be used to customize your health check.
+        :param bootstrap_servers: The bootstrap servers used to create the consumer. Used for
+            prometheus labels.
 
         """
         self.name = name
@@ -200,6 +255,7 @@ class _BaseKafkaQueueConsumerFactory(QueueConsumerFactory):
         self.kafka_consume_batch_size = kafka_consume_batch_size
         self.message_unpack_fn = message_unpack_fn
         self.health_check_fn = health_check_fn
+        self.bootstrap_servers = bootstrap_servers
 
     @classmethod
     def new(
@@ -255,6 +311,7 @@ class _BaseKafkaQueueConsumerFactory(QueueConsumerFactory):
             kafka_consume_batch_size=kafka_consume_batch_size,
             message_unpack_fn=message_unpack_fn,
             health_check_fn=health_check_fn,
+            bootstrap_servers=bootstrap_servers,
         )
 
     @classmethod
@@ -324,7 +381,11 @@ class _BaseKafkaQueueConsumerFactory(QueueConsumerFactory):
 
     def build_message_handler(self) -> KafkaMessageHandler:
         return KafkaMessageHandler(
-            self.baseplate, self.name, self.handler_fn, self.message_unpack_fn
+            self.baseplate,
+            self.name,
+            self.handler_fn,
+            self.message_unpack_fn,
+            bootstrap_servers=self.bootstrap_servers,
         )
 
     def build_health_checker(self, listener: socket.socket) -> StreamServer:
@@ -402,6 +463,11 @@ class InOrderConsumerFactory(_BaseKafkaQueueConsumerFactory):
             with context.span.make_child("kafka.commit"):
                 self.consumer.commit(message=message, asynchronous=False)
 
+        logger.error(self.consumer)
+        logger.error(type(self.consumer))
+        logger.error(dir(self.consumer))
+        # logger.error(self.consumer.assignment())
+        # logger.error(self.consumer.consumer_group_metadata())
         return KafkaMessageHandler(
             self.baseplate,
             self.name,
@@ -409,6 +475,7 @@ class InOrderConsumerFactory(_BaseKafkaQueueConsumerFactory):
             self.message_unpack_fn,
             # commit offset after each successful message handle()
             on_success_fn=commit_offset,
+            bootstrap_servers=self.bootstrap_servers,
         )
 
 

--- a/baseplate/frameworks/queue_consumer/kafka.py
+++ b/baseplate/frameworks/queue_consumer/kafka.py
@@ -137,11 +137,10 @@ class KafkaMessageHandler(MessageHandler):
         self.message_unpack_fn = message_unpack_fn
         self.on_success_fn = on_success_fn
         # as far as I can tell, there is no way to extract the bootstrap servers from the
-        # consumer or the message itself. So wee need to have it passed from the parent
+        # consumer or the message itself. So we need to have it passed from the parent
         self.bootstrap_servers = bootstrap_servers
 
     def handle(self, message: confluent_kafka.Message) -> None:
-        logger.error("handling stuff")
         prom_labels = KafkaConsumerPrometheusLabels(
             kafka_address=self.bootstrap_servers,
             kafka_topic=message.topic() if message.topic() is not None else "",
@@ -211,7 +210,6 @@ class KafkaMessageHandler(MessageHandler):
             )
             raise
         finally:
-            logger.error(prom_labels)
             KAFKA_PROCESSING_TIME.labels(
                 **prom_labels._asdict(), kafka_success=prom_success
             ).observe(time.perf_counter() - start_time)
@@ -463,11 +461,6 @@ class InOrderConsumerFactory(_BaseKafkaQueueConsumerFactory):
             with context.span.make_child("kafka.commit"):
                 self.consumer.commit(message=message, asynchronous=False)
 
-        logger.error(self.consumer)
-        logger.error(type(self.consumer))
-        logger.error(dir(self.consumer))
-        # logger.error(self.consumer.assignment())
-        # logger.error(self.consumer.consumer_group_metadata())
         return KafkaMessageHandler(
             self.baseplate,
             self.name,

--- a/tests/unit/frameworks/queue_consumer/kafka_tests.py
+++ b/tests/unit/frameworks/queue_consumer/kafka_tests.py
@@ -7,12 +7,17 @@ import confluent_kafka
 import pytest
 
 from gevent.server import StreamServer
+from prometheus_client import REGISTRY
 
 from baseplate import Baseplate
 from baseplate import RequestContext
 from baseplate import ServerSpan
 from baseplate.frameworks.queue_consumer.kafka import FastConsumerFactory
 from baseplate.frameworks.queue_consumer.kafka import InOrderConsumerFactory
+from baseplate.frameworks.queue_consumer.kafka import KAFKA_ACTIVE_MESSAGES
+from baseplate.frameworks.queue_consumer.kafka import KAFKA_PROCESSED_TOTAL
+from baseplate.frameworks.queue_consumer.kafka import KAFKA_PROCESSING_TIME
+from baseplate.frameworks.queue_consumer.kafka import KafkaConsumerPrometheusLabels
 from baseplate.frameworks.queue_consumer.kafka import KafkaConsumerWorker
 from baseplate.frameworks.queue_consumer.kafka import KafkaMessageHandler
 from baseplate.lib import metrics
@@ -50,6 +55,11 @@ def name():
 
 
 class TestKafkaMessageHandler:
+    def setup(self):
+        KAFKA_PROCESSING_TIME.clear()
+        KAFKA_PROCESSED_TOTAL.clear()
+        KAFKA_ACTIVE_MESSAGES.clear()
+
     @pytest.fixture
     def message(self):
         msg = mock.Mock(spec=confluent_kafka.Message)
@@ -63,8 +73,15 @@ class TestKafkaMessageHandler:
         return msg
 
     @mock.patch("baseplate.frameworks.queue_consumer.kafka.time")
-    def test_handle(self, time, context, span, baseplate, name, message):
+    @pytest.mark.parametrize("bootstrap_servers", [None, "127.0.0.1:9092"])
+    def test_handle(self, time, context, span, baseplate, name, message, bootstrap_servers):
         time.time.return_value = 2.0
+        time.perf_counter.side_effect = [1, 2]
+
+        prom_labels = KafkaConsumerPrometheusLabels(
+            kafka_address=bootstrap_servers if bootstrap_servers is not None else "",
+            kafka_topic="topic_1",
+        )
 
         handler_fn = mock.Mock()
         message_unpack_fn = mock.Mock(
@@ -78,8 +95,35 @@ class TestKafkaMessageHandler:
         mock_gauge = mock.Mock()
         context.metrics.gauge.return_value = mock_gauge
 
-        handler = KafkaMessageHandler(baseplate, name, handler_fn, message_unpack_fn, on_success_fn)
-        handler.handle(message)
+        mock_manager = mock.Mock()
+        with mock.patch.object(
+            KAFKA_ACTIVE_MESSAGES.labels(**prom_labels._asdict()),
+            "inc",
+            wraps=KAFKA_ACTIVE_MESSAGES.labels(**prom_labels._asdict()).inc,
+        ) as active_inc_spy_method:
+            mock_manager.attach_mock(active_inc_spy_method, "inc")
+            with mock.patch.object(
+                KAFKA_ACTIVE_MESSAGES.labels(**prom_labels._asdict()),
+                "dec",
+                wraps=KAFKA_ACTIVE_MESSAGES.labels(**prom_labels._asdict()).dec,
+            ) as active_dec_spy_method:
+                mock_manager.attach_mock(active_dec_spy_method, "dec")
+
+                if bootstrap_servers is None:
+                    handler = KafkaMessageHandler(
+                        baseplate, name, handler_fn, message_unpack_fn, on_success_fn
+                    )
+                else:
+                    handler = KafkaMessageHandler(
+                        baseplate,
+                        name,
+                        handler_fn,
+                        message_unpack_fn,
+                        on_success_fn,
+                        bootstrap_servers=bootstrap_servers,
+                    )
+                handler.handle(message)
+
         baseplate.make_context_object.assert_called_once()
         baseplate.make_server_span.assert_called_once_with(context, f"{name}.handler")
         baseplate.make_server_span().__enter__.assert_called_once()
@@ -108,6 +152,25 @@ class TestKafkaMessageHandler:
         context.metrics.gauge.assert_called_once_with(f"{name}.topic_1.offset.3")
         mock_gauge.replace.assert_called_once_with(33)
 
+        assert (
+            REGISTRY.get_sample_value(
+                f"{KAFKA_PROCESSING_TIME._name}_bucket",
+                {**prom_labels._asdict(), **{"kafka_success": "true", "le": "+Inf"}},
+            )
+            == 1
+        )
+        assert (
+            REGISTRY.get_sample_value(
+                f"{KAFKA_PROCESSED_TOTAL._name}_total",
+                {**prom_labels._asdict(), **{"kafka_success": "true"}},
+            )
+            == 1
+        )
+        assert (
+            REGISTRY.get_sample_value(f"{KAFKA_ACTIVE_MESSAGES._name}", prom_labels._asdict()) == 0
+        )
+        assert mock_manager.mock_calls == [mock.call.inc(), mock.call.dec()]
+
     def test_handle_no_endpoint_timestamp(self, context, span, baseplate, name, message):
         handler_fn = mock.Mock()
         message_unpack_fn = mock.Mock(return_value={"body": "some text"})
@@ -116,8 +179,30 @@ class TestKafkaMessageHandler:
         mock_gauge = mock.Mock()
         context.metrics.gauge.return_value = mock_gauge
 
-        handler = KafkaMessageHandler(baseplate, name, handler_fn, message_unpack_fn, on_success_fn)
-        handler.handle(message)
+        prom_labels = KafkaConsumerPrometheusLabels(
+            kafka_address="",
+            kafka_topic="topic_1",
+        )
+
+        mock_manager = mock.Mock()
+        with mock.patch.object(
+            KAFKA_ACTIVE_MESSAGES.labels(**prom_labels._asdict()),
+            "inc",
+            wraps=KAFKA_ACTIVE_MESSAGES.labels(**prom_labels._asdict()).inc,
+        ) as active_inc_spy_method:
+            mock_manager.attach_mock(active_inc_spy_method, "inc")
+            with mock.patch.object(
+                KAFKA_ACTIVE_MESSAGES.labels(**prom_labels._asdict()),
+                "dec",
+                wraps=KAFKA_ACTIVE_MESSAGES.labels(**prom_labels._asdict()).dec,
+            ) as active_dec_spy_method:
+                mock_manager.attach_mock(active_dec_spy_method, "dec")
+
+                handler = KafkaMessageHandler(
+                    baseplate, name, handler_fn, message_unpack_fn, on_success_fn
+                )
+                handler.handle(message)
+
         baseplate.make_context_object.assert_called_once()
         baseplate.make_server_span.assert_called_once_with(context, f"{name}.handler")
         baseplate.make_server_span().__enter__.assert_called_once()
@@ -141,6 +226,25 @@ class TestKafkaMessageHandler:
         context.metrics.gauge.assert_called_once_with(f"{name}.topic_1.offset.3")
         mock_gauge.replace.assert_called_once_with(33)
 
+        assert (
+            REGISTRY.get_sample_value(
+                f"{KAFKA_PROCESSING_TIME._name}_bucket",
+                {**prom_labels._asdict(), **{"kafka_success": "true", "le": "+Inf"}},
+            )
+            == 1
+        )
+        assert (
+            REGISTRY.get_sample_value(
+                f"{KAFKA_PROCESSED_TOTAL._name}_total",
+                {**prom_labels._asdict(), **{"kafka_success": "true"}},
+            )
+            == 1
+        )
+        assert (
+            REGISTRY.get_sample_value(f"{KAFKA_ACTIVE_MESSAGES._name}", prom_labels._asdict()) == 0
+        )
+        assert mock_manager.mock_calls == [mock.call.inc(), mock.call.dec()]
+
     def test_handle_kafka_error(self, context, span, baseplate, name, message):
         handler_fn = mock.Mock()
         message_unpack_fn = mock.Mock()
@@ -153,8 +257,26 @@ class TestKafkaMessageHandler:
 
         handler = KafkaMessageHandler(baseplate, name, handler_fn, message_unpack_fn, on_success_fn)
 
-        with pytest.raises(ValueError):
-            handler.handle(message)
+        prom_labels = KafkaConsumerPrometheusLabels(
+            kafka_address="",
+            kafka_topic="topic_1",
+        )
+
+        mock_manager = mock.Mock()
+        with mock.patch.object(
+            KAFKA_ACTIVE_MESSAGES.labels(**prom_labels._asdict()),
+            "inc",
+            wraps=KAFKA_ACTIVE_MESSAGES.labels(**prom_labels._asdict()).inc,
+        ) as active_inc_spy_method:
+            mock_manager.attach_mock(active_inc_spy_method, "inc")
+            with mock.patch.object(
+                KAFKA_ACTIVE_MESSAGES.labels(**prom_labels._asdict()),
+                "dec",
+                wraps=KAFKA_ACTIVE_MESSAGES.labels(**prom_labels._asdict()).dec,
+            ) as active_dec_spy_method:
+                mock_manager.attach_mock(active_dec_spy_method, "dec")
+                with pytest.raises(ValueError):
+                    handler.handle(message)
 
         baseplate.make_context_object.assert_called_once()
         baseplate.make_server_span.assert_called_once_with(context, f"{name}.handler")
@@ -166,6 +288,25 @@ class TestKafkaMessageHandler:
         context.metrics.timer.assert_not_called()
         context.metrics.gauge.assert_not_called()
 
+        assert (
+            REGISTRY.get_sample_value(
+                f"{KAFKA_PROCESSING_TIME._name}_bucket",
+                {**prom_labels._asdict(), **{"kafka_success": "false", "le": "+Inf"}},
+            )
+            == 1
+        )
+        assert (
+            REGISTRY.get_sample_value(
+                f"{KAFKA_PROCESSED_TOTAL._name}_total",
+                {**prom_labels._asdict(), **{"kafka_success": "false"}},
+            )
+            == 1
+        )
+        assert (
+            REGISTRY.get_sample_value(f"{KAFKA_ACTIVE_MESSAGES._name}", prom_labels._asdict()) == 0
+        )
+        assert mock_manager.mock_calls == [mock.call.inc(), mock.call.dec()]
+
     def test_handle_unpack_error(self, context, span, baseplate, name, message):
         handler_fn = mock.Mock()
         message_unpack_fn = mock.Mock(side_effect=ValueError("something bad happened"))
@@ -174,7 +315,27 @@ class TestKafkaMessageHandler:
         context.span = span
 
         handler = KafkaMessageHandler(baseplate, name, handler_fn, message_unpack_fn, on_success_fn)
-        handler.handle(message)
+
+        prom_labels = KafkaConsumerPrometheusLabels(
+            kafka_address="",
+            kafka_topic="topic_1",
+        )
+
+        mock_manager = mock.Mock()
+        with mock.patch.object(
+            KAFKA_ACTIVE_MESSAGES.labels(**prom_labels._asdict()),
+            "inc",
+            wraps=KAFKA_ACTIVE_MESSAGES.labels(**prom_labels._asdict()).inc,
+        ) as active_inc_spy_method:
+            mock_manager.attach_mock(active_inc_spy_method, "inc")
+            with mock.patch.object(
+                KAFKA_ACTIVE_MESSAGES.labels(**prom_labels._asdict()),
+                "dec",
+                wraps=KAFKA_ACTIVE_MESSAGES.labels(**prom_labels._asdict()).dec,
+            ) as active_dec_spy_method:
+                mock_manager.attach_mock(active_dec_spy_method, "dec")
+                handler.handle(message)
+
         baseplate.make_context_object.assert_called_once()
         baseplate.make_server_span.assert_called_once_with(context, f"{name}.handler")
         baseplate.make_server_span().__enter__.assert_called_once()
@@ -196,6 +357,25 @@ class TestKafkaMessageHandler:
         context.metrics.timer.assert_not_called()
         context.metrics.gauge.assert_not_called()
 
+        assert (
+            REGISTRY.get_sample_value(
+                f"{KAFKA_PROCESSING_TIME._name}_bucket",
+                {**prom_labels._asdict(), **{"kafka_success": "false", "le": "+Inf"}},
+            )
+            == 1
+        )
+        assert (
+            REGISTRY.get_sample_value(
+                f"{KAFKA_PROCESSED_TOTAL._name}_total",
+                {**prom_labels._asdict(), **{"kafka_success": "false"}},
+            )
+            == 1
+        )
+        assert (
+            REGISTRY.get_sample_value(f"{KAFKA_ACTIVE_MESSAGES._name}", prom_labels._asdict()) == 0
+        )
+        assert mock_manager.mock_calls == [mock.call.inc(), mock.call.dec()]
+
     def test_handle_handler_error(self, context, span, baseplate, name, message):
         handler_fn = mock.Mock(side_effect=ValueError("something went wrong"))
         message_unpack_fn = mock.Mock(
@@ -205,8 +385,26 @@ class TestKafkaMessageHandler:
 
         handler = KafkaMessageHandler(baseplate, name, handler_fn, message_unpack_fn, on_success_fn)
 
-        with pytest.raises(ValueError):
-            handler.handle(message)
+        prom_labels = KafkaConsumerPrometheusLabels(
+            kafka_address="",
+            kafka_topic="topic_1",
+        )
+
+        mock_manager = mock.Mock()
+        with mock.patch.object(
+            KAFKA_ACTIVE_MESSAGES.labels(**prom_labels._asdict()),
+            "inc",
+            wraps=KAFKA_ACTIVE_MESSAGES.labels(**prom_labels._asdict()).inc,
+        ) as active_inc_spy_method:
+            mock_manager.attach_mock(active_inc_spy_method, "inc")
+            with mock.patch.object(
+                KAFKA_ACTIVE_MESSAGES.labels(**prom_labels._asdict()),
+                "dec",
+                wraps=KAFKA_ACTIVE_MESSAGES.labels(**prom_labels._asdict()).dec,
+            ) as active_dec_spy_method:
+                mock_manager.attach_mock(active_dec_spy_method, "dec")
+                with pytest.raises(ValueError):
+                    handler.handle(message)
 
         baseplate.make_context_object.assert_called_once()
         baseplate.make_server_span.assert_called_once_with(context, f"{name}.handler")
@@ -229,6 +427,25 @@ class TestKafkaMessageHandler:
         on_success_fn.assert_not_called()
         context.metrics.timer.assert_not_called()
         context.metrics.gauge.assert_not_called()
+
+        assert (
+            REGISTRY.get_sample_value(
+                f"{KAFKA_PROCESSING_TIME._name}_bucket",
+                {**prom_labels._asdict(), **{"kafka_success": "false", "le": "+Inf"}},
+            )
+            == 1
+        )
+        assert (
+            REGISTRY.get_sample_value(
+                f"{KAFKA_PROCESSED_TOTAL._name}_total",
+                {**prom_labels._asdict(), **{"kafka_success": "false"}},
+            )
+            == 1
+        )
+        assert (
+            REGISTRY.get_sample_value(f"{KAFKA_ACTIVE_MESSAGES._name}", prom_labels._asdict()) == 0
+        )
+        assert mock_manager.mock_calls == [mock.call.inc(), mock.call.dec()]
 
 
 @pytest.fixture
@@ -368,7 +585,7 @@ class TestInOrderConsumerFactory:
         assert pump.consumer == factory.consumer
         assert pump.work_queue == work_queue
 
-    def test_build_message_handler(self, make_queue_consumer_factory):
+    def test_build_message_handler(self, make_queue_consumer_factory, bootstrap_servers):
         factory = make_queue_consumer_factory()
         handler = factory.build_message_handler()
         assert isinstance(handler, KafkaMessageHandler)
@@ -377,6 +594,7 @@ class TestInOrderConsumerFactory:
         assert handler.handler_fn == factory.handler_fn
         assert handler.message_unpack_fn == factory.message_unpack_fn
         assert handler.on_success_fn.__name__ == "commit_offset"
+        assert handler.bootstrap_servers == bootstrap_servers
 
     def test_build_multiple_message_handlers(self, make_queue_consumer_factory):
         factory = make_queue_consumer_factory()
@@ -487,7 +705,7 @@ class TestFastConsumerFactory:
     def make_queue_consumer_factory(self, name, baseplate, bootstrap_servers, group_id, topics):
         @mock.patch("confluent_kafka.Consumer")
         def _make_queue_consumer_factory(kafka_consumer, health_check_fn=None):
-            mock_consumer = mock.Mock()
+            mock_consumer = mock.Mock(config={"bootstrap_servers": bootstrap_servers})
             mock_consumer.list_topics.return_value = mock.Mock(
                 topics={"topic_1": mock.Mock(), "topic_2": mock.Mock(), "topic_3": mock.Mock()}
             )
@@ -514,7 +732,7 @@ class TestFastConsumerFactory:
         assert pump.consumer == factory.consumer
         assert pump.work_queue == work_queue
 
-    def test_build_message_handler(self, make_queue_consumer_factory):
+    def test_build_message_handler(self, make_queue_consumer_factory, bootstrap_servers):
         factory = make_queue_consumer_factory()
         handler = factory.build_message_handler()
         assert isinstance(handler, KafkaMessageHandler)
@@ -523,6 +741,7 @@ class TestFastConsumerFactory:
         assert handler.handler_fn == factory.handler_fn
         assert handler.message_unpack_fn == factory.message_unpack_fn
         assert handler.on_success_fn is None
+        assert handler.bootstrap_servers == bootstrap_servers
 
     @pytest.mark.parametrize("health_check_fn", [None, lambda req: True])
     def test_build_health_checker(self, health_check_fn, make_queue_consumer_factory):


### PR DESCRIPTION
## 🧪 Testing Steps / Validation
```
# HELP kafka_consumer_messages_processed_total Multiprocess metric
# TYPE kafka_consumer_messages_processed_total counter
kafka_consumer_messages_processed_total{kafka_address="127.0.0.1:9092",kafka_success="false",kafka_topic="test_topic"} 20.0
# HELP kafka_consumer_message_processing_time_seconds Multiprocess metric
# TYPE kafka_consumer_message_processing_time_seconds histogram
kafka_consumer_message_processing_time_seconds_sum{kafka_address="127.0.0.1:9092",kafka_success="false",kafka_topic="test_topic"} 0.007279703000002691
kafka_consumer_message_processing_time_seconds_bucket{kafka_address="127.0.0.1:9092",kafka_success="false",kafka_topic="test_topic",le="0.0001"} 0.0
kafka_consumer_message_processing_time_seconds_bucket{kafka_address="127.0.0.1:9092",kafka_success="false",kafka_topic="test_topic",le="0.00025"} 0.0
kafka_consumer_message_processing_time_seconds_bucket{kafka_address="127.0.0.1:9092",kafka_success="false",kafka_topic="test_topic",le="0.000625"} 19.0
kafka_consumer_message_processing_time_seconds_bucket{kafka_address="127.0.0.1:9092",kafka_success="false",kafka_topic="test_topic",le="0.0015625"} 20.0
kafka_consumer_message_processing_time_seconds_bucket{kafka_address="127.0.0.1:9092",kafka_success="false",kafka_topic="test_topic",le="0.00390625"} 20.0
kafka_consumer_message_processing_time_seconds_bucket{kafka_address="127.0.0.1:9092",kafka_success="false",kafka_topic="test_topic",le="0.009765625"} 20.0
kafka_consumer_message_processing_time_seconds_bucket{kafka_address="127.0.0.1:9092",kafka_success="false",kafka_topic="test_topic",le="0.0244140625"} 20.0
kafka_consumer_message_processing_time_seconds_bucket{kafka_address="127.0.0.1:9092",kafka_success="false",kafka_topic="test_topic",le="0.06103515625"} 20.0
kafka_consumer_message_processing_time_seconds_bucket{kafka_address="127.0.0.1:9092",kafka_success="false",kafka_topic="test_topic",le="0.152587890625"} 20.0
kafka_consumer_message_processing_time_seconds_bucket{kafka_address="127.0.0.1:9092",kafka_success="false",kafka_topic="test_topic",le="0.3814697265625"} 20.0
kafka_consumer_message_processing_time_seconds_bucket{kafka_address="127.0.0.1:9092",kafka_success="false",kafka_topic="test_topic",le="0.95367431640625"} 20.0
kafka_consumer_message_processing_time_seconds_bucket{kafka_address="127.0.0.1:9092",kafka_success="false",kafka_topic="test_topic",le="2.384185791015625"} 20.0
kafka_consumer_message_processing_time_seconds_bucket{kafka_address="127.0.0.1:9092",kafka_success="false",kafka_topic="test_topic",le="5.9604644775390625"} 20.0
kafka_consumer_message_processing_time_seconds_bucket{kafka_address="127.0.0.1:9092",kafka_success="false",kafka_topic="test_topic",le="14.901161193847656"} 20.0
kafka_consumer_message_processing_time_seconds_bucket{kafka_address="127.0.0.1:9092",kafka_success="false",kafka_topic="test_topic",le="+Inf"} 20.0
kafka_consumer_message_processing_time_seconds_count{kafka_address="127.0.0.1:9092",kafka_success="false",kafka_topic="test_topic"} 20.0
# HELP kafka_consumer_active_messages Multiprocess metric
# TYPE kafka_consumer_active_messages gauge
kafka_consumer_active_messages{kafka_address="127.0.0.1:9092",kafka_topic="test_topic",pid="58176"} 0.0
```

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] CI tests (if present) are passing
- [x] Adheres to code style for repo
- [x] Contributor License Agreement (CLA) completed if not a Reddit employee
