### PR TITLE
correct pool label

### DIFF
--- a/baseplate/clients/memcache/__init__.py
+++ b/baseplate/clients/memcache/__init__.py
@@ -150,7 +150,7 @@ class MemcacheContextFactory(ContextFactory):
     )
 
     free_connections_gauge = Gauge(
-        f"{PROM_PREFIX}_free_connections",
+        f"{PROM_PREFIX}_idle_connections",
         "Number of free connections in this pool",
         PROM_LABELS,
     )

--- a/baseplate/clients/memcache/__init__.py
+++ b/baseplate/clients/memcache/__init__.py
@@ -135,7 +135,7 @@ class MemcacheContextFactory(ContextFactory):
     """
 
     PROM_PREFIX = "memcached_client_pool"
-    PROM_LABELS = ["pool"]
+    PROM_LABELS = ["memcached_pool"]
 
     pool_size_gauge = Gauge(
         f"{PROM_PREFIX}_max_size",

--- a/baseplate/clients/redis.py
+++ b/baseplate/clients/redis.py
@@ -53,7 +53,7 @@ ACTIVE_REQUESTS = Gauge(
 )
 
 PROM_POOL_PREFIX = f"{PROM_PREFIX}_pool"
-PROM_LABELS = ["pool"]
+PROM_LABELS = ["redis_pool"]
 
 MAX_CONNECTIONS = Gauge(
     f"{PROM_POOL_PREFIX}_max_size",


### PR DESCRIPTION
label is supposed to be prefixed for redis pool

memcache pool is supposed to be idle_connections not free_connections