### PR TITLE
Add warnings and recommendations to docs about timeout-related connection leaks

### DIFF
--- a/docs/api/baseplate/clients/sqlalchemy.rst
+++ b/docs/api/baseplate/clients/sqlalchemy.rst
@@ -53,10 +53,11 @@ Configuration
 -------------
 
 .. warning::
-   :py:class:`sqlalchemy.pool.QueuePool` does not handle :py:class:`~baseplate.observers.timeout.ServerTimeout`
-   exceptions gracefully, resulting in connection pool leaks. It is recommended
-   to avoid local pooling (via :py:class:`sqlalchemy.pool.NullPool`) and instead
-   use middleware pooling (such as `pgbouncer`) while this issue persists.
+   :py:class:`sqlalchemy.pool.QueuePool` does not handle `ServerTimeout`
+   exceptions gracefully, potentially leaking connections. It is recommended
+   to avoid local pooling entirely (via :py:class:`sqlalchemy.pool.NullPool`)
+   while this issue persists and instead rely on middleware pooling (such as
+   `pgbouncer`).
 
 .. autoclass:: SQLAlchemySession
 

--- a/docs/api/baseplate/clients/sqlalchemy.rst
+++ b/docs/api/baseplate/clients/sqlalchemy.rst
@@ -53,6 +53,7 @@ Configuration
 -------------
 
 .. warning::
+
    :py:class:`sqlalchemy.pool.QueuePool` does not handle `ServerTimeout`
    exceptions gracefully, potentially leaking connections. It is recommended
    to avoid local pooling entirely (via :py:class:`sqlalchemy.pool.NullPool`)

--- a/docs/api/baseplate/clients/sqlalchemy.rst
+++ b/docs/api/baseplate/clients/sqlalchemy.rst
@@ -52,6 +52,12 @@ request::
 Configuration
 -------------
 
+.. warning::
+   :py:class:`sqlalchemy.pool.QueuePool` does not handle :py:class:`~baseplate.observers.timeout.ServerTimeout`
+   exceptions gracefully, resulting in connection pool leaks. It is recommended
+   to avoid local pooling (via :py:class:`sqlalchemy.pool.NullPool`) and instead
+   use middleware pooling (such as `pgbouncer`) while this issue persists.
+
 .. autoclass:: SQLAlchemySession
 
 .. autofunction:: engine_from_config

--- a/docs/api/baseplate/observers/timeout.rst
+++ b/docs/api/baseplate/observers/timeout.rst
@@ -14,6 +14,14 @@ upstream services are yet taken into account.
    taking a long time because it is doing compute-heavy actions and not
    yielding to the event loop it might go on longer than the allotted timeout.
 
+.. warning::
+
+   The timeout mechanism may throw a :py:class:`~baseplate.observers.timeout.ServerTimeout`
+   exception whenever a gevent context switch occurs. If this exception is not
+   handled gracefully your application could get stuck in a bad state. For example,
+   if a `:py:class:`~baseplate.observers.timeout.ServerTimeout` exception is thrown
+   while releasing a connection then the connection might never be fully released.
+
 .. versionadded:: 1.2
 
 .. versionchanged:: 1.3.3

--- a/docs/api/baseplate/observers/timeout.rst
+++ b/docs/api/baseplate/observers/timeout.rst
@@ -16,11 +16,11 @@ upstream services are yet taken into account.
 
 .. warning::
 
-   The timeout mechanism may throw a :py:class:`~baseplate.observers.timeout.ServerTimeout`
-   exception whenever a gevent context switch occurs. If this exception is not
-   handled gracefully your application could get stuck in a bad state. For example,
-   if a `:py:class:`~baseplate.observers.timeout.ServerTimeout` exception is thrown
-   while releasing a connection then the connection might never be fully released.
+   The timeout mechanism may throw a `ServerTimeout` exception whenever a gevent
+   context switch occurs. If this exception is not handled gracefully your
+   application could get stuck in a bad state. For example, if a `ServerTimeout`
+   exception is thrown while releasing a connection then the connection might
+   never be fully released.
 
 .. versionadded:: 1.2
 


### PR DESCRIPTION
## 💸 TL;DR
This PR updates the docs with a warning about `ServerTimeout` exceptions, and a recommendation to avoid SqlAlchemy connection pool leaks until the issue is resolved.
