### PR TITLE
fix(RedisClusterClient): Add `redis_client_name` attribute

### DIFF
--- a/baseplate/clients/redis_cluster.py
+++ b/baseplate/clients/redis_cluster.py
@@ -328,12 +328,21 @@ def cluster_pool_from_config(
 class ClusterRedisClient(config.Parser):
     """Configure a clustered Redis client.
 
+    :param redis_client_name: The name of this Redis client. Prefer to use `client_name`
+    keyword argument to the `pool_from_config` function. Use this if your using a Redis
+    host or proxy that doesn't support the `CLIENT SETNAME` function.
+
     This is meant to be used with
     :py:meth:`baseplate.Baseplate.configure_context`.
     See :py:func:`cluster_pool_from_config` for available configuration settings.
     """
 
     def __init__(self, redis_client_name: str = "", **kwargs: Any):
+        # This is for backwards compatibility. Originally we asked clients to
+        # set the `client_name` attribute to get the `redis_client_name`
+        # tag to appear on Prometheus metrics. Unfortunately this broke clients
+        # that use a proxy to connect to Redis.
+        # See: https://github.com/redis/redis-py/issues/2384/
         client_name = redis_client_name
         if client_name == "":
             client_name = kwargs.get("client_name", "")

--- a/baseplate/clients/redis_cluster.py
+++ b/baseplate/clients/redis_cluster.py
@@ -333,12 +333,19 @@ class ClusterRedisClient(config.Parser):
     See :py:func:`cluster_pool_from_config` for available configuration settings.
     """
 
-    def __init__(self, **kwargs: Any):
+    def __init__(self, redis_client_name: str = "", **kwargs: Any):
+        client_name = redis_client_name
+        if client_name == "":
+            client_name = kwargs.get("client_name", "")
+
         self.kwargs = kwargs
+        self.redis_client_name = client_name
 
     def parse(self, key_path: str, raw_config: config.RawConfig) -> "ClusterRedisContextFactory":
         connection_pool = cluster_pool_from_config(raw_config, f"{key_path}.", **self.kwargs)
-        return ClusterRedisContextFactory(connection_pool, key_path)
+        return ClusterRedisContextFactory(
+            connection_pool, key_path, redis_client_name=self.redis_client_name
+        )
 
 
 class ClusterRedisContextFactory(ContextFactory):
@@ -353,9 +360,15 @@ class ClusterRedisContextFactory(ContextFactory):
     :param connection_pool: A connection pool.
     """
 
-    def __init__(self, connection_pool: rediscluster.ClusterConnectionPool, name: str = "redis"):
+    def __init__(
+        self,
+        connection_pool: rediscluster.ClusterConnectionPool,
+        name: str = "redis",
+        redis_client_name: str = "",
+    ):
         self.connection_pool = connection_pool
         self.name = name
+        self.redis_client_name = redis_client_name
 
     def report_runtime_metrics(self, batch: metrics.Client) -> None:
         if not isinstance(self.connection_pool, rediscluster.ClusterBlockingConnectionPool):
@@ -376,6 +389,7 @@ class ClusterRedisContextFactory(ContextFactory):
             self.connection_pool,
             getattr(self.connection_pool, "track_key_reads_sample_rate", 0),
             getattr(self.connection_pool, "track_key_writes_sample_rate", 0),
+            self.redis_client_name,
         )
 
 
@@ -396,6 +410,7 @@ class MonitoredRedisClusterConnection(rediscluster.RedisCluster):
         connection_pool: rediscluster.ClusterConnectionPool,
         track_key_reads_sample_rate: float = 0,
         track_key_writes_sample_rate: float = 0,
+        redis_client_name: str = "",
     ):
         self.context_name = context_name
         self.server_span = server_span
@@ -404,6 +419,7 @@ class MonitoredRedisClusterConnection(rediscluster.RedisCluster):
         self.hot_key_tracker = HotKeyTracker(
             self, self.track_key_reads_sample_rate, self.track_key_writes_sample_rate
         )
+        self.redis_client_name = redis_client_name
 
         super().__init__(
             connection_pool=connection_pool,
@@ -420,9 +436,7 @@ class MonitoredRedisClusterConnection(rediscluster.RedisCluster):
             success = "true"
             labels = {
                 f"{PROM_LABELS_PREFIX}_command": command,
-                f"{PROM_LABELS_PREFIX}_client_name": self.connection_pool.connection_kwargs.get(
-                    "client_name", ""
-                ),
+                f"{PROM_LABELS_PREFIX}_client_name": self.redis_client_name,
                 f"{PROM_LABELS_PREFIX}_database": self.connection_pool.connection_kwargs.get(
                     "db", ""
                 ),
@@ -462,6 +476,7 @@ class MonitoredRedisClusterConnection(rediscluster.RedisCluster):
             self.response_callbacks,
             read_from_replicas=self.read_from_replicas,
             hot_key_tracker=self.hot_key_tracker,
+            redis_client_name=self.redis_client_name,
         )
 
     # No transaction support in redis-py-cluster
@@ -479,11 +494,13 @@ class MonitoredClusterRedisPipeline(ClusterPipeline):
         connection_pool: rediscluster.ClusterConnectionPool,
         response_callbacks: Dict,
         hot_key_tracker: Optional[HotKeyTracker],
+        redis_client_name: str = "",
         **kwargs: Any,
     ):
         self.trace_name = trace_name
         self.server_span = server_span
         self.hot_key_tracker = hot_key_tracker
+        self.redis_client_name = redis_client_name
         super().__init__(connection_pool, response_callbacks, **kwargs)
 
     def execute_command(self, *args: Any, **kwargs: Any) -> Any:
@@ -501,9 +518,7 @@ class MonitoredClusterRedisPipeline(ClusterPipeline):
             start_time = perf_counter()
             labels = {
                 f"{PROM_LABELS_PREFIX}_command": "pipeline",
-                f"{PROM_LABELS_PREFIX}_client_name": self.connection_pool.connection_kwargs.get(
-                    "client_name", ""
-                ),
+                f"{PROM_LABELS_PREFIX}_client_name": self.redis_client_name,
                 f"{PROM_LABELS_PREFIX}_database": self.connection_pool.connection_kwargs.get(
                     "db", ""
                 ),

--- a/tests/integration/redis_cluster_tests.py
+++ b/tests/integration/redis_cluster_tests.py
@@ -1,9 +1,13 @@
 import unittest
 
+from typing import Any
+
 try:
     import rediscluster
 except ImportError:
     raise unittest.SkipTest("redis-py-cluster is not installed")
+
+from prometheus_client import REGISTRY
 
 from baseplate.lib.config import ConfigurationError
 from baseplate.clients.redis_cluster import cluster_pool_from_config
@@ -11,6 +15,9 @@ from baseplate.clients.redis_cluster import cluster_pool_from_config
 from baseplate.clients.redis_cluster import ClusterRedisClient
 from baseplate import Baseplate
 from . import TestBaseplateObserver, get_endpoint_or_skip_container
+from baseplate.clients.redis_cluster import ACTIVE_REQUESTS
+from baseplate.clients.redis_cluster import LATENCY_SECONDS
+from baseplate.clients.redis_cluster import REQUESTS_TOTAL
 
 redis_endpoint = get_endpoint_or_skip_container("redis-cluster-node", 7000)
 
@@ -87,6 +94,13 @@ class ClusterPoolFromConfigTests(unittest.TestCase):
 
 class RedisClusterIntegrationTests(unittest.TestCase):
     def setUp(self):
+        self.setup_baseplate_redis(
+            {
+                "redis_client_name": "test_client",
+            },
+        )
+
+    def setup_baseplate_redis(self, redis_cluster_kwargs: dict[str, Any] = {}):
         self.baseplate_observer = TestBaseplateObserver()
 
         baseplate = Baseplate(
@@ -97,7 +111,7 @@ class RedisClusterIntegrationTests(unittest.TestCase):
             }
         )
         baseplate.register(self.baseplate_observer)
-        baseplate.configure_context({"rediscluster": ClusterRedisClient()})
+        baseplate.configure_context({"rediscluster": ClusterRedisClient(**redis_cluster_kwargs)})
 
         self.context = baseplate.make_context_object()
         self.server_span = baseplate.make_server_span(self.context, "test")
@@ -156,3 +170,91 @@ class RedisClusterIntegrationTests(unittest.TestCase):
         self.assertTrue(span_observer.on_start_called)
         self.assertTrue(span_observer.on_finish_called)
         self.assertIsNone(span_observer.on_finish_exc_info)
