### PR TITLE
expose prometheus metrics for Zookeeper in live-data sidecar

### DIFF
--- a/baseplate/lib/live_data/zookeeper.py
+++ b/baseplate/lib/live_data/zookeeper.py
@@ -11,17 +11,17 @@ from baseplate.lib.secrets import SecretsStore
 from baseplate.server.monkey import gevent_is_patched
 
 SESSION_LOST_TOTAL = Counter(
-    "zookeeper_client_session_lost_total",
+    "live_data_fetcher_lost_sessions_total",
     "The number of times a Zookeeper client has had a session be lost.",
 )
 
 SESSION_SUSPENDED_TOTAL = Counter(
-    "zookeeper_client_session_suspended_total",
+    "live_data_fetcher_suspended_sessions_total",
     "The number of times a Zookeeper client has had a session be suspended.",
 )
 
 SESSION_SUCCESSFUL_TOTAL = Counter(
-    "zookeeper_client_session_connected_total",
+    "live_data_fetcher_connected_sessions_total",
     "The number of times a Zookeeper client has successfully established a session.",
 )
 

--- a/baseplate/lib/live_data/zookeeper.py
+++ b/baseplate/lib/live_data/zookeeper.py
@@ -1,14 +1,14 @@
 """Helpers for interacting with ZooKeeper."""
 from typing import Optional
 
-from kazoo.client import KazooClient, KazooState
+from kazoo.client import KazooClient
+from kazoo.client import KazooState
 from kazoo.handlers.gevent import SequentialGeventHandler
+from prometheus_client import Counter
 
 from baseplate.lib import config
 from baseplate.lib.secrets import SecretsStore
 from baseplate.server.monkey import gevent_is_patched
