### PR TITLE
Redis Health check support 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,10 @@ WORKDIR /src
 # don't care for our tests.
 ENV CASS_DRIVER_NO_EXTENSIONS theytaketoolongtobuild
 
+RUN apt-get update -y
+
+RUN apt-get install -y librdkafka-dev
+
 COPY requirements*.txt ./
 RUN pip install -r requirements.txt
 

--- a/baseplate/server/healthcheck.py
+++ b/baseplate/server/healthcheck.py
@@ -65,31 +65,10 @@ def check_redis_service(endpoint: EndpointConfiguration, probe: int) -> None:
         raise ValueError("Cannot connect to the endpoint")
 
 
-def check_redis_cluster_service(endpoint: EndpointConfiguration, probe: int) -> None:
-    try:
-        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-            sock.settimeout(REDIS_TIMEOUT)
-            address: InternetAddress = typing.cast(InternetAddress, endpoint.address)
-            sock.connect((address.host, address.port))
-            if probe in [IsHealthyProbe.LIVENESS, IsHealthyProbe.STARTUP]:
-                sock.sendall(b"PING\n")
-                data = sock.recv(PING_BUFFER).decode("UTF-8")
-                if not re.match(r"\+PONG", data):
-                    raise ValueError("Did not receive a PONG to the PING")
-            elif probe == IsHealthyProbe.READINESS:
-                sock.sendall(b"CLUSTER INFO\n")
-                data = sock.recv(CLUSTER_INFO_BUFFER).decode("UTF-8")
-                if not re.search(r"cluster_state:pass", data):
-                    raise ValueError("Did not receive cluster_state:ok from the redis cluster")
-    except socket.timeout:
-        raise ValueError("Cannot connect to the endpoint")
-
-
 CHECKERS = {
     "thrift": check_thrift_service,
     "wsgi": check_http_service,
     "redis": check_redis_service,
-    "redis-cluster": check_redis_cluster_service,
 }
 
 

--- a/baseplate/server/healthcheck.py
+++ b/baseplate/server/healthcheck.py
@@ -20,8 +20,7 @@ from baseplate.thrift.ttypes import IsHealthyRequest
 
 TIMEOUT = 30  # seconds
 REDIS_TIMEOUT = 2  # seconds
-PING_BUFFER = 128  # byte size
-CLUSTER_INFO_BUFFER = 1024  # byte size
+PING_BUFFER = 128  # buffer size
 
 
 def check_thrift_service(endpoint: EndpointConfiguration, probe: int) -> None:

--- a/baseplate/server/healthcheck.py
+++ b/baseplate/server/healthcheck.py
@@ -19,7 +19,7 @@ from baseplate.thrift.ttypes import IsHealthyRequest
 
 
 TIMEOUT = 30  # seconds
-REDIS_TIMEOUT = 2  # seconds
+REDIS_TIMEOUT = 15  # seconds
 PING_BUFFER = 128  # buffer size
 
 

--- a/docs/cli/healthcheck.rst
+++ b/docs/cli/healthcheck.rst
@@ -22,11 +22,17 @@ liveness:
 
    $ baseplate-healthcheck thrift 127.0.0.1:9090 --probe liveness
 
-or a WSGI (HTTP) service listening on a UNIX domain socket, with default probe
+A WSGI (HTTP) service listening on a UNIX domain socket, with default probe
 
 .. code-block:: console
 
    $ baseplate-healthcheck wsgi /run/myservice.sock
+
+or a redis service listening on host:port with liveness probe:
+
+.. code-block:: console
+
+   $ baseplate-healthcheck redis 127.0.0.1:6379 --probe liveness
 
 Results
 -------

--- a/docs/cli/healthcheck.rst
+++ b/docs/cli/healthcheck.rst
@@ -9,7 +9,7 @@ Command Line
 ------------
 
 There are two required arguments on the command line: the protocol of the
-service to check (``thrift`` or ``wsgi``) and the endpoint to connect to.
+service to check (``thrift``, ``wsgi`` or ``redis``) and the endpoint to connect to.
 
 There's also an optional argument on the command line: the probe to check.
 By default the probe to check is ``readiness``, but you can choose one from:


### PR DESCRIPTION
## 💸 TL;DR
<!-- What's the three sentence summary of purpose of the PR -->
Adds a Redis health check for baseplate.py. This can be used by redis envoy proxy.

## 📜 Details
[Jira] https://reddit.atlassian.net/browse/STRGS-240 and https://reddit.atlassian.net/browse/STRGS-12


## 🧪 Testing Steps / Validation
I was able to test the function that I added by running a local redis node and by stopping the service and testing to make sure I can get socket time out. 

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] CI tests (if present) are passing
- [ ] Adheres to code style for repo
- [ ] Contributor License Agreement (CLA) completed if not a Reddit employee
