### PR TITLE
[BASE-127] Fix thrift client connection reuse (introduced in 2.4.13)

### DIFF
--- a/baseplate/clients/thrift.py
+++ b/baseplate/clients/thrift.py
@@ -207,15 +207,15 @@ def _build_thrift_proxy_method(name: str) -> Callable[..., Any]:
         trace_name = f"{self.namespace}.{name}"
         last_error = None
 
-        try:
-            for time_remaining in self.retry_policy:
-                start_time = time.perf_counter()
-                ACTIVE_REQUESTS.labels(
-                    thrift_method=name,
-                    thrift_client_name=self.namespace,
-                ).inc()
-
+        for time_remaining in self.retry_policy:
+            try:
                 with self.pool.connection() as prot:
+                    start_time = time.perf_counter()
+                    ACTIVE_REQUESTS.labels(
+                        thrift_method=name,
+                        thrift_client_name=self.namespace,
+                    ).inc()
+
                     span = self.server_span.make_child(trace_name)
                     span.set_tag("slug", self.namespace)
 
@@ -266,7 +266,7 @@ def _build_thrift_proxy_method(name: str) -> Callable[..., Any]:
                         last_error = str(exc)
                         if exc.inner is not None:
                             last_error += f" ({exc.inner})"
-                        continue
+                        raise  # we need to raise all exceptions so that self.pool.connect() self-heals
                     except (TApplicationException, TProtocolException):
                         # these are subclasses of TException but aren't ones that
                         # should be expected in the protocol. this is an error!
@@ -292,55 +292,59 @@ def _build_thrift_proxy_method(name: str) -> Callable[..., Any]:
                         # a normal result
                         span.finish()
                         return result
+                    finally:
+                        thrift_success = "true"
+                        exception_type = ""
+                        baseplate_status = ""
+                        baseplate_status_code = ""
+                        exc_info = sys.exc_info()
+                        if exc_info[0] is not None:
+                            thrift_success = "false"
+                            exception_type = exc_info[0].__name__
+                            current_exc = exc_info[1]
+                            try:
+                                # We want the following code to execute whenever the
+                                # service raises an instance of Baseplate's `Error` class.
+                                # Unfortunately, we cannot just rely on `isinstance` to do
+                                # what we want here because some services compile
+                                # Baseplate's thrift file on their own and import `Error`
+                                # from that. When this is done, `isinstance` will always
+                                # return `False` since it's technically a different class.
+                                # To fix this, we optimistically try to access `code` on
+                                # `current_exc` and just catch the `AttributeError` if the
+                                # `code` attribute is not present.
+                                baseplate_status_code = current_exc.code  # type: ignore
+                                baseplate_status = ErrorCode()._VALUES_TO_NAMES.get(current_exc.code, "")  # type: ignore
+                            except AttributeError:
+                                pass
 
-            raise TTransportException(
-                type=TTransportException.TIMED_OUT,
-                message=f"retry policy exhausted while attempting {self.namespace}.{name}, last error was: {last_error}",
-            )
-        finally:
-            thrift_success = "true"
-            exception_type = ""
-            baseplate_status = ""
-            baseplate_status_code = ""
-            exc_info = sys.exc_info()
-            if exc_info[0] is not None:
-                thrift_success = "false"
-                exception_type = exc_info[0].__name__
-                current_exc = exc_info[1]
-                try:
-                    # We want the following code to execute whenever the
-                    # service raises an instance of Baseplate's `Error` class.
-                    # Unfortunately, we cannot just rely on `isinstance` to do
-                    # what we want here because some services compile
-                    # Baseplate's thrift file on their own and import `Error`
-                    # from that. When this is done, `isinstance` will always
-                    # return `False` since it's technically a different class.
-                    # To fix this, we optimistically try to access `code` on
-                    # `current_exc` and just catch the `AttributeError` if the
-                    # `code` attribute is not present.
-                    baseplate_status_code = current_exc.code  # type: ignore
-                    baseplate_status = ErrorCode()._VALUES_TO_NAMES.get(current_exc.code, "")  # type: ignore
-                except AttributeError:
-                    pass
+                        REQUEST_LATENCY.labels(
+                            thrift_method=name,
+                            thrift_client_name=self.namespace,
+                            thrift_success=thrift_success,
+                        ).observe(time.perf_counter() - start_time)
 
-            REQUEST_LATENCY.labels(
-                thrift_method=name,
-                thrift_client_name=self.namespace,
-                thrift_success=thrift_success,
-            ).observe(time.perf_counter() - start_time)
+                        REQUESTS_TOTAL.labels(
+                            thrift_method=name,
+                            thrift_client_name=self.namespace,
+                            thrift_success=thrift_success,
+                            thrift_exception_type=exception_type,
+                            thrift_baseplate_status_code=baseplate_status_code,
+                            thrift_baseplate_status=baseplate_status,
+                        ).inc()
 
