### PR TITLE
Remove assert statement from config.py

### DIFF
--- a/baseplate/lib/config.py
+++ b/baseplate/lib/config.py
@@ -495,7 +495,8 @@ class SpecParser(Parser[ConfigNamespace]):
     def parse(self, key_path: str, raw_config: RawConfig) -> ConfigNamespace:
         parsed = ConfigNamespace()
         for key, spec in self.spec.items():
-            assert "." not in key, "dots are not allowed in keys"
+            if "." in key:
+                raise AssertionError("dots are not allowed in keys")
 
             if key_path:
                 sub_key_path = f"{key_path}.{key}"


### PR DESCRIPTION

## 💸 TL;DR
Asserts in Python make errors hard to track down and can be disabled at runtime if particular flags are provided. These things together make asserts a bad pattern in production code. This PR is an example PR for a bug to get rid of all asserts.

## 📜 Details
[Design Doc](<!-- insert Google Doc link here if applicable -->)

[Jira](<!-- insert Jira link if applicable -->)

<!-- Add additional details required for the PR: breaking changes, screenshots, external dependency changes -->

## 🧪 Testing Steps / Validation
<!-- add details on how this PR has been tested, include reproductions and screenshots where applicable -->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] CI tests (if present) are passing
- [ ] Adheres to code style for repo
- [ ] Contributor License Agreement (CLA) completed if not a Reddit employee
