### PR TITLE
Reduce cardinality of http_server_active_requests

### DIFF
--- a/baseplate/clients/cassandra.py
+++ b/baseplate/clients/cassandra.py
@@ -50,6 +50,7 @@ REQUEST_ACTIVE = Gauge(
     "cassandra_client_active_requests",
     "Current number of active cassandra queries",
     CassandraPrometheusLabels._fields,
+    multiprocess_mode="livesum",
 )
 REQUEST_TOTAL = Counter(
     "cassandra_client_requests_total",

--- a/baseplate/clients/memcache/__init__.py
+++ b/baseplate/clients/memcache/__init__.py
@@ -195,6 +195,7 @@ ACTIVE_REQUESTS = Gauge(
     f"{PROM_NAMESPACE}_client_active_requests",
     "Number of active requests",
     LABELS_COMMON,
+    multiprocess_mode="livesum",
 )
 
 

--- a/baseplate/clients/redis.py
+++ b/baseplate/clients/redis.py
@@ -50,6 +50,7 @@ ACTIVE_REQUESTS = Gauge(
     f"{PROM_PREFIX}_active_requests",
     "Number of active requests for a given client",
     PROM_SHARED_LABELS,
+    multiprocess_mode="livesum",
 )
 
 PROM_POOL_PREFIX = f"{PROM_PREFIX}_pool"
@@ -59,16 +60,19 @@ MAX_CONNECTIONS = Gauge(
     f"{PROM_POOL_PREFIX}_max_size",
     "Maximum number of connections allowed in this redis client connection pool",
     PROM_LABELS,
+    multiprocess_mode="livesum",
 )
 IDLE_CONNECTIONS = Gauge(
     f"{PROM_POOL_PREFIX}_idle_connections",
     "Number of idle connections in this redis client connection pool",
     PROM_LABELS,
+    multiprocess_mode="livesum",
 )
 OPEN_CONNECTIONS = Gauge(
     f"{PROM_POOL_PREFIX}_active_connections",
     "Number of open connections in this redis client connection pool",
     PROM_LABELS,
+    multiprocess_mode="livesum",
 )
 
 

--- a/baseplate/clients/requests.py
+++ b/baseplate/clients/requests.py
@@ -134,6 +134,7 @@ ACTIVE_REQUESTS = Gauge(
     f"{PROM_NAMESPACE}_active_requests",
     "Number of active requests for a given client",
     HTTP_LABELS_COMMON,
+    multiprocess_mode="livesum",
 )
 
 

--- a/baseplate/clients/sqlalchemy.py
+++ b/baseplate/clients/sqlalchemy.py
@@ -168,17 +168,20 @@ class SQLAlchemyEngineContextFactory(ContextFactory):
         f"{PROM_POOL_PREFIX}_max_size",
         "Maximum number of connections allowed in this pool",
         PROM_POOL_LABELS,
+        multiprocess_mode="livesum",
     )
 
     checked_out_connections_gauge = Gauge(
         f"{PROM_POOL_PREFIX}_active_connections",
         "Number of connections in use by this pool (checked out + overflow)",
         PROM_POOL_LABELS,
+        multiprocess_mode="livesum",
     )
     checked_in_connections_gauge = Gauge(
         f"{PROM_POOL_PREFIX}_idle_connections",
         "Number of connections not in use by this pool (unused pool connections)",
         PROM_POOL_LABELS,
+        multiprocess_mode="livesum",
     )
 
     PROM_LABELS = [
@@ -198,6 +201,7 @@ class SQLAlchemyEngineContextFactory(ContextFactory):
         f"{PROM_PREFIX}_active_requests",
         "total requests that are in-flight",
         PROM_LABELS,
+        multiprocess_mode="livesum",
     )
 
     requests_total = Counter(

--- a/baseplate/clients/thrift.py
+++ b/baseplate/clients/thrift.py
@@ -62,6 +62,7 @@ ACTIVE_REQUESTS = Gauge(
     f"{PROM_NAMESPACE}_active_requests",
     "number of in-flight requests",
     PROM_COMMON_LABELS,
+    multiprocess_mode="livesum",
 )
 
 

--- a/baseplate/frameworks/pyramid/__init__.py
+++ b/baseplate/frameworks/pyramid/__init__.py
@@ -115,6 +115,7 @@ ACTIVE_REQUESTS = Gauge(
         "http_method",
         "http_endpoint",
     ],
+    multiprocess_mode="livesum",
 )
 
 

--- a/baseplate/frameworks/queue_consumer/kafka.py
+++ b/baseplate/frameworks/queue_consumer/kafka.py
@@ -65,6 +65,7 @@ KAFKA_ACTIVE_MESSAGES = Gauge(
     "kafka_consumer_active_messages",
     "gauge that reflects the number of messages currently being processed",
     KafkaConsumerPrometheusLabels._fields,
+    multiprocess_mode="livesum",
 )
 
 

--- a/baseplate/frameworks/queue_consumer/kombu.py
+++ b/baseplate/frameworks/queue_consumer/kombu.py
@@ -55,6 +55,7 @@ AMQP_ACTIVE_MESSAGES = Gauge(
     "amqp_consumer_active_messages",
     "gauge that reflects the number of messages currently being processed",
     AmqpConsumerPrometheusLabels._fields,
+    multiprocess_mode="livesum",
 )
 
 

--- a/baseplate/frameworks/thrift/__init__.py
+++ b/baseplate/frameworks/thrift/__init__.py
@@ -53,6 +53,7 @@ PROM_ACTIVE = Gauge(
     f"{PROM_NAMESPACE}_active_requests",
     "The number of in-flight requests being handled by the service",
     ["thrift_method"],
+    multiprocess_mode="livesum",
 )
 
 


### PR DESCRIPTION
<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 💸 TL;DR
Set the multiprocess mode on `http_server_active_requests` to "livesum" to reduce the cardinality to one metric per server.

## 📜 Details
[Design Doc](<!-- insert Google Doc link here if applicable -->)

[Jira](<!-- insert Jira link if applicable -->)

<!-- Add additional details required for the PR: breaking changes, screenshots, external dependency changes -->

## 🧪 Testing Steps / Validation
<!-- add details on how this PR has been tested, include reproductions and screenshots where applicable -->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] CI tests (if present) are passing
- [ ] Adheres to code style for repo
- [ ] Contributor License Agreement (CLA) completed if not a Reddit employee
