### PR TITLE
Apply same logic for request.matched_route.pattern to middleware

### DIFF
--- a/baseplate/frameworks/pyramid/__init__.py
+++ b/baseplate/frameworks/pyramid/__init__.py
@@ -145,7 +145,7 @@ def _make_baseplate_tween(
             if request.matched_route:
                 http_endpoint = (
                     request.matched_route.pattern
-                    if request.matched_route.pattern
+                    if (hasattr(request.matched_route, "pattern") and request.matched_route.pattern)
                     else request.matched_route.name
                 )
             http_method = request.method.lower()

--- a/baseplate/frameworks/pyramid/__init__.py
+++ b/baseplate/frameworks/pyramid/__init__.py
@@ -149,6 +149,8 @@ def _make_baseplate_tween(
                     else request.matched_route.name
                 )
             http_method = request.method.lower()
+
+            print(f"request: {http_method} endpoint: {str(http_endpoint)}")
             http_response_code = ""
 
             if sys.exc_info() == (None, None, None):

--- a/tests/unit/frameworks/pyramid/http_server_prom_tests.py
+++ b/tests/unit/frameworks/pyramid/http_server_prom_tests.py
@@ -24,7 +24,7 @@ class TestPyramidHttpServerIntegrationPrometheus:
         RESPONSE_SIZE.clear()
 
     @pytest.mark.parametrize(
-        "response,path",
+        "response",
         [
             Response("ok"),
             Response("page not found", status=404),

--- a/tests/unit/frameworks/pyramid/http_server_prom_tests.py
+++ b/tests/unit/frameworks/pyramid/http_server_prom_tests.py
@@ -2,6 +2,7 @@ from contextlib import nullcontext as does_not_raise
 from unittest import mock
 
 import pytest
+import types
 
 from prometheus_client import REGISTRY
 from pyramid.response import Response
@@ -149,13 +150,13 @@ class TestPyramidHttpServerIntegrationPrometheus:
 
         prom_labels = {
             "http_method": "get",
-            "http_endpoint": "route_pattern",
+            "http_endpoint": "route_name",
         }
 
         handler = mock.MagicMock(return_value=response)
         registry = mock.MagicMock()
         request = mock.MagicMock(content_length=42, method="GET")
-        request.matched_route.name = "route"
+        request.matched_route = types.SimpleNamespace(name="route_name")
         event = mock.MagicMock(request=request)
         bpConfigurator = BaseplateConfigurator(mock.MagicMock())
 

--- a/tests/unit/frameworks/pyramid/http_server_prom_tests.py
+++ b/tests/unit/frameworks/pyramid/http_server_prom_tests.py
@@ -1,8 +1,9 @@
+import types
+
 from contextlib import nullcontext as does_not_raise
 from unittest import mock
 
 import pytest
-import types
 
 from prometheus_client import REGISTRY
 from pyramid.response import Response

--- a/tests/unit/frameworks/pyramid/http_server_prom_tests.py
+++ b/tests/unit/frameworks/pyramid/http_server_prom_tests.py
@@ -24,7 +24,7 @@ class TestPyramidHttpServerIntegrationPrometheus:
         RESPONSE_SIZE.clear()
 
     @pytest.mark.parametrize(
-        "response",
+        "response,path",
         [
             Response("ok"),
             Response("page not found", status=404),
@@ -32,7 +32,7 @@ class TestPyramidHttpServerIntegrationPrometheus:
             Exception("some generic exception"),
         ],
     )
-    def test_http_server_metric_collection_method(self, response):
+    def test_http_server_metric_collection_method_with_request_pattern(self, response):
         status_code = ""
         http_success = "false"
         expectation = does_not_raise()
@@ -53,6 +53,109 @@ class TestPyramidHttpServerIntegrationPrometheus:
         request = mock.MagicMock(content_length=42, method="GET")
         request.matched_route.name = "route"
         request.matched_route.pattern = "route_pattern"
+        event = mock.MagicMock(request=request)
+        bpConfigurator = BaseplateConfigurator(mock.MagicMock())
+
+        mock_manager = mock.Mock()
+        with mock.patch.object(
+            ACTIVE_REQUESTS.labels(**prom_labels),
+            "inc",
+            wraps=ACTIVE_REQUESTS.labels(**prom_labels).inc,
+        ) as active_inc_spy_method:
+            mock_manager.attach_mock(active_inc_spy_method, "inc")
+            with mock.patch.object(
+                ACTIVE_REQUESTS.labels(**prom_labels),
+                "dec",
+                wraps=ACTIVE_REQUESTS.labels(**prom_labels).dec,
+            ) as active_dec_spy_method:
+                mock_manager.attach_mock(active_dec_spy_method, "dec")
+                with mock.patch.object(
+                    REQUEST_SIZE.labels(**prom_labels, http_success=http_success),
+                    "observe",
+                    wraps=REQUEST_SIZE.labels(**prom_labels, http_success=http_success).observe,
+                ) as request_size_spy_method:
+                    mock_manager.attach_mock(request_size_spy_method, "request_observe")
+                    with mock.patch.object(
+                        RESPONSE_SIZE.labels(**prom_labels, http_success=http_success),
+                        "observe",
+                        wraps=RESPONSE_SIZE.labels(
+                            **prom_labels, http_success=http_success
+                        ).observe,
+                    ) as response_size_spy_method:
+                        mock_manager.attach_mock(response_size_spy_method, "response_observe")
+                        with expectation:
+                            bpConfigurator._on_new_request(event)
+                            _make_baseplate_tween(handler=handler, _registry=registry)(request)
+
+        assert (
+            REGISTRY.get_sample_value(
+                "http_server_requests_total",
+                {**prom_labels, "http_response_code": status_code, "http_success": http_success},
+            )
+            == 1
+        )
+        assert (
+            REGISTRY.get_sample_value(
+                "http_server_latency_seconds_bucket",
+                {**prom_labels, "http_success": http_success, "le": "+Inf"},
+            )
+            == 1
+        )
+        assert REGISTRY.get_sample_value("http_server_active_requests", prom_labels) == 0
+        expected_calls = [
+            mock.call.inc(),  # ensures we first increase number of active requests
+            mock.call.dec(),
+            mock.call.request_observe(42),
+        ]
+        if not isinstance(response, Exception):
+            expected_calls.append(mock.call.response_observe(response.content_length))
+        assert mock_manager.mock_calls == expected_calls
+
+        assert (
+            REGISTRY.get_sample_value(
+                "http_server_request_size_bytes_bucket",
+                {**prom_labels, "http_success": http_success, "le": "+Inf"},
+            )
+            == 1
+        )
+        expected_response_size_count = 0 if isinstance(response, Exception) else 1
+        assert (
+            REGISTRY.get_sample_value(
+                "http_server_response_size_bytes_bucket",
+                {**prom_labels, "http_success": http_success, "le": "+Inf"},
+            )
+            == expected_response_size_count
+        )
+
+    @pytest.mark.parametrize(
+        "response",
+        [
+            Response("ok"),
+            Response("page not found", status=404),
+            Response("service unavailable", status=503),
+            Exception("some generic exception"),
+        ],
+    )
+    def test_http_server_metric_collection_method_no_pattern(self, response):
+        status_code = ""
+        http_success = "false"
+        expectation = does_not_raise()
+        if not isinstance(response, Exception):
+            status_code = str(response.status_code)
+            if status_code == "200":
+                http_success = "true"
+        else:
+            expectation = pytest.raises(type(response))
+
+        prom_labels = {
+            "http_method": "get",
+            "http_endpoint": "route_pattern",
+        }
+
+        handler = mock.MagicMock(return_value=response)
+        registry = mock.MagicMock()
+        request = mock.MagicMock(content_length=42, method="GET")
+        request.matched_route.name = "route"
         event = mock.MagicMock(request=request)
         bpConfigurator = BaseplateConfigurator(mock.MagicMock())
 


### PR DESCRIPTION
I'm not confident that this fixes it, but the request was to match the logic between the two and add a test to reduce the risk, which I do agree with.