### PR TITLE
test(RedisClient): Use common setup/teardown logic in tests

### DIFF
--- a/tests/integration/redis_cluster_tests.py
+++ b/tests/integration/redis_cluster_tests.py
@@ -1,7 +1,5 @@
 import unittest
 
-from typing import Any
-
 try:
     import rediscluster
 except ImportError:
@@ -244,5 +242,5 @@ class RedisClusterIntegrationTests(RedisIntegrationTestCase):
                     REGISTRY.get_sample_value(ACTIVE_REQUESTS._name, {**expected_labels}) == 0.0
                 ), "Should have 0 (and not None) active requests"
 
-                # After each interation of teh loop we are starting a new testcase so we need to teardown
+                # Each iteration of this loop is effectively a different testcase
                 self.tearDown()

--- a/tests/integration/redis_testcase.py
+++ b/tests/integration/redis_testcase.py
@@ -1,0 +1,60 @@
+import unittest
+
+import redis
+
+import baseplate.clients.redis as baseplate_redis
+
+from baseplate import Baseplate
+
+from . import get_endpoint_or_skip_container
+from . import TestBaseplateObserver
+
+redis_url = f'redis://{get_endpoint_or_skip_container("redis", 6379)}'
+redis_cluster_url = f'redis://{get_endpoint_or_skip_container("redis-cluster-node", 7000)}'
+
+
+class RedisIntegrationTestConfigurationError(Exception):
+    pass
+
+
+class RedisIntegrationTestCase(unittest.TestCase):
+    baseplate_app_config = None
+    redis_client_builder = None
+    redis_context_name = "redis"
+
+    def setUp(self):
+        if not self.baseplate_app_config:
+            raise RedisIntegrationTestConfigurationError(
+                "Unable to run tests. `baseplate_app_config` is not set",
+            )
+
+        if not self.redis_client_builder:
+            raise RedisIntegrationTestConfigurationError(
+                "Unable to setup Redis client, 'redis_client_builder' not set",
+            )
+
+        self.baseplate_observer = TestBaseplateObserver()
+
+        baseplate = Baseplate(self.baseplate_app_config)
+        baseplate.register(self.baseplate_observer)
+        baseplate.configure_context({self.redis_context_name: self.redis_client_builder()})
+
+        self.context = baseplate.make_context_object()
+        self.server_span = baseplate.make_server_span(self.context, "test")
+
+    def tearDown(self):
+        # You can't use the Redis connection on the Baseplate context because its
+        # parent server span has been closed already
+        redis_cli = redis.Redis.from_url(redis_url)
+        redis_cli.flushall()
+
+        redis_cluster_cli = redis.Redis.from_url(redis_cluster_url)
+        redis_cluster_cli.flushall()
+
+        # Clear prometheus metrics
+        baseplate_redis.LATENCY_SECONDS.clear()
+        baseplate_redis.REQUESTS_TOTAL.clear()
+        baseplate_redis.ACTIVE_REQUESTS.clear()
+        baseplate_redis.MAX_CONNECTIONS.clear()
+        baseplate_redis.IDLE_CONNECTIONS.clear()
+        baseplate_redis.OPEN_CONNECTIONS.clear()

--- a/tests/integration/redis_tests.py
+++ b/tests/integration/redis_tests.py
@@ -7,9 +7,9 @@ except ImportError:
     raise unittest.SkipTest("redis-py is not installed")
 
 from baseplate.clients.redis import RedisClient
-from baseplate import Baseplate
 
-from . import TestBaseplateObserver, get_endpoint_or_skip_container
+from . import get_endpoint_or_skip_container
+from .redis_testcase import RedisIntegrationTestCase, redis_url
 
 from baseplate.clients.redis import MessageQueue
 from baseplate.lib.message_queue import TimedOutError
@@ -18,16 +18,12 @@ from baseplate.lib.message_queue import TimedOutError
 redis_endpoint = get_endpoint_or_skip_container("redis", 6379)
 
 
-class RedisIntegrationTests(unittest.TestCase):
+class RedisIntegrationTests(RedisIntegrationTestCase):
     def setUp(self):
-        self.baseplate_observer = TestBaseplateObserver()
+        self.baseplate_app_config = {"redis.url": redis_url}
+        self.redis_client_builder = RedisClient
 
-        baseplate = Baseplate({"redis.url": f"redis://{redis_endpoint}/0"})
-        baseplate.register(self.baseplate_observer)
-        baseplate.configure_context({"redis": RedisClient()})
-
-        self.context = baseplate.make_context_object()
-        self.server_span = baseplate.make_server_span(self.context, "test")
+        super().setUp()
 
     def test_simple_command(self):
         with self.server_span:


### PR DESCRIPTION
Currently not all cleanup tasks are done to ensure that Redis integration tests can't interfere with eachother. In particular I ran into a case where adding a test would caused the `lock_test` to hang when run a second time. This was because my new test happened to set a key with the same name as the lock. To avoid this issue This change will result in Redis clearing all data between each test run.

In addition this change clears all Redis Prometheus metrics between every run.

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 💸 TL;DR
<!-- What's the three sentence summary of purpose of the PR -->

## 📜 Details
[Design Doc](<!-- insert Google Doc link here if applicable -->)

[Jira](<!-- insert Jira link if applicable -->)

<!-- Add additional details required for the PR: breaking changes, screenshots, external dependency changes -->

## 🧪 Testing Steps / Validation
<!-- add details on how this PR has been tested, include reproductions and screenshots where applicable -->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [X] CI tests (if present) are passing
- [X] Adheres to code style for repo
- [ ] Contributor License Agreement (CLA) completed if not a Reddit employee
