### PR TITLE
upgrade flake8 and pylint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ build/
 dist/
 .eggs/
 .mypy_cache/
+
+.idea/

--- a/baseplate/clients/redis.py
+++ b/baseplate/clients/redis.py
@@ -255,7 +255,7 @@ class MonitoredRedisConnection(redis.StrictRedis):
                 REQUESTS_TOTAL.labels(**result_labels).inc()
                 LATENCY_SECONDS.labels(**result_labels).observe(perf_counter() - start_time)
 
-    # pylint: disable=arguments-differ
+    # pylint: disable=arguments-renamed
     def pipeline(  # type: ignore
         self, name: str, transaction: bool = True, shard_hint: Optional[str] = None
     ) -> "MonitoredRedisPipeline":

--- a/baseplate/lib/edgecontext.py
+++ b/baseplate/lib/edgecontext.py
@@ -14,4 +14,3 @@ class EdgeContextFactory(ABC):
         :param header_value: The raw bytes of the header payload.
 
         """
-        ...

--- a/pylintrc
+++ b/pylintrc
@@ -7,9 +7,6 @@
 # pygtk.require().
 #init-hook=
 
-# Profiled execution.
-profile=no
-
 # Add files or directories to the blacklist. They should be base names, not
 # paths.
 ignore=thrift
@@ -39,7 +36,6 @@ load-plugins=pylint_baseplate_plugin
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
 disable= attribute-defined-outside-init,
-         bad-continuation,
          broad-except,
          c-extension-no-member,
          duplicate-code,
@@ -48,7 +44,6 @@ disable= attribute-defined-outside-init,
          import-outside-toplevel,
          line-too-long,
          missing-docstring,
-         no-self-use,
          protected-access,
          too-few-public-methods,
          too-many-arguments,
@@ -72,11 +67,6 @@ disable= attribute-defined-outside-init,
 # mypackage.mymodule.MyReporterClass.
 output-format=text
 
-# Put messages in a separate file for each module / package specified on the
-# command line instead of printing them on stdout. Reports (if any) will be
-# written in a file name "pylint_global.[txt|html]".
-files-output=no
-
 # Tells whether to display a full report or only the messages
 reports=yes
 
@@ -86,10 +76,6 @@ reports=yes
 # number of statements analyzed. This is used by the global evaluation report
 # (RP0004).
 evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
-
-# Add a comment according to your evaluation note. This is used by the global
-# evaluation report (RP0004).
-comment=no
 
 # Template used to display messages. This is a python new-style format string
 # used to format the message information. See doc for all details
@@ -143,9 +129,6 @@ ignore-long-lines=^\s*(# )?<?https?://\S+>?$
 # else.
 single-line-if-stmt=no
 
-# List of optional constructs for which whitespace checking is disabled
-no-space-check=trailing-comma,dict-separator
-
 # Maximum number of lines in a module
 max-module-lines=1000
 
@@ -164,10 +147,6 @@ ignore-mixin-members=yes
 # (useful for classes with attributes dynamically set).
 ignored-classes=SQLObject,Error
 
-# When zope mode is activated, add a predefined set of Zope acquired attributes
-# to generated-members.
-zope=no
-
 # List of members which are set dynamically and missed by pylint inference
 # system, and so shouldn't trigger E0201 when accessed. Python regular
 # expressions are accepted.
@@ -176,11 +155,8 @@ generated-members=REQUEST,acl_users,aq_parent
 
 [BASIC]
 
-# Required attributes for module, separated by a comma
-required-attributes=
-
 # List of builtins function names that should not be used, separated by a comma
-bad-functions=map,filter,apply,input
+bad-builtin=map,filter,apply,input
 
 # Regular expression which should only match correct module names
 module-rgx=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
@@ -230,10 +206,6 @@ docstring-min-length=-1
 
 
 [CLASSES]
-
-# List of interface methods to ignore, separated by a comma. This is used for
-# instance to not check methods defines in Zope's Interface base class.
-ignore-iface-methods=isImplementedBy,deferred,extends,names,namesAndDescriptions,queryDescriptionFor,getBases,getDescriptionFor,getDoc,getName,getTaggedValue,getTaggedValueTags,isEqualOrExtendedBy,setTaggedValue,isImplementedByInstancesOf,adaptWith,is_implemented_by
 
 # List of method names used to declare (i.e. assign) instance attributes.
 defining-attr-methods=__init__,__new__,setUp

--- a/requirements-transitive.txt
+++ b/requirements-transitive.txt
@@ -28,6 +28,7 @@ greenlet==1.0.0
 hupper==1.10.2
 idna==2.10
 imagesize==1.2.0
+importlib-metadata==4.2.0
 iniconfig==1.1.1
 isort==5.7.0
 Jinja2==2.11.3
@@ -35,6 +36,7 @@ kazoo==2.8.0
 kombu==4.6.11
 lazy-object-proxy==1.4.3
 MarkupSafe==1.1.1
+mccabe==0.7.0
 moto==3.1.4
 mypy-extensions==0.4.3
 ndg-httpsclient==0.5.1
@@ -50,8 +52,10 @@ pluggy==0.13.1
 posix-ipc==1.0.5
 py==1.10.0
 pyasn1==0.4.8
+pycodestyle==2.9.1
 pycparser==2.20
 pyenchant==3.2.0
+pyflakes==2.5.0
 Pygments==2.7.4
 pymemcache==1.4.3
 pyOpenSSL==20.0.1

--- a/requirements-transitive.txt
+++ b/requirements-transitive.txt
@@ -35,7 +35,6 @@ kazoo==2.8.0
 kombu==4.6.11
 lazy-object-proxy==1.4.3
 MarkupSafe==1.1.1
-mccabe==0.6.1
 moto==3.1.4
 mypy-extensions==0.4.3
 ndg-httpsclient==0.5.1
@@ -51,10 +50,8 @@ pluggy==0.13.1
 posix-ipc==1.0.5
 py==1.10.0
 pyasn1==0.4.8
-pycodestyle==2.6.0
 pycparser==2.20
 pyenchant==3.2.0
-pyflakes==2.2.0
 Pygments==2.7.4
 pymemcache==1.4.3
 pyOpenSSL==20.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,15 +4,14 @@
 # See install_requires and extras_require in setup.py for the range of versions
 # supported.
 -r requirements-transitive.txt
-astroid==2.8.4
 black==21.10b0
 boto3==1.21.20
-flake8==3.8.4
+flake8==5.0.4
 lxml==4.6.5
 mypy==0.910
 prometheus-client==0.14.1
 pydocstyle==5.1.1
-pylint==2.11.1
+pylint==2.15.3
 pytest==6.2.2
 pytest-cov==2.11.1
 pytz==2021.1

--- a/tests/unit/lint/db_query_string_format_plugin_tests.py
+++ b/tests/unit/lint/db_query_string_format_plugin_tests.py
@@ -18,7 +18,7 @@ class TestNoCQLStringFormatChecker(pylint.testutils.CheckerTestCase):
         self.checker.visit_assign(assign_node_a)
         self.checker.visit_call(call_node_b)
         self.assertAddsMessages(
-            pylint.testutils.Message(msg_id="database-query-string-format", node=call_node_b)
+            pylint.testutils.MessageTest(msg_id="database-query-string-format", node=call_node_b)
         )
 
     def test_finds_variable_call_string_format_query(self):
@@ -32,7 +32,7 @@ class TestNoCQLStringFormatChecker(pylint.testutils.CheckerTestCase):
         self.checker.visit_assign(assign_node_a)
         self.checker.visit_call(call_node_b)
         self.assertAddsMessages(
-            pylint.testutils.Message(msg_id="database-query-string-format", node=call_node_b)
+            pylint.testutils.MessageTest(msg_id="database-query-string-format", node=call_node_b)
         )
 
     def test_finds_binop_string_format_query(self):
@@ -44,7 +44,7 @@ class TestNoCQLStringFormatChecker(pylint.testutils.CheckerTestCase):
 
         self.checker.visit_call(call_node_a)
         self.assertAddsMessages(
-            pylint.testutils.Message(msg_id="database-query-string-format", node=call_node_a)
+            pylint.testutils.MessageTest(msg_id="database-query-string-format", node=call_node_a)
         )
 
     def test_finds_call_string_format_query(self):
@@ -56,7 +56,7 @@ class TestNoCQLStringFormatChecker(pylint.testutils.CheckerTestCase):
 
         self.checker.visit_call(call_node_a)
         self.assertAddsMessages(
-            pylint.testutils.Message(msg_id="database-query-string-format", node=call_node_a)
+            pylint.testutils.MessageTest(msg_id="database-query-string-format", node=call_node_a)
         )
 
     def test_ignores_variable_non_string_format_query(self):

--- a/tests/unit/lint/example_plugin_tests.py
+++ b/tests/unit/lint/example_plugin_tests.py
@@ -23,7 +23,7 @@ class TestNoReassignmentChecker(pylint.testutils.CheckerTestCase):
         self.checker.visit_assign(assign_node_a)
         self.checker.visit_assign(assign_node_b)
         self.assertAddsMessages(
-            pylint.testutils.Message(msg_id="reassigned-variable", node=assign_node_a)
+            pylint.testutils.MessageTest(msg_id="reassigned-variable", node=assign_node_a)
         )
 
     def test_ignores_no_reassigned_variable(self):


### PR DESCRIPTION
## 💸 TL;DR
Builds were failing (e.g. [link](https://github.com/reddit/baseplate.py/actions/runs/3200563486/jobs/5227611744)) because importlib_metadata (a dependency of flake8) [removed a feature](https://importlib-metadata.readthedocs.io/en/latest/history.html). Pinning it to `importlib_metadata < 5` works, but instead let's just update flake8.

That had some conflicts, so updating pylint as well (and removing some transitive dependencies that don't seem important to pin since they are already effectively pinned by the existing imports).
## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] CI tests (if present) are passing
- [ ] Adheres to code style for repo
- [ ] Contributor License Agreement (CLA) completed if not a Reddit employee