+
+    def test_metrics(self):
+        client_name = "redis_test"
+        for client_name_kwarg_name in [
+            "redis_client_name",
+            "client_name",
+        ]:
+            with self.subTest():
+                self.setup_baseplate_redis(
+                    redis_cluster_kwargs={
+                        client_name_kwarg_name: client_name,
+                    },
+                )
+                # Clear preometheus metrics
+                ACTIVE_REQUESTS.clear()
+                REQUESTS_TOTAL.clear()
+                LATENCY_SECONDS.clear()
+                expected_labels = {
+                    "redis_client_name": client_name,
+                    "redis_type": "cluster",
+                    "redis_command": "SET",
+                    "redis_database": "0",
+                }
+                with self.server_span:
+                    self.context.rediscluster.set("prometheus", "rocks")
+
+                request_labels = {**expected_labels, "redis_success": "true"}
+                assert (
+                    REGISTRY.get_sample_value(f"{REQUESTS_TOTAL._name}_total", request_labels)
+                    == 1.0
+                ), "Unexpected value for REQUESTS_TOTAL metric. Expected one 'set' command"
+                assert (
+                    REGISTRY.get_sample_value(
+                        f"{LATENCY_SECONDS._name}_bucket", {**request_labels, "le": "+Inf"}
+                    )
+                    == 1.0
+                ), "Expected one 'set' latency request"
+                assert (
+                    REGISTRY.get_sample_value(ACTIVE_REQUESTS._name, {**expected_labels}) == 0.0
+                ), "Should have 0 (and not None) active requests"
+
+    def test_pipeline_metrics(self):
+        client_name = "test_client"
+        for client_name_kwarg_name in [
+            "redis_client_name",
+            "client_name",
+        ]:
+            with self.subTest():
+                self.setup_baseplate_redis(
+                    redis_cluster_kwargs={
+                        client_name_kwarg_name: client_name,
+                    },
+                )
+                # Clear preometheus metrics
+                ACTIVE_REQUESTS.clear()
+                REQUESTS_TOTAL.clear()
+                LATENCY_SECONDS.clear()
+                expected_labels = {
+                    "redis_client_name": client_name,
+                    "redis_type": "cluster",
+                    "redis_command": "pipeline",
+                    "redis_database": "0",
+                }
+                with self.server_span:
+                    with self.context.rediscluster.pipeline("foo") as pipeline:
+                        pipeline.set("foo", "bar")
+                        pipeline.get("foo")
+                        pipeline.get("foo")
+                        pipeline.get("foo")
+                        pipeline.get("foo")
+                        pipeline.get("foo")
+                        pipeline.delete("foo")
+                        pipeline.execute()
+
+                request_labels = {**expected_labels, "redis_success": "true"}
+                assert (
+                    REGISTRY.get_sample_value(f"{REQUESTS_TOTAL._name}_total", request_labels)
+                    == 1.0
+                ), "Unexpected value for REQUESTS_TOTAL metric. Expected one 'set' command"
+                assert (
+                    REGISTRY.get_sample_value(
+                        f"{LATENCY_SECONDS._name}_bucket", {**request_labels, "le": "+Inf"}
+                    )
+                    == 1.0
+                ), "Expected one 'set' latency request"
+                assert (
+                    REGISTRY.get_sample_value(ACTIVE_REQUESTS._name, {**expected_labels}) == 0.0
+                ), "Should have 0 (and not None) active requests"

--- a/tests/unit/clients/redis_cluster_tests.py
+++ b/tests/unit/clients/redis_cluster_tests.py
@@ -85,7 +85,6 @@ class TestMonitoredRedisConnection:
         return cluster_pool_from_config(
             app_config=app_config,
             prefix="redis.",
-            client_name="test_client",
             init_slot_cache=False,
             startup_nodes=[
                 {
@@ -107,7 +106,9 @@ class TestMonitoredRedisConnection:
     @pytest.fixture
     @mock.patch("rediscluster.RedisCluster", new=mock.MagicMock())
     def monitored_redis_connection(self, span, connection_pool):
-        return MonitoredRedisClusterConnection("redis_context_name", span, connection_pool)
+        return MonitoredRedisClusterConnection(
+            "redis_context_name", span, connection_pool, redis_client_name="test_client"
+        )
 
     # NOTE: a successful execute_command() call is difficult to mock
     def test_execute_command_exc_redis_err(


### PR DESCRIPTION
This updates RedisClusterClient.

Currently clients that use the `client_name` property to set the Redis client with a Envoy Redis proxy are not able to connect to Redis. At it's root this is an issue an issue with the redis-py library (see redis/redis-py#2384).

Currently Baseplate's wrapper around the Redis client uses the `client_name` to set the `redis_client_name` label on Prometheus metrics. Due to the issue mentioned above clients who use a Redis Proxy are not about to set the `redis_client_name` Prometheus label. The additional `redis_client_name` property is now used to set the Prometheus label. For backwards compatibility, if `client_name` is set, but `redis_client_name` is not, the `redis_client_name` defaults to `client_name`.

This makes the same change to #741 does for the RedisCluster client.

## 💸 TL;DR
<!-- What's the three sentence summary of purpose of the PR -->

## 📜 Details
[Design Doc](<!-- insert Google Doc link here if applicable -->)

[Jira](<!-- insert Jira link if applicable -->)

<!-- Add additional details required for the PR: breaking changes, screenshots, external dependency changes -->

## 🧪 Testing Steps / Validation
<!-- add details on how this PR has been tested, include reproductions and screenshots where applicable -->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] CI tests (if present) are passing
- [ ] Adheres to code style for repo
- [ ] Contributor License Agreement (CLA) completed if not a Reddit employee
