### PR TITLE
[live-data-fetcher] Anonymize s3 client in sidecar to allow unsigned requests

### DIFF
--- a/baseplate/sidecars/live_data_watcher.py
+++ b/baseplate/sidecars/live_data_watcher.py
@@ -15,9 +15,9 @@ from typing import Optional
 
 import boto3  # type: ignore
 
-from botocore import UNSIGNED
+from botocore import UNSIGNED  # type: ignore
 from botocore.client import ClientError  # type: ignore
-from botocore.client import Config
+from botocore.client import Config  # type: ignore
 from botocore.exceptions import EndpointConnectionError  # type: ignore
 from kazoo.client import KazooClient
 from kazoo.protocol.states import ZnodeStat
@@ -137,11 +137,11 @@ def _load_from_s3(data: bytes) -> bytes:
         )
         raise LoaderException from e
 
-    # Client needs to be anonymous/unsigned or boto3 will try to read the local credentials 
-    # on the service pods. And - due to an AWS quirk - any request that comes in signed with 
-    # credentails will profile for permissions for the resource being requested EVEN if the 
-    # resource is public. In other words, this means that a given service could not access 
-    # public resources belonging to another cluster/AWS account unless the request credentials 
+    # Client needs to be anonymous/unsigned or boto3 will try to read the local credentials
+    # on the service pods. And - due to an AWS quirk - any request that comes in signed with
+    # credentails will profile for permissions for the resource being requested EVEN if the
+    # resource is public. In other words, this means that a given service could not access
+    # public resources belonging to another cluster/AWS account unless the request credentials
     # were unsigned.
     s3_client = boto3.client(
         "s3",

--- a/baseplate/sidecars/live_data_watcher.py
+++ b/baseplate/sidecars/live_data_watcher.py
@@ -137,7 +137,7 @@ def _load_from_s3(data: bytes) -> bytes:
         )
         raise LoaderException from e
 
-    if loader_config.get("anon") == True:
+    if loader_config.get("anon") is True:
         # Client needs to be anonymous/unsigned or boto3 will try to read the local credentials
         # on the service pods. And - due to an AWS quirk - any request that comes in signed with
         # credentials will profile for permissions for the resource being requested EVEN if the

--- a/baseplate/sidecars/live_data_watcher.py
+++ b/baseplate/sidecars/live_data_watcher.py
@@ -137,10 +137,12 @@ def _load_from_s3(data: bytes) -> bytes:
         )
         raise LoaderException from e
 
