### PR TITLE
BASE-163 - fix(thrift server) - Have the thrift server populate label…

### DIFF
--- a/baseplate/clients/thrift.py
+++ b/baseplate/clients/thrift.py
@@ -313,6 +313,11 @@ def _build_thrift_proxy_method(name: str) -> Callable[..., Any]:
                                 # To fix this, we optimistically try to access `code` on
                                 # `current_exc` and just catch the `AttributeError` if the
                                 # `code` attribute is not present.
+                                # Note: if the error code was not originally defined in baseplate, or the
+                                # name associated with the error was overriden, this cannot reflect that
+                                # we will emit the status code in both cases
+                                # but the status will be blank in the first case, and the baseplate name
+                                # in the second
                                 baseplate_status_code = current_exc.code  # type: ignore
                                 baseplate_status = ErrorCode()._VALUES_TO_NAMES.get(current_exc.code, "")  # type: ignore
                             except AttributeError:


### PR DESCRIPTION
…s for prometheus metrics even when the error does not come from baseplate if possible.

hrift_baseplate_status_code - will be set to exc.code if available
hrift_baseplate_status - will be set to the corresponding _baseplate_
corresponding name for this status code. We do not have a way to get the
name for a new exception not defined in baseplate, or for a name that
was changed from the one originally set in baseplate.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] CI tests (if present) are passing
- [x] Adheres to code style for repo
- [x] Contributor License Agreement (CLA) completed if not a Reddit employee
