### PR TITLE
Add example for Pyramid HTTPException

### DIFF
--- a/docs/api/baseplate/frameworks/pyramid.rst
+++ b/docs/api/baseplate/frameworks/pyramid.rst
@@ -23,6 +23,9 @@ An abbreviated example of it in use::
 
         return configurator.make_wsgi_app()
 
+Exceptions
+------
+
 .. warning::
 
     Because of how Baseplate instruments Pyramid, you should not make an
@@ -38,6 +41,11 @@ An abbreviated example of it in use::
 
 .. autoclass:: StaticTrustHandler
     :members:
+
+**HTTP Exceptions**
+
+Pyramid contains HTTP exception classes that accept parameters and contain a response object. Read more about `pyramid HTTP exceptions <https://docs.pylonsproject.org/projects/pyramid/en/latest/api/httpexceptions.html>`_.
+Example usage of pyramid.httpexceptions can be found in `tests/integration/pyramid_tests.py <../../../../tests/integration/pyramid_tests.py>`_
 
 Events
 ------


### PR DESCRIPTION
<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #575. 

## 📜 Details
This adds an example usage of Pyramid's HTTPException in the tests and a short blurb in documentation. This is in response to #575, in which the failure reproduction test seemed to be setting `explanation` and expecting the response `body` to contain the `explanation`. A test was added with the correctly set and expected parameters in this PR

## 🧪 Testing Steps / Validation
- Followed [testing instructions](https://github.com/reddit/baseplate.py/blob/develop/CONTRIBUTING.md#testing-and-linting) to run tests locally 

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] CI tests (if present) are passing
- [x] Adheres to code style for repo
- [ ] Contributor License Agreement (CLA) completed if not a Reddit employee
