### PR TITLE
exposing prometheus metrics from event-publisher sidecar

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,10 @@ linkcheck:
 
 .PHONY: test
 test: doctest
-	pytest -v tests/
+	# Some files use gevent to monkey patch stdlib functions. This causes problems
+	# if it happens after importing the sequential versions of some of these. Thus
+	# we need to do it as early as possible.
+	python -m gevent.monkey --module pytest -v tests/
 
 .PHONY: fmt
 fmt:

--- a/baseplate/server/prometheus.py
+++ b/baseplate/server/prometheus.py
@@ -78,10 +78,10 @@ def start_prometheus_exporter(address: EndpointConfiguration = PROMETHEUS_EXPORT
 
 
 def start_prometheus_exporter_for_sidecar() -> None:
-    port = os.environ.get("BASEPLATE_SIDECAR_ADMIN_PORT")
+    port = os.environ.get("BASEPLATE_SIDECAR_METRICS_PORT")
     if port is None:
         logger.error(
-            "BASEPLATE_SIDECAR_ADMIN_PORT must be set for sidecar to expose Prometheus metrics."
+            "BASEPLATE_SIDECAR_METRICS_PORT must be set for sidecar to expose Prometheus metrics."
         )
     else:
         endpoint = Endpoint("0.0.0.0:" + port)

--- a/baseplate/server/prometheus.py
+++ b/baseplate/server/prometheus.py
@@ -26,6 +26,7 @@ from prometheus_client import generate_latest
 from prometheus_client import multiprocess
 
 from baseplate.lib.config import Endpoint
+from baseplate.lib.config import EndpointConfiguration
 from baseplate.server.net import bind_socket
 
 
@@ -52,7 +53,7 @@ def export_metrics(environ: "WSGIEnvironment", start_response: "StartResponse") 
     return [data]
 
 
-def start_prometheus_exporter() -> None:
+def start_prometheus_exporter(address: EndpointConfiguration = PROMETHEUS_EXPORTER_ADDRESS) -> None:
     if "PROMETHEUS_MULTIPROC_DIR" not in os.environ:
         logger.error(
             "prometheus-client is installed but PROMETHEUS_MULTIPROC_DIR is not set to a writeable directory."
@@ -61,7 +62,7 @@ def start_prometheus_exporter() -> None:
 
     atexit.register(multiprocess.mark_process_dead, os.getpid())
 
-    server_socket = bind_socket(PROMETHEUS_EXPORTER_ADDRESS)
+    server_socket = bind_socket(address)
     server = WSGIServer(
         server_socket,
         application=export_metrics,
@@ -70,7 +71,18 @@ def start_prometheus_exporter() -> None:
     )
     logger.info(
         "Prometheus metrics exported on server listening on %s%s",
-        PROMETHEUS_EXPORTER_ADDRESS,
+        address,
         METRICS_ENDPOINT,
     )
     server.start()
+
+
+def start_prometheus_exporter_for_sidecar() -> None:
+    port = os.environ.get("BASEPLATE_SIDECAR_ADMIN_PORT")
+    if port is None:
+        logger.error(
+            "BASEPLATE_SIDECAR_ADMIN_PORT must be set for sidecar to expose Prometheus metrics."
+        )
+    else:
+        endpoint = Endpoint("0.0.0.0:" + port)
+        start_prometheus_exporter(endpoint)

--- a/baseplate/sidecars/event_publisher.py
+++ b/baseplate/sidecars/event_publisher.py
@@ -23,7 +23,7 @@ from typing import Any
 from typing import List
 from typing import Optional
 
-from gevent import sleep
+import gevent
 from prometheus_client import Counter, Histogram
 import requests
 
@@ -240,7 +240,8 @@ def publish_events() -> None:
     publisher = BatchPublisher(metrics_client, cfg)
 
     while True:
-        sleep(0)
+        # allow other routines to execute (specifically handling requests to /metrics)
+        gevent.sleep(0)
         message: Optional[bytes]
 
         try:

--- a/baseplate/sidecars/event_publisher.py
+++ b/baseplate/sidecars/event_publisher.py
@@ -1,3 +1,16 @@
+# pylint: disable=wrong-import-position,wrong-import-order
+from gevent.monkey import patch_all
+
+from baseplate.server.monkey import patch_stdlib_queues
+
+# In order to allow Prometheus to scrape metrics, we need to concurrently
+# handle requests to '/metrics' along with the sidecar's execution.
+# Monkey patching is used to replace the stdlib sequential versions of functions
+# with concurrent versions. It must happen as soon as possible, before the
+# sequential versions are imported.
+patch_all()
+patch_stdlib_queues()
+
 import argparse
 import configparser
 import email.utils
@@ -10,6 +23,8 @@ from typing import Any
 from typing import List
 from typing import Optional
 
+from gevent import sleep
+from prometheus_client import Counter, Histogram
 import requests
 
 from baseplate import __version__ as baseplate_version
@@ -22,6 +37,7 @@ from baseplate.lib.message_queue import TimedOutError
 from baseplate.lib.metrics import metrics_client_from_config
 from baseplate.lib.retry import RetryPolicy
 from baseplate.server import EnvironmentInterpolation
+from baseplate.server.prometheus import start_prometheus_exporter_for_sidecar
 from baseplate.sidecars import Batch
 from baseplate.sidecars import BatchFull
 from baseplate.sidecars import SerializedBatch
@@ -98,6 +114,11 @@ class V2JBatch(V2Batch):
         return SerializedBatch(item_count=len(self._items), serialized=serialized)
 
 
+publishCountTotal = Counter("event_publish_total", "total count of published events")
+publishLatency = Histogram("event_publish_latency", "latency for publishing a batch of events")
+publishErrors = Counter("event_publish_errors", "total count of published events", ["error_type"])
+
+
 class BatchPublisher:
     def __init__(self, metrics_client: metrics.Client, cfg: Any):
         self.metrics = metrics_client
@@ -130,16 +151,18 @@ class BatchPublisher:
         for _ in RetryPolicy.new(budget=MAX_RETRY_TIME, backoff=RETRY_BACKOFF):
             try:
                 with self.metrics.timer("post"):
-                    response = self.session.post(
-                        self.url,
-                        headers=headers,
-                        data=compressed_payload,
-                        timeout=POST_TIMEOUT,
-                        # http://docs.python-requests.org/en/latest/user/advanced/#keep-alive
-                        stream=False,
-                    )
+                    with publishLatency.time():
+                        response = self.session.post(
+                            self.url,
+                            headers=headers,
+                            data=compressed_payload,
+                            timeout=POST_TIMEOUT,
+                            # http://docs.python-requests.org/en/latest/user/advanced/#keep-alive
+                            stream=False,
+                        )
                 response.raise_for_status()
             except requests.HTTPError as exc:
+                publishErrors.labels(error_type="http").inc()
                 self.metrics.counter("error.http").increment()
 
                 # we should crash if it's our fault
@@ -152,9 +175,11 @@ class BatchPublisher:
                 else:
                     logger.exception("HTTP Request failed.")
             except OSError:
+                publishErrors.labels(error_type="io").inc()
                 self.metrics.counter("error.io").increment()
                 logger.exception("HTTP Request failed")
             else:
+                publishCountTotal.inc(payload.item_count)
                 self.metrics.counter("sent").increment(payload.item_count)
                 return
 
@@ -215,6 +240,7 @@ def publish_events() -> None:
     publisher = BatchPublisher(metrics_client, cfg)
 
     while True:
+        sleep(0)
         message: Optional[bytes]
 
         try:
@@ -238,4 +264,5 @@ def publish_events() -> None:
 
 
 if __name__ == "__main__":
+    start_prometheus_exporter_for_sidecar()
     publish_events()

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,8 @@ exclude_lines =
 [flake8]
 max-line-length = 100
 ignore = W503, E203, E501, D100, D101, D102, D103, D104, D105, D106, D107
+per-file-ignores =
+    baseplate/sidecars/*.py: E402, C0413
 exclude =
     baseplate/thrift/
     tests/integration/test_thrift/


### PR DESCRIPTION
<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 💸 TL;DR
<!-- What's the three sentence summary of purpose of the PR -->
We want to expose Prometheus metrics from our sidecars. This PR sets that up for the event_publisher sidecar, and adds a generic method that can be used by other sidecar types.

## 📜 Details
[Jira](https://reddit.atlassian.net/browse/BASE-122)

## 🧪 Testing Steps / Validation
I ran this locally, commenting out the bits that actually publish to a real queue. I'm not sure if there's a clean way to do a "realistic" test, but would love to know if there is.

I added the monkey patching based on what I see here, though I'm not confident this is the right way to do this https://github.com/reddit/baseplate.py/blob/develop/bin/baseplate-serve

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] CI tests (if present) are passing
- [ ] Adheres to code style for repo
~~- [ ]Contributor License Agreement (CLA) completed if not a Reddit employee~~
