### PR TITLE
Make bp.py prom latency buckets match bp.go

### DIFF
--- a/baseplate/lib/prometheus_metrics.py
+++ b/baseplate/lib/prometheus_metrics.py
@@ -1,7 +1,7 @@
 # default_latency_buckets creates the default bucket values for time based histogram metrics.
 # we want this to match the baseplate.go default_buckets
 # bp.go v0 ref: https://github.com/reddit/baseplate.go/blob/master/prometheusbp/metrics.go.
-# bp.go v2 ref: https://XXXXXXXXX/reddit-go/baseplate/blob/main/metricsbp/metricsbp.go
+# bp.go v2 ref: https://XXXXXXXXX/baseplate/blob/main/metricsbp/metricsbp.go
 
 default_latency_buckets = [
     0.000100,  # 100us

--- a/baseplate/lib/prometheus_metrics.py
+++ b/baseplate/lib/prometheus_metrics.py
@@ -1,13 +1,25 @@
 # default_latency_buckets creates the default bucket values for time based histogram metrics.
-# we want this to match the baseplate.go default_buckets, ref: https://github.com/reddit/baseplate.go/blob/master/prometheusbp/metrics.go.
-# start is the value of the lowest bucket.
-# factor is amount to multiply the previous bucket by to get the value for the next bucket.
-# count is the number of buckets created.
-start = 0.0001
-factor = 2.5
-count = 14
-# creates 14 buckets from 100us ~ 14.9s.
-default_latency_buckets = [start * factor ** i for i in range(count)]
+# we want this to match the baseplate.go default_buckets
+# bp.go v0 ref: https://github.com/reddit/baseplate.go/blob/master/prometheusbp/metrics.go.
+# bp.go v2 ref: https://github.snooguts.net/reddit-go/baseplate/blob/main/metricsbp/metricsbp.go
+
+default_latency_buckets = [
+	0.000100,  # 100us
+	0.000500,  # 500us
+	0.001000,  # 1ms
+	0.002500,  # 2.5ms
+	0.005000,  # 5ms
+	0.010000,  # 10ms
+	0.025000,  # 25ms
+	0.050000,  # 50ms
+	0.100000,  # 100ms
+	0.250000,  # 250ms
+	0.500000,  # 500ms
+	1.000000,  # 1s
+	5.000000,  # 5s
+	15.000000, # 15s (fastly timeout)
+	30.000000, # 30s
+]
 
 # Default buckets for size base histograms, from <=8 bytes to 4mB in 20
 # increments (8*2^i).  Larger requests go in the +Inf bucket.

--- a/baseplate/lib/prometheus_metrics.py
+++ b/baseplate/lib/prometheus_metrics.py
@@ -1,7 +1,7 @@
 # default_latency_buckets creates the default bucket values for time based histogram metrics.
 # we want this to match the baseplate.go default_buckets
 # bp.go v0 ref: https://github.com/reddit/baseplate.go/blob/master/prometheusbp/metrics.go.
-# bp.go v2 ref: https://github.snooguts.net/reddit-go/baseplate/blob/main/metricsbp/metricsbp.go
+# bp.go v2 ref: https://XXXXXXXXX/reddit-go/baseplate/blob/main/metricsbp/metricsbp.go
 
 default_latency_buckets = [
 	0.000100,  # 100us

--- a/baseplate/lib/prometheus_metrics.py
+++ b/baseplate/lib/prometheus_metrics.py
@@ -17,8 +17,8 @@ default_latency_buckets = [
     0.500000,  # 500ms
     1.000000,  # 1s
     5.000000,  # 5s
-    15.000000, # 15s (fastly timeout)
-    30.000000, # 30s
+    15.000000,  # 15s (fastly timeout)
+    30.000000,  # 30s
 ]
 
 # Default buckets for size base histograms, from <=8 bytes to 4mB in 20

--- a/baseplate/lib/prometheus_metrics.py
+++ b/baseplate/lib/prometheus_metrics.py
@@ -4,21 +4,21 @@
 # bp.go v2 ref: https://XXXXXXXXX/reddit-go/baseplate/blob/main/metricsbp/metricsbp.go
 
 default_latency_buckets = [
-	0.000100,  # 100us
-	0.000500,  # 500us
-	0.001000,  # 1ms
-	0.002500,  # 2.5ms
-	0.005000,  # 5ms
-	0.010000,  # 10ms
-	0.025000,  # 25ms
-	0.050000,  # 50ms
-	0.100000,  # 100ms
-	0.250000,  # 250ms
-	0.500000,  # 500ms
-	1.000000,  # 1s
-	5.000000,  # 5s
-	15.000000, # 15s (fastly timeout)
-	30.000000, # 30s
+    0.000100,  # 100us
+    0.000500,  # 500us
+    0.001000,  # 1ms
+    0.002500,  # 2.5ms
+    0.005000,  # 5ms
+    0.010000,  # 10ms
+    0.025000,  # 25ms
+    0.050000,  # 50ms
+    0.100000,  # 100ms
+    0.250000,  # 250ms
+    0.500000,  # 500ms
+    1.000000,  # 1s
+    5.000000,  # 5s
+    15.000000, # 15s (fastly timeout)
+    30.000000, # 30s
 ]
 
 # Default buckets for size base histograms, from <=8 bytes to 4mB in 20


### PR DESCRIPTION
See discussion
https://reddit.slack.com/archives/C01GM1KQTV2/p1659015166955969

See https://github.snooguts.net/reddit-go/baseplate/blob/main/metricsbp/metricsbp.go

## 💸 TL;DR
<!-- What's the three sentence summary of purpose of the PR -->

## 📜 Details
[Design Doc](<!-- insert Google Doc link here if applicable -->)

[Jira](<!-- insert Jira link if applicable -->)

<!-- Add additional details required for the PR: breaking changes, screenshots, external dependency changes -->

## 🧪 Testing Steps / Validation
<!-- add details on how this PR has been tested, include reproductions and screenshots where applicable -->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] CI tests (if present) are passing
- [ ] Adheres to code style for repo
- [ ] Contributor License Agreement (CLA) completed if not a Reddit employee