-            REQUESTS_TOTAL.labels(
-                thrift_method=name,
-                thrift_client_name=self.namespace,
-                thrift_success=thrift_success,
-                thrift_exception_type=exception_type,
-                thrift_baseplate_status_code=baseplate_status_code,
-                thrift_baseplate_status=baseplate_status,
-            ).inc()
+                        ACTIVE_REQUESTS.labels(
+                            thrift_method=name,
+                            thrift_client_name=self.namespace,
+                        ).dec()
+            except TTransportException:
+                # swallow exception so we can retry on TTransportException (relies on the for loop)
+                continue
 
-            ACTIVE_REQUESTS.labels(
-                thrift_method=name,
-                thrift_client_name=self.namespace,
-            ).dec()
+        # this only happens if we exhaust the retry policy
+        raise TTransportException(
+            type=TTransportException.TIMED_OUT,
+            message=f"retry policy exhausted while attempting {self.namespace}.{name}, last error was: {last_error}",
+        )
 
     return _call_thrift_method

--- a/tests/unit/clients/thrift_tests.py
+++ b/tests/unit/clients/thrift_tests.py
@@ -138,11 +138,12 @@ class TestPrometheusMetrics:
 
         proxy_method = _build_thrift_proxy_method("handle")
         pool = mock.MagicMock(timeout=None)
-        pool.__enter__.return_value = mock.MagicMock()
+        prot = mock.MagicMock()
+        pool.connection().__enter__.return_value = prot
         client_cls = mock.MagicMock()
         client_cls.handle = handle
         handler = mock.MagicMock(
-            retry_policy=[None],
+            retry_policy=[None, None],
             pool=pool,
             namespace="test_namespace",
         )
@@ -175,25 +176,55 @@ class TestPrometheusMetrics:
                 with expectation:
                     proxy_method(self=handler)
 
+        tries = 1 if exc_type != "TTransportException" else 2
         assert (
             REGISTRY.get_sample_value(
                 "thrift_client_requests_total",
                 {**prom_labels, **requests_total_prom_labels, "thrift_success": thrift_success},
             )
-            == 1
+            == tries
         )
         assert (
             REGISTRY.get_sample_value(
                 "thrift_client_latency_seconds_bucket",
                 {**prom_labels, "thrift_success": thrift_success, "le": "+Inf"},
             )
-            == 1
+            == tries
         )
         assert REGISTRY.get_sample_value("thrift_client_active_requests", prom_labels) == 0
-        assert mock_manager.mock_calls == [
-            mock.call.inc(),
-            mock.call.dec(),
-        ]  # ensures we first increase number of active requests
+        assert (
+            mock_manager.mock_calls
+            == [
+                mock.call.inc(),
+                mock.call.dec(),
+            ]
+            * tries
+        )  # ensures we first increase number of active requests
+
+    def test_build_thrift_proxy_method_fail_connection(self):
+        def handle(*args, **kwargs):
+            return 42
+
+        proxy_method = _build_thrift_proxy_method("handle")
+        pool = mock.MagicMock(timeout=None)
+        pool.connection().__enter__.side_effect = Exception("failed to establish connection")
+        client_cls = mock.MagicMock()
+        client_cls.handle = handle
+        handler = mock.MagicMock(
+            retry_policy=[None, None],
+            pool=pool,
+            namespace="test_namespace",
+        )
+        handler.client_cls.return_value = client_cls
+
+        with pytest.raises(Exception):
+            proxy_method(self=handler)
+
+        prom_labels = {
+            "thrift_method": "handle",
+            "thrift_client_name": "test_namespace",
+        }
+        assert REGISTRY.get_sample_value("thrift_client_active_requests", prom_labels) is None
 
 
 class TestThriftContextFactory:


### PR DESCRIPTION
Emit prometheus metrics for individual retry calls instead of whole
"transaction"
Do not emit metrics if the connection cannot be established to begin
with. (self.pool.connection() raises an exception)

The documentation for thrift_pool.py:ThriftConnectionPool.connection() reads:
> When the context is exited, the connection is returned to the pool.
> However, if it was exited via an unexpected Thrift exception, the
> connection is closed instead because the state of the connection is
> unknown.

As of 2.4.13, TTransportException (used to decide whether we should
retry or not) is raised, but caught before the context manager handling
pool.connection() can catch it. Which means that on retries, the
connections would end up in an unknown state, returned to the pool, and
yield potential bad results on subsequent uses. This change fixes that.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] CI tests (if present) are passing
- [x] Adheres to code style for repo
- [x] Contributor License Agreement (CLA) completed if not a Reddit employee
