### PR TITLE
Make the metrics client optional

### DIFF
--- a/baseplate/__init__.py
+++ b/baseplate/__init__.py
@@ -340,7 +340,6 @@ class Baseplate:
                     self._app_config, self._metrics_client
                 )
             )
-
         elif "metrics.namespace" in self._app_config:
             from baseplate.lib.metrics import metrics_client_from_config
             from baseplate.observers.metrics import MetricsBaseplateObserver
@@ -351,9 +350,8 @@ class Baseplate:
                     self._app_config, self._metrics_client
                 )
             )
-
         else:
-            skipped.append("metrics")
+            skipped.append("statsd metrics")
 
         if "tracing.service_name" in self._app_config:
             from baseplate.observers.tracing import tracing_client_from_config

--- a/baseplate/clients/redis.py
+++ b/baseplate/clients/redis.py
@@ -178,11 +178,8 @@ class RedisContextFactory(ContextFactory):
         self.redis_client_name = redis_client_name
 
     def report_runtime_metrics(self, batch: Optional[metrics.Client]) -> None:
-        logger.info("reporting redis client runtime metrics pre")
         if not isinstance(self.connection_pool, redis.BlockingConnectionPool):
             return
-
-        logger.info("reporting redis client runtime metrics")
 
         size = self.connection_pool.max_connections
         open_connections_num = len(self.connection_pool._connections)  # type: ignore

--- a/baseplate/clients/redis.py
+++ b/baseplate/clients/redis.py
@@ -178,6 +178,7 @@ class RedisContextFactory(ContextFactory):
         self.redis_client_name = redis_client_name
 
     def report_runtime_metrics(self, batch: Optional[metrics.Client]) -> None:
+        logger.info("reporting redis client runtime metrics pre")
         if not isinstance(self.connection_pool, redis.BlockingConnectionPool):
             return
 

--- a/baseplate/clients/redis.py
+++ b/baseplate/clients/redis.py
@@ -5,6 +5,7 @@ from typing import Dict
 from typing import Optional
 
 import redis
+import logging
 
 # redis.client.StrictPipeline was renamed to redis.client.Pipeline in version 3.0
 try:
@@ -23,6 +24,8 @@ from baseplate.lib import message_queue
 from baseplate.lib import metrics
 
 from baseplate.lib.prometheus_metrics import default_latency_buckets
+
+logger = logging.getLogger(__name__)
 
 PROM_PREFIX = "redis_client"
 PROM_LABELS_PREFIX = "redis"
@@ -177,6 +180,8 @@ class RedisContextFactory(ContextFactory):
     def report_runtime_metrics(self, batch: Optional[metrics.Client]) -> None:
         if not isinstance(self.connection_pool, redis.BlockingConnectionPool):
             return
+
+        logger.info("reporting redis client runtime metrics")
 
         size = self.connection_pool.max_connections
         open_connections_num = len(self.connection_pool._connections)  # type: ignore

--- a/baseplate/clients/redis.py
+++ b/baseplate/clients/redis.py
@@ -1,4 +1,3 @@
-import redis
 import logging
 
 from math import ceil
@@ -6,6 +5,8 @@ from time import perf_counter
 from typing import Any
 from typing import Dict
 from typing import Optional
+
+import redis
 
 # redis.client.StrictPipeline was renamed to redis.client.Pipeline in version 3.0
 try:

--- a/baseplate/clients/redis.py
+++ b/baseplate/clients/redis.py
@@ -1,11 +1,11 @@
+import redis
+import logging
+
 from math import ceil
 from time import perf_counter
 from typing import Any
 from typing import Dict
 from typing import Optional
-
-import redis
-import logging
 
 # redis.client.StrictPipeline was renamed to redis.client.Pipeline in version 3.0
 try:

--- a/baseplate/clients/redis_cluster.py
+++ b/baseplate/clients/redis_cluster.py
@@ -379,7 +379,7 @@ class ClusterRedisContextFactory(ContextFactory):
         self.name = name
         self.redis_client_name = redis_client_name
 
-    def report_runtime_metrics(self, batch: metrics.Client) -> None:
+    def report_runtime_metrics(self, batch: Optional[metrics.Client]) -> None:
         if not isinstance(self.connection_pool, rediscluster.ClusterBlockingConnectionPool):
             return
 
@@ -388,8 +388,9 @@ class ClusterRedisContextFactory(ContextFactory):
         MAX_CONNECTIONS.labels(self.name).set(size)
         OPEN_CONNECTIONS.labels(self.name).set(open_connections_num)
 
-        batch.gauge("pool.size").replace(size)
-        batch.gauge("pool.open_connections").replace(open_connections_num)
+        if batch:
+            batch.gauge("pool.size").replace(size)
+            batch.gauge("pool.open_connections").replace(open_connections_num)
 
     def make_object_for_context(self, name: str, span: Span) -> "MonitoredRedisClusterConnection":
         return MonitoredRedisClusterConnection(

--- a/baseplate/clients/thrift.py
+++ b/baseplate/clients/thrift.py
@@ -148,7 +148,7 @@ class ThriftContextFactory(ContextFactory):
         self.max_connections_gauge.labels(pool_name).set(self.pool.size)
         self.active_connections_gauge.labels(pool_name).set(self.pool.checkedout)
 
-        if batch: 
+        if batch:
             batch.gauge("pool.size").replace(self.pool.size)
             batch.gauge("pool.in_use").replace(self.pool.checkedout)
 

--- a/baseplate/server/runtime_monitor.py
+++ b/baseplate/server/runtime_monitor.py
@@ -255,7 +255,7 @@ def start(server_config: Dict[str, str], application: Any, pool: Pool) -> None:
 
     if cfg.monitoring.connection_pool:
         reporters.append(_BaseplateReporter(baseplate.get_runtime_metric_reporters()))
-        logger.info("Set up conneciton pool monitoring")
+        logger.info("Set up connection pool monitoring")
 
     if cfg.monitoring.blocked_hub is not None:
         try:

--- a/baseplate/server/runtime_monitor.py
+++ b/baseplate/server/runtime_monitor.py
@@ -46,6 +46,7 @@ class _OpenConnectionsReporter(_Reporter):
         if batch:
             batch.gauge("open_connections").replace(len(self.pool.greenlets))
 
+
 class _ActiveRequestsObserver(BaseplateObserver, _Reporter):
     def __init__(self) -> None:
         self.live_requests: Dict[str, float] = {}

--- a/baseplate/server/runtime_monitor.py
+++ b/baseplate/server/runtime_monitor.py
@@ -218,6 +218,7 @@ def _report_runtime_metrics_periodically(
             except Exception as exc:
                 logger.debug("Error while sending server metrics: %s", exc)
         else:
+            logger.info("triggering reporters")
             for reporter in reporters:
                 reporter.report(None)
 
@@ -250,31 +251,37 @@ def start(server_config: Dict[str, str], application: Any, pool: Pool) -> None:
         observer = _ActiveRequestsObserver()
         reporters.append(observer)
         baseplate.register(observer)
+        logger.info("Set up concurrency monitoring")
 
     if cfg.monitoring.connection_pool:
         reporters.append(_BaseplateReporter(baseplate.get_runtime_metric_reporters()))
+        logger.info("Set up conneciton pool monitoring")
 
     if cfg.monitoring.blocked_hub is not None:
         try:
             reporters.append(_BlockedGeventHubReporter(cfg.monitoring.blocked_hub.total_seconds()))
+            logger.info("Set up blocked gevent monitoring")
         except Exception as exc:
             logger.info("monitoring.blocked_hub disabled: %s", exc)
 
     if cfg.monitoring.gc.stats:
         try:
             reporters.append(_GCStatsReporter())
+            logger.info("Set up gc monitoring")
         except Exception as exc:
             logger.info("monitoring.gc.stats disabled: %s", exc)
 
     if cfg.monitoring.gc.timing:
         try:
             reporters.append(_GCTimingReporter())
+            logger.info("Set up gc.timing monitoring")
         except Exception as exc:
             logger.info("monitoring.gc.timing disabled: %s", exc)
 
     if cfg.monitoring.gc.refcycle:
         try:
             reporters.append(_RefCycleReporter(cfg.monitoring.gc.refcycle))
+            logger.info("Set up gc.refcycle monitoring")
         except Exception as exc:
             logger.info("monitoring.gc.refcycle disabled: %s", exc)
 

--- a/baseplate/server/runtime_monitor.py
+++ b/baseplate/server/runtime_monitor.py
@@ -200,6 +200,7 @@ def _report_runtime_metrics_periodically(
         time.sleep(time_until_next_report)
 
         if metrics_client:
+            try:
                 with metrics_client.batch() as batch:
                     batch.namespace += b".runtime"
                     batch.base_tags["hostname"] = hostname
@@ -214,8 +215,8 @@ def _report_runtime_metrics_periodically(
                                 reporter.__class__.__name__,
                                 exc,
                             )
-                        except Exception as exc:
-                            logger.debug("Error while sending server metrics: %s", exc)
+            except Exception as exc:
+                logger.debug("Error while sending server metrics: %s", exc)
         else:
             for reporter in reporters:
                 reporter.report(None)

--- a/baseplate/server/runtime_monitor.py
+++ b/baseplate/server/runtime_monitor.py
@@ -142,14 +142,15 @@ class _BaseplateReporter(_Reporter):
         self.reporters = reporters
 
     def report(self, batch: metrics.Batch) -> None:
-        if batch:
-            for name, reporter in self.reporters.items():
-                try:
+        for name, reporter in self.reporters.items():
+            try:
+                if batch:
                     batch.base_tags["client"] = name
-                    reporter(batch)
-                except Exception as exc:
-                    logger.exception("Error generating client metrics: %s: %s", name, exc)
-                finally:
+                reporter(batch)
+            except Exception as exc:
+                logger.exception("Error generating client metrics: %s: %s", name, exc)
+            finally:
+                if batch:
                     del batch.base_tags["client"]
 
 
@@ -218,7 +219,6 @@ def _report_runtime_metrics_periodically(
             except Exception as exc:
                 logger.debug("Error while sending server metrics: %s", exc)
         else:
-            logger.info("triggering reporters")
             for reporter in reporters:
                 reporter.report(None)
 

--- a/baseplate/server/runtime_monitor.py
+++ b/baseplate/server/runtime_monitor.py
@@ -200,7 +200,6 @@ def _report_runtime_metrics_periodically(
         time.sleep(time_until_next_report)
 
         if metrics_client:
-            try:
                 with metrics_client.batch() as batch:
                     batch.namespace += b".runtime"
                     batch.base_tags["hostname"] = hostname
@@ -215,10 +214,11 @@ def _report_runtime_metrics_periodically(
                                 reporter.__class__.__name__,
                                 exc,
                             )
-            except Exception as exc:
-                logger.debug("Error while sending server metrics: %s", exc)
+                        except Exception as exc:
+                            logger.debug("Error while sending server metrics: %s", exc)
         else:
-            reporter.report(None)
+            for reporter in reporters:
+                reporter.report(None)
 
 
 def start(server_config: Dict[str, str], application: Any, pool: Pool) -> None:


### PR DESCRIPTION
<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 💸 TL;DR
When you remove the configs for metrics.tagging or metrics.namespace, it no longer creates a statsd metrics client, which is expected, but ends up disabling running through the runtime metrics, which is not. This results in some prometheus metrics such as connection pool information from the redis client to not report. Currently testing

## 🧪 Testing Steps / Validation
<!-- add details on how this PR has been tested, include reproductions and screenshots where applicable -->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] CI tests (if present) are passing
- [ ] Adheres to code style for repo
- [ ] Contributor License Agreement (CLA) completed if not a Reddit employee