-    # Client needs to be anonymous/unsigned or boto3 will try to read the local credentials on the service pods.
-    # And - due to an AWS quirk - any request that comes in signed with credentails will profile for permissions
-    # for the resource being requested EVEN if the resource is public.
-    # In other words, this means that a given service could not access public resources belonging to another cluster/AWS account unless the request credentials were unsigned.
+    # Client needs to be anonymous/unsigned or boto3 will try to read the local credentials 
+    # on the service pods. And - due to an AWS quirk - any request that comes in signed with 
+    # credentails will profile for permissions for the resource being requested EVEN if the 
+    # resource is public. In other words, this means that a given service could not access 
+    # public resources belonging to another cluster/AWS account unless the request credentials 
+    # were unsigned.
     s3_client = boto3.client(
         "s3",
         config=Config(signature_version=UNSIGNED),

--- a/baseplate/sidecars/live_data_watcher.py
+++ b/baseplate/sidecars/live_data_watcher.py
@@ -141,9 +141,9 @@ def _load_from_s3(data: bytes) -> bytes:
         # Client needs to be anonymous/unsigned or boto3 will try to read the local credentials
         # on the service pods. And - due to an AWS quirk - any request that comes in signed with
         # credentials will profile for permissions for the resource being requested EVEN if the
-        # resource is public. In other words, this means that a given service could not access
-        # public resources belonging to another cluster/AWS account unless the request credentials
-        # were unsigned.
+        # resource is public. In other words, this means that a given service cannot access
+        # a public resource belonging to another cluster/AWS account unless the request credentials
+        # are unsigned.
         s3_client = boto3.client(
             "s3",
             config=Config(signature_version=UNSIGNED),

--- a/baseplate/sidecars/live_data_watcher.py
+++ b/baseplate/sidecars/live_data_watcher.py
@@ -140,7 +140,7 @@ def _load_from_s3(data: bytes) -> bytes:
     if loader_config.get("anon") == True:
         # Client needs to be anonymous/unsigned or boto3 will try to read the local credentials
         # on the service pods. And - due to an AWS quirk - any request that comes in signed with
-        # credentails will profile for permissions for the resource being requested EVEN if the
+        # credentials will profile for permissions for the resource being requested EVEN if the
         # resource is public. In other words, this means that a given service could not access
         # public resources belonging to another cluster/AWS account unless the request credentials
         # were unsigned.

--- a/baseplate/sidecars/live_data_watcher.py
+++ b/baseplate/sidecars/live_data_watcher.py
@@ -17,7 +17,7 @@ import boto3  # type: ignore
 
 from botocore import UNSIGNED  # type: ignore
 from botocore.client import ClientError  # type: ignore
-from botocore.client import Config  # type: ignore
+from botocore.client import Config
 from botocore.exceptions import EndpointConnectionError  # type: ignore
 from kazoo.client import KazooClient
 from kazoo.protocol.states import ZnodeStat

--- a/tests/unit/sidecars/live_data_watcher_loader_tests.py
+++ b/tests/unit/sidecars/live_data_watcher_loader_tests.py
@@ -77,12 +77,19 @@ def test_load_from_s3_missing_config(start_mock_s3, missing_config):
         assert _load_from_s3(json.dumps(data).encode("utf-8"))
 
 
-def test_successful_load_from_s3(s3_stub):
+@pytest.mark.parametrize(
+    "anon_req",
+    (
+        True,
+        False,
+    ),
+)
+def test_successful_load_from_s3(s3_stub, anon_req):
     contents = b"my-test-contents"
     bucket_name = "my-test-bucket"
     file_key = "my-test-key"
     sse_key = "key"
-    anon = True
+    anon = anon_req
 
     s3_stub.add_response(
         "get_object",

--- a/tests/unit/sidecars/live_data_watcher_loader_tests.py
+++ b/tests/unit/sidecars/live_data_watcher_loader_tests.py
@@ -79,10 +79,10 @@ def test_load_from_s3_missing_config(start_mock_s3, missing_config):
 
 def test_successful_load_from_s3(s3_stub):
     contents = b"my-test-contents"
-    bucket = "my-test-bucket"
-    key = "my-test-key"
+    bucket_name = "my-test-bucket"
     file_key = "my-test-key"
     sse_key = "key"
+    anon = True
 
     s3_stub.add_response(
         "get_object",
@@ -90,7 +90,7 @@ def test_successful_load_from_s3(s3_stub):
             "Body": StreamingBody(io.BytesIO(contents), len(contents)),
         },
         expected_params={
-            "Bucket": bucket,
+            "Bucket": bucket_name,
             "Key": file_key,
             "SSECustomerKey": sse_key,
             "SSECustomerAlgorithm": "AES256",
@@ -99,7 +99,13 @@ def test_successful_load_from_s3(s3_stub):
 
     data = _load_from_s3(
         json.dumps(
-            {"region_name": "us-east-1", "bucket_name": bucket, "file_key": key, "sse_key": "key"}
+            {
+                "region_name": "us-east-1",
+                "bucket_name": bucket_name,
+                "file_key": file_key,
+                "sse_key": sse_key,
+                "anon": anon,
+            }
         ).encode("utf-8")
     )
 

--- a/tests/unit/sidecars/live_data_watcher_loader_tests.py
+++ b/tests/unit/sidecars/live_data_watcher_loader_tests.py
@@ -78,18 +78,17 @@ def test_load_from_s3_missing_config(start_mock_s3, missing_config):
 
 
 @pytest.mark.parametrize(
-    "anon_req",
+    "anon",
     (
         True,
         False,
     ),
 )
-def test_successful_load_from_s3(s3_stub, anon_req):
+def test_successful_load_from_s3(s3_stub, anon):
     contents = b"my-test-contents"
     bucket_name = "my-test-bucket"
     file_key = "my-test-key"
     sse_key = "key"
-    anon = anon_req
 
     s3_stub.add_response(
         "get_object",


### PR DESCRIPTION
## 💸 TL;DR

This is a bug-fix for an issue we found with some services unable to access public resources in an s3 bucket from the AWS Kubernetes Prod account.

Some services were seeing the following error: `"An error occurred (AccessDenied) when calling the GetObject operation"` despite the objects/resources being fully public. All of this was despite anonymous local retrieval via an incognito browser being successful.

## 📜 Details

This bug was discovered as part of the [Zookeeper -> S3](https://docs.google.com/document/d/1vaSg31jkIuh5yf-wt2-SdU6N6T7w8Em7X9QKeKphd2c/edit) migration project for Experiments.

See [Migration Timeline](https://docs.google.com/document/d/1U5UUjkMS3l13KZ1xoQHXU1NJHk1t1YcOQgMbQKRB_jU/edit) for time sequence of events, findings, issues we ran into, and our resolutions.

For this migration, we require services to be able to READ public encrypted objects in an S3 bucket on the AWS Kubernetes Prod account. 

However, our first launch attempt saw services such as `reddit-service-admin-action` encountering [AccessDenied](https://app.reddit.logdna.com/bca89a3380/logs/view?t=timestamp%3A1660591916718&a=1660591916718.1512432119740129287&q=%22An%20error%20occurred%20(AccessDenied)%20when%20calling%20the%20GetObject%20operation%22) errors. This issue was especially bizarre given that the resources in the s3 bucket were publicly accessible (verified via incognito browser access).

Thanks to @ckwang8128's magic debugging skills, we discovered that because the s3 requests were signed, credentials were being pulled from local service pods thus making it so that services in a different AWS account than `AWS Kubernetes Prod` were unable to access our public resources. By making the s3 client anonymized, we are now treating the requests as unsigned - accessing the public resources will no longer try to profile for permissions from an AWS account.

## 🧪 Testing Steps / Validation
This change was sanity checked as a script on a pod - attempted to access a resource in a different cluster (different AWS account). Without this change, access is restricted. After this change, access was allowed. 

Setup of anonymous client and retrieval of object is as follows:

```
import boto3
from botocore import UNSIGNED
from botocore.client import Config

s3 = boto3.client('s3', config=Config(signature_version=UNSIGNED),region_name='us-east-1')
s3.get_object(Bucket="reddit-experiment-config-prod-active-configs", Key="7a9780e27ef4a671a41a3b98478caa43_experiment_config.json", SSECustomerKey="df9ee5aab842a0fa43058bc067afd30d", SSECustomerAlgorithm="AES256")
```


## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] CI tests (if present) are passing
- [x] Adheres to code style for repo
- [x] Contributor License Agreement (CLA) completed if not a Reddit employee
