### PR TITLE
fix(RedisClient): Add 'redis_client_name` property

### DIFF
--- a/baseplate/clients/redis.py
+++ b/baseplate/clients/redis.py
@@ -131,7 +131,7 @@ class RedisClient(config.Parser):
     def __init__(self, redis_client_name: str = "", **kwargs: Any):
         # This is for backwards compatibility. Originally we asked clients to
         # set the `client_name` attribute to get the `redis_client_name`
-        # tag to appear on Pjjjrometheus metrics. Unfortunately this broke clients
+        # tag to appear on Prometheus metrics. Unfortunately this broke clients
         # that use a proxy to connect to Redis.
         # See: https://github.com/redis/redis-py/issues/2384
         client_name = redis_client_name

--- a/tests/unit/clients/redis_tests.py
+++ b/tests/unit/clients/redis_tests.py
@@ -94,7 +94,9 @@ class TestMonitoredRedisConnection:
 
     @pytest.fixture
     def monitored_redis_connection(self, span, connection_pool):
-        yield MonitoredRedisConnection("redis_context_name", span, connection_pool)
+        yield MonitoredRedisConnection(
+            "redis_context_name", span, connection_pool, redis_client_name="test_client"
+        )
 
     def test_execute_command_exc_redis_err(
         self, monitored_redis_connection, expected_labels, app_config

--- a/tests/unit/clients/redis_tests.py
+++ b/tests/unit/clients/redis_tests.py
@@ -80,9 +80,7 @@ class TestMonitoredRedisConnection:
 
     @pytest.fixture
     def connection_pool(self, app_config, connection):
-        yield pool_from_config(
-            app_config=app_config, prefix="redis.", client_name="test_client", **connection
-        )
+        yield pool_from_config(app_config=app_config, prefix="redis.", **connection)
 
     @pytest.fixture
     def context(self):
@@ -167,7 +165,11 @@ class TestMonitoredRedisConnection:
                 ), "Should have 0 (and not None) active requests"
 
     def test_pipeline_instrumentation_failing(
-        self, monitored_redis_connection, expected_labels, app_config
+        self,
+        monitored_redis_connection,
+        expected_labels,
+        app_config,
+        redis_client_name="test_client",
     ):
         active_labels = {**expected_labels, "redis_command": "pipeline"}
         mock_manager = mock.Mock()


### PR DESCRIPTION
<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 💸 TL;DR

This change adds the `redis_client_name` property to the RedisClient. This allows clients that use a Redis proxy to set the `redis_client_name` label on Prometheus metrics.

## 📜 Details

Currently clients that use the `client_name` property to set the Redis
client with a Envoy Redis proxy are not able to connect to Redis. At
it's root this is an issue an issue with the redis-py library (see
https://github.com/redis/redis-py/issues/2384).

Currently Baseplate's wrapper around the Redis client uses the
`client_name` to set the `redis_client_name` label on Prometheus metrics.
Due to the issue mentioned above clients who use a Redis Proxy are not
about to set the `redis_client_name` Prometheus label. The additional
`redis_client_name` property is now used to set the Prometheus label.
For backwards compatibility, if `client_name` is set, but
`redis_client_name` is not, the `redis_client_name` defaults to
`client_name`.

Equivalent change to RedisCluster shortly.

## 🧪 Testing Steps / Validation
<!-- add details on how this PR has been tested, include reproductions and screenshots where applicable -->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [X] CI tests (if present) are passing
- [X] Adheres to code style for repo
- [ ] Contributor License Agreement (CLA) completed if not a Reddit employee
