### PR TITLE
fix(metrics): track 404 on new request better BASE-125 BASE-126

### DIFF
--- a/baseplate/frameworks/pyramid/__init__.py
+++ b/baseplate/frameworks/pyramid/__init__.py
@@ -150,7 +150,7 @@ def _make_baseplate_tween(
                 )
             else:
                 http_endpoint = "404"
-                
+
             http_method = request.method.lower()
             http_response_code = ""
 

--- a/baseplate/frameworks/pyramid/__init__.py
+++ b/baseplate/frameworks/pyramid/__init__.py
@@ -208,6 +208,9 @@ def manually_close_request_metrics(request: Request, response: Optional[Response
                 time.perf_counter() - request.reddit_start_time
             )
 
+        if hasattr(request, "content_length"):
+            REQUEST_SIZE.labels(**histogram_labels).observe(request.content_length or 0)
+
         if response:
             try:
                 if response.content_length is not None:

--- a/baseplate/frameworks/pyramid/__init__.py
+++ b/baseplate/frameworks/pyramid/__init__.py
@@ -218,7 +218,6 @@ def manually_close_request_metrics(request: Request, response: Optional[Response
             if hasattr(response, "content_length") and response.content_length is not None:
                 RESPONSE_SIZE.labels(**histogram_labels).observe(response.content_length)
 
-
         # avoid missing a secondary request if the same request object is re-used in scripting
         request.reddit_prom_metrics_enabled = False
         request.reddit_start_time = None

--- a/baseplate/frameworks/pyramid/__init__.py
+++ b/baseplate/frameworks/pyramid/__init__.py
@@ -215,11 +215,9 @@ def manually_close_request_metrics(request: Request, response: Optional[Response
 
         # response may not be set if this handler is called from a pyramid script handler
         if response:
-            try:
-                if hasattr(response, "content_length") and response.content_length is not None:
-                    RESPONSE_SIZE.labels(**histogram_labels).observe(response.content_length)
-            except Exception:
-                pass
+            if hasattr(response, "content_length") and response.content_length is not None:
+                RESPONSE_SIZE.labels(**histogram_labels).observe(response.content_length)
+
 
         # avoid missing a secondary request if the same request object is re-used in scripting
         request.reddit_prom_metrics_enabled = False

--- a/baseplate/frameworks/pyramid/__init__.py
+++ b/baseplate/frameworks/pyramid/__init__.py
@@ -152,8 +152,6 @@ def _make_baseplate_tween(
                 http_endpoint = "404"
 
             http_method = request.method.lower()
-
-            print(f"request: {http_method} endpoint: {str(http_endpoint)}")
             http_response_code = ""
 
             if sys.exc_info() == (None, None, None):

--- a/baseplate/frameworks/pyramid/__init__.py
+++ b/baseplate/frameworks/pyramid/__init__.py
@@ -148,6 +148,9 @@ def _make_baseplate_tween(
                     if request.matched_route.pattern
                     else request.matched_route.name
                 )
+            else:
+                http_endpoint = "404"
+                
             http_method = request.method.lower()
             http_response_code = ""
 
@@ -307,7 +310,7 @@ class BaseplateConfigurator:
 
         # this request didn't match a route we know
         if not request.matched_route:
-            # TODO: some metric for 404s would be good
+            ACTIVE_REQUESTS.labels(http_method=request.method.lower(), http_endpoint="404").inc()
             return
 
         trace_info = None


### PR DESCRIPTION

![Screen Shot 2022-08-03 at 3 54 42 PM](https://user-images.githubusercontent.com/1282393/182697347-f1e9ceb3-6d5e-4db0-b09e-c481a8c4f70c.png)
On the internal service we're using for testing, the negative metric decreases further when hitting a page that has no matched route