### PR TITLE
BASEPLATE_SIDECAR_(s/METRICS/ADMIN)_PORT

### DIFF
--- a/baseplate/server/prometheus.py
+++ b/baseplate/server/prometheus.py
@@ -78,10 +78,10 @@ def start_prometheus_exporter(address: EndpointConfiguration = PROMETHEUS_EXPORT
 
 
 def start_prometheus_exporter_for_sidecar() -> None:
-    port = os.environ.get("BASEPLATE_SIDECAR_METRICS_PORT")
+    port = os.environ.get("BASEPLATE_SIDECAR_ADMIN_PORT")
     if port is None:
         logger.error(
-            "BASEPLATE_SIDECAR_METRICS_PORT must be set for sidecar to expose Prometheus metrics."
+            "BASEPLATE_SIDECAR_ADMIN_PORT must be set for sidecar to expose Prometheus metrics."
         )
     else:
         endpoint = Endpoint("0.0.0.0:" + port)


### PR DESCRIPTION
I ended up naming the env var slightly differently https://github.snooguts.net/reddit/infrared/blob/master/pkg/baseplate/sidecars.go#L47

Updating it here to match

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] CI tests (if present) are passing - fixed in separate PR here https://github.com/reddit/baseplate.py/pull/750
- [x] Adheres to code style for repo
- [ ] Contributor License Agreement (CLA) completed if not a Reddit employee
