### PR TITLE
fix(metrics): make http_server http_endpoint use more general matching

### DIFF
--- a/baseplate/frameworks/pyramid/__init__.py
+++ b/baseplate/frameworks/pyramid/__init__.py
@@ -333,7 +333,7 @@ class BaseplateConfigurator:
         if request.matched_route:
             endpoint = (
                 request.matched_route.pattern
-                if request.matched_route.pattern
+                if hasattr(request.matched_route, "pattern")
                 else request.matched_route.name
             )
         ACTIVE_REQUESTS.labels(http_method=request.method.lower(), http_endpoint=endpoint).inc()

--- a/baseplate/frameworks/pyramid/__init__.py
+++ b/baseplate/frameworks/pyramid/__init__.py
@@ -333,7 +333,7 @@ class BaseplateConfigurator:
         if request.matched_route:
             endpoint = (
                 request.matched_route.pattern
-                if hasattr(request.matched_route, "pattern")
+                if (hasattr(request.matched_route, "pattern") and request.matched_route.pattern)
                 else request.matched_route.name
             )
         ACTIVE_REQUESTS.labels(http_method=request.method.lower(), http_endpoint=endpoint).inc()


### PR DESCRIPTION
see: https://github.com/reddit/baseplate.py/pull/716#discussion_r931175277

```alembic -c infrared/development.ini upgrade head
XXXXX
AttributeError: 'types.SimpleNamespace' object has no attribute 'pattern'
make: *** [Makefile:41: make-test-data] Error 1
```

Tested with <service-name> initdb job, and only 2 services do this.

Even though the simplenamespace isn't the best option since it doesn't match the same contract, I don't want to break things as part of the upgrade