-
-from prometheus_client import Counter
 
 SESSION_LOST_TOTAL = Counter(
     "zookeeper_client_session_lost",

--- a/baseplate/lib/live_data/zookeeper.py
+++ b/baseplate/lib/live_data/zookeeper.py
@@ -12,24 +12,26 @@ from baseplate.server.monkey import gevent_is_patched
 
 SESSION_LOST_TOTAL = Counter(
     "zookeeper_client_session_lost",
-    "The number of times a Zookeeper session as been lost for a client."
+    "The number of times a Zookeeper session as been lost for a client.",
 )
 
 SESSION_SUSPENDED_TOTAL = Counter(
     "zookeeper_client_session_suspended",
-    "The number of times a Zookeeper session as been suspended for a client."
+    "The number of times a Zookeeper session as been suspended for a client.",
 )
 
 SESSION_SUCCESSFUL_TOTAL = Counter(
     "zookeeper_client_session_connected",
-    "The number of times a Zookeeper session has successfully connected for a client."
+    "The number of times a Zookeeper session has successfully connected for a client.",
 )
 
+
 class SessionStatsListener:
-    """ A Kazoo listener that monitors changes in connection state.
+    """A Kazoo listener that monitors changes in connection state.
     Increments an event counter whenever connection state changes in a
     Zookeeper connection.
     """
+
     def __init__(self):
         pass
 
@@ -40,6 +42,7 @@ class SessionStatsListener:
             SESSION_SUSPENDED_TOTAL.inc()
         else:
             SESSION_SUCCESSFUL_TOTAL.inc()
+
 
 def zookeeper_client_from_config(
     secrets: SecretsStore, app_config: config.RawConfig, read_only: Optional[bool] = None

--- a/baseplate/lib/live_data/zookeeper.py
+++ b/baseplate/lib/live_data/zookeeper.py
@@ -11,18 +11,18 @@ from baseplate.lib.secrets import SecretsStore
 from baseplate.server.monkey import gevent_is_patched
 
 SESSION_LOST_TOTAL = Counter(
-    "zookeeper_client_session_lost",
-    "The number of times a Zookeeper session as been lost for a client.",
+    "zookeeper_client_session_lost_total",
+    "The number of times a Zookeeper client has had a session be lost.",
 )
 
 SESSION_SUSPENDED_TOTAL = Counter(
-    "zookeeper_client_session_suspended",
-    "The number of times a Zookeeper session as been suspended for a client.",
+    "zookeeper_client_session_suspended_total",
+    "The number of times a Zookeeper client has had a session be suspended.",
 )
 
 SESSION_SUCCESSFUL_TOTAL = Counter(
-    "zookeeper_client_session_connected",
-    "The number of times a Zookeeper session has successfully connected for a client.",
+    "zookeeper_client_session_connected_total",
+    "The number of times a Zookeeper client has successfully established a session.",
 )
 
 

--- a/baseplate/lib/live_data/zookeeper.py
+++ b/baseplate/lib/live_data/zookeeper.py
@@ -32,10 +32,7 @@ class SessionStatsListener:
     Zookeeper connection.
     """
 
-    def __init__(self):
-        pass
-
-    def __call__(self, state):
+    def __call__(self, state: KazooState) -> None:
         if state == KazooState.LOST:
             SESSION_LOST_TOTAL.inc()
         elif state == KazooState.SUSPENDED:

--- a/baseplate/sidecars/live_data_watcher.py
+++ b/baseplate/sidecars/live_data_watcher.py
@@ -17,7 +17,6 @@ import json
 import logging
 import os
 import sys
-import time
 
 from enum import Enum
 from pathlib import Path

--- a/baseplate/sidecars/live_data_watcher.py
+++ b/baseplate/sidecars/live_data_watcher.py
@@ -25,6 +25,7 @@ from typing import Any
 from typing import NoReturn
 from typing import Optional
 
+import gevent
 import boto3  # type: ignore
 
 from botocore import UNSIGNED  # type: ignore

--- a/baseplate/sidecars/live_data_watcher.py
+++ b/baseplate/sidecars/live_data_watcher.py
@@ -1,5 +1,6 @@
 """Watch nodes in ZooKeeper and sync their contents to disk on change."""
 from gevent.monkey import patch_all
+
 from baseplate.server.monkey import patch_stdlib_queues
 
 # In order to allow Prometheus to scrape metrics, we need to concurrently

--- a/baseplate/sidecars/live_data_watcher.py
+++ b/baseplate/sidecars/live_data_watcher.py
@@ -1,4 +1,5 @@
 """Watch nodes in ZooKeeper and sync their contents to disk on change."""
+# pylint: disable=wrong-import-position,wrong-import-order
 from gevent.monkey import patch_all
 
 from baseplate.server.monkey import patch_stdlib_queues
@@ -24,8 +25,8 @@ from typing import Any
 from typing import NoReturn
 from typing import Optional
 
-import gevent
 import boto3  # type: ignore
+import gevent
 
 from botocore import UNSIGNED  # type: ignore
 from botocore.client import ClientError  # type: ignore

--- a/baseplate/sidecars/live_data_watcher.py
+++ b/baseplate/sidecars/live_data_watcher.py
@@ -200,7 +200,7 @@ def watch_zookeeper_nodes(zookeeper: KazooClient, nodes: Any) -> NoReturn:
     # all the interesting stuff is now happening in the Kazoo worker thread
     # and so we'll just spin and periodically heartbeat to prove we're alive.
     while True:
-        time.sleep(HEARTBEAT_INTERVAL)
+        gevent.sleep(HEARTBEAT_INTERVAL)
 
         # see the comment in baseplate.live_data.zookeeper for explanation of
         # how reconnects work with the background thread.


### PR DESCRIPTION
## 💸 TL;DR
This introduces new metrics for the live-data sidecar, monitoring Zookeeper session state. We record sessions loss and session suspension, indicators that Zookeeper clusters are exhibiting issues from the client-side.

## 📜 Details
Introduces three new prometheus counters for recording Zookeeper session state transitions.
Similar to https://github.com/reddit/baseplate.py/pull/742 this change adds prometheus exporting for the live-data sidecar.

[Jira]
https://reddit.atlassian.net/browse/STRGS-268

## 🧪 Testing Steps / Validation
Ran this locally against a dockerized Zookeeper container populated with fake experiment data.
```
PROMETHEUS_MULTIPROC_DIR=~/scratch BASEPLATE_SIDECAR_METRICS_PORT=6061 python baseplate/sidecars/live_data_watcher.py ~/scratch/fake_config.ini
```

## ✅ Checks
- [ ] CI tests (if present) are passing
- [x] Adheres to code style for repo
~~Contributor License Agreement (CLA) completed if not a Reddit employee~~
