### PR TITLE
add Prometheus to remaining sidecar types

### DIFF
--- a/baseplate/sidecars/event_publisher.py
+++ b/baseplate/sidecars/event_publisher.py
@@ -1,3 +1,16 @@
+# pylint: disable=wrong-import-position,wrong-import-order
+from gevent.monkey import patch_all
+
+from baseplate.server.monkey import patch_stdlib_queues
+
+# In order to allow Prometheus to scrape metrics, we need to concurrently
+# handle requests to '/metrics' along with the sidecar's execution.
+# Monkey patching is used to replace the stdlib sequential versions of functions
+# with concurrent versions. It must happen as soon as possible, before the
+# sequential versions are imported.
+patch_all()
+patch_stdlib_queues()
+
 import argparse
 import configparser
 import email.utils
@@ -10,9 +23,13 @@ from typing import Any
 from typing import List
 from typing import Optional
 
+import gevent
 import requests
 
-from baseplate import __version__ as baseplate_version
+from prometheus_client import Counter
+
+from baseplate import Baseplate
+from baseplate.clients.requests import ExternalRequestsClient
 from baseplate.lib import config
 from baseplate.lib import metrics
 from baseplate.lib.events import MAX_EVENT_SIZE
@@ -42,6 +59,8 @@ MAX_RETRY_TIME = 5 * 60
 MAX_BATCH_AGE = 1
 # maximum size (in bytes) of a batch of events
 MAX_BATCH_SIZE = 500 * 1024
+
+PUBLISHES_COUNT_TOTAL = Counter("event_publishes_total", "total count of published events")
 
 
 class MaxRetriesError(Exception):
@@ -100,14 +119,17 @@ class V2JBatch(V2Batch):
 
 class BatchPublisher:
     def __init__(self, metrics_client: metrics.Client, cfg: Any):
+        bp = Baseplate()
+        bp.configure_context(
+            {
+                "http_client": ExternalRequestsClient("event_collector"),
+            }
+        )
+        self.baseplate = bp
         self.metrics = metrics_client
         self.url = f"{cfg.collector.scheme}://{cfg.collector.hostname}/v{cfg.collector.version}"
         self.key_name = cfg.key.name
         self.key_secret = cfg.key.secret
-        self.session = requests.Session()
-        self.session.headers[
-            "User-Agent"
-        ] = f"baseplate.py-{self.__class__.__name__}/{baseplate_version}"
 
     def _sign_payload(self, payload: bytes) -> str:
         digest = hmac.new(self.key_secret, payload, hashlib.sha256).hexdigest()
@@ -129,15 +151,14 @@ class BatchPublisher:
 
         for _ in RetryPolicy.new(budget=MAX_RETRY_TIME, backoff=RETRY_BACKOFF):
             try:
-                with self.metrics.timer("post"):
-                    response = self.session.post(
-                        self.url,
-                        headers=headers,
-                        data=compressed_payload,
-                        timeout=POST_TIMEOUT,
-                        # http://docs.python-requests.org/en/latest/user/advanced/#keep-alive
-                        stream=False,
-                    )
+                with self.baseplate.server_context("post") as context:
+                    with self.metrics.timer("post"):
+                        response = context.http_client.post(
+                            self.url,
+                            headers=headers,
+                            data=compressed_payload,
+                            timeout=POST_TIMEOUT,
+                        )
                 response.raise_for_status()
             except requests.HTTPError as exc:
                 self.metrics.counter("error.http").increment()
@@ -155,6 +176,7 @@ class BatchPublisher:
                 self.metrics.counter("error.io").increment()
                 logger.exception("HTTP Request failed")
             else:
+                PUBLISHES_COUNT_TOTAL.inc(payload.item_count)
                 self.metrics.counter("sent").increment(payload.item_count)
                 return
 
@@ -215,6 +237,8 @@ def publish_events() -> None:
     publisher = BatchPublisher(metrics_client, cfg)
 
     while True:
+        # allow other routines to execute (specifically handling requests to /metrics)
+        gevent.sleep(0)
         message: Optional[bytes]
 
         try:

--- a/baseplate/sidecars/event_publisher.py
+++ b/baseplate/sidecars/event_publisher.py
@@ -61,7 +61,7 @@ MAX_BATCH_AGE = 1
 # maximum size (in bytes) of a batch of events
 MAX_BATCH_SIZE = 500 * 1024
 
-PUBLISHES_COUNT_TOTAL = Counter("event_publishes_total", "total count of published events")
+PUBLISHES_COUNT_TOTAL = Counter("eventv2_publishes_total", "total count of published events")
 
 
 class MaxRetriesError(Exception):

--- a/baseplate/sidecars/event_publisher.py
+++ b/baseplate/sidecars/event_publisher.py
@@ -39,6 +39,7 @@ from baseplate.lib.message_queue import TimedOutError
 from baseplate.lib.metrics import metrics_client_from_config
 from baseplate.lib.retry import RetryPolicy
 from baseplate.server import EnvironmentInterpolation
+from baseplate.server.prometheus import start_prometheus_exporter_for_sidecar
 from baseplate.sidecars import Batch
 from baseplate.sidecars import BatchFull
 from baseplate.sidecars import SerializedBatch
@@ -263,4 +264,5 @@ def publish_events() -> None:
 
 
 if __name__ == "__main__":
+    start_prometheus_exporter_for_sidecar()
     publish_events()

--- a/baseplate/sidecars/live_data_watcher.py
+++ b/baseplate/sidecars/live_data_watcher.py
@@ -1,11 +1,23 @@
 """Watch nodes in ZooKeeper and sync their contents to disk on change."""
+# pylint: disable=wrong-import-position,wrong-import-order
+from gevent.monkey import patch_all
+
+from baseplate.server.monkey import patch_stdlib_queues
+
+# In order to allow Prometheus to scrape metrics, we need to concurrently
+# handle requests to '/metrics' along with the sidecar's execution.
+# Monkey patching is used to replace the stdlib sequential versions of functions
+# with concurrent versions. It must happen as soon as possible, before the
+# sequential versions are imported.
+patch_all()
+patch_stdlib_queues()
+
 import argparse
 import configparser
 import json
 import logging
 import os
 import sys
-import time
 
 from enum import Enum
 from pathlib import Path
@@ -14,6 +26,7 @@ from typing import NoReturn
 from typing import Optional
 
 import boto3  # type: ignore
+import gevent
 
 from botocore import UNSIGNED  # type: ignore
 from botocore.client import ClientError  # type: ignore
@@ -26,6 +39,7 @@ from baseplate.lib import config
 from baseplate.lib.live_data.zookeeper import zookeeper_client_from_config
 from baseplate.lib.secrets import secrets_store_from_config
 from baseplate.server import EnvironmentInterpolation
+from baseplate.server.prometheus import start_prometheus_exporter_for_sidecar
 
 
 logger = logging.getLogger(__name__)
@@ -187,7 +201,7 @@ def watch_zookeeper_nodes(zookeeper: KazooClient, nodes: Any) -> NoReturn:
     # all the interesting stuff is now happening in the Kazoo worker thread
     # and so we'll just spin and periodically heartbeat to prove we're alive.
     while True:
-        time.sleep(HEARTBEAT_INTERVAL)
+        gevent.sleep(HEARTBEAT_INTERVAL)
 
         # see the comment in baseplate.live_data.zookeeper for explanation of
         # how reconnects work with the background thread.
@@ -258,4 +272,5 @@ def main() -> NoReturn:
 
 
 if __name__ == "__main__":
+    start_prometheus_exporter_for_sidecar()
     main()

--- a/baseplate/sidecars/secrets_fetcher.py
+++ b/baseplate/sidecars/secrets_fetcher.py
@@ -60,6 +60,19 @@ with the JSON file as its first and only argument. This allows you to read in th
 write to a new file in whatever format needed, and restart other services if necessary.
 
 """
+# pylint: disable=wrong-import-position,wrong-import-order
+from gevent.monkey import patch_all
+
+from baseplate.server.monkey import patch_stdlib_queues
+
+# In order to allow Prometheus to scrape metrics, we need to concurrently
+# handle requests to '/metrics' along with the sidecar's execution.
+# Monkey patching is used to replace the stdlib sequential versions of functions
+# with concurrent versions. It must happen as soon as possible, before the
+# sequential versions are imported.
+patch_all()
+patch_stdlib_queues()
+
 import argparse
 import configparser
 import datetime
@@ -68,7 +81,6 @@ import logging
 import os
 import posixpath
 import subprocess
-import time
 import urllib.parse
 import uuid
 
@@ -78,11 +90,13 @@ from typing import Dict
 from typing import Optional
 from typing import Tuple
 
+import gevent
 import requests
 
 from baseplate import __version__ as baseplate_version
 from baseplate.lib import config
 from baseplate.server import EnvironmentInterpolation
+from baseplate.server.prometheus import start_prometheus_exporter_for_sidecar
 
 
 logger = logging.getLogger(__name__)
@@ -427,8 +441,9 @@ def main() -> None:
             last_proc = trigger_callback(cfg.callback, cfg.output.path, last_proc)
             time_til_expiration = soonest_expiration - datetime.datetime.utcnow()
             time_to_sleep = time_til_expiration - VAULT_TOKEN_PREFETCH_TIME
-            time.sleep(max(int(time_to_sleep.total_seconds()), 1))
+            gevent.sleep(max(int(time_to_sleep.total_seconds()), 1))
 
 
 if __name__ == "__main__":
+    start_prometheus_exporter_for_sidecar()
     main()

--- a/baseplate/sidecars/trace_publisher.py
+++ b/baseplate/sidecars/trace_publisher.py
@@ -57,7 +57,7 @@ MAX_NUM_CONNS = 5
 # maximum number of retries when publishing traces
 RETRY_LIMIT_DEFAULT = 10
 
-PUBLISHES_COUNT_TOTAL = Counter("trace_publishes_total", "total count of published traces")
+PUBLISHES_COUNT_TOTAL = Counter("zipkin_trace_publishes_total", "total count of published traces")
 
 
 class MaxRetriesError(Exception):

--- a/baseplate/sidecars/trace_publisher.py
+++ b/baseplate/sidecars/trace_publisher.py
@@ -23,7 +23,7 @@ import requests
 from prometheus_client import Counter
 
 from baseplate import Baseplate
-from baseplate.clients.requests import ExternalRequestsClient
+from baseplate.clients.requests import InternalRequestsClient
 from baseplate.lib import config
 from baseplate.lib import metrics
 from baseplate.lib.message_queue import MessageQueue
@@ -185,7 +185,7 @@ def publish_traces() -> None:
     bp = Baseplate()
     bp.configure_context(
         {
-            "http_client": ExternalRequestsClient(
+            "http_client": InternalRequestsClient(
                 "trace_collector", pool_connections=MAX_NUM_CONNS, pool_maxsize=MAX_NUM_CONNS
             ),
         }

--- a/tests/unit/observers/tracing/publisher_tests.py
+++ b/tests/unit/observers/tracing/publisher_tests.py
@@ -10,17 +10,24 @@ from baseplate.sidecars import trace_publisher
 
 
 class ZipkinPublisherTest(unittest.TestCase):
-    @mock.patch("requests.Session", autospec=True)
-    def setUp(self, mock_Session):
-        self.session = mock_Session.return_value
-        self.session.headers = {}
+    @mock.patch("baseplate.clients.requests.BaseplateSession", autospec=True)
+    @mock.patch("baseplate.RequestContext", autospec=True)
+    @mock.patch("baseplate.Baseplate", autospec=True)
+    def setUp(self, bp, context, session):
         self.metrics_client = mock.MagicMock(autospec=metrics.Client)
         self.zipkin_api_url = "http://test.local/api/v2"
-        self.publisher = trace_publisher.ZipkinPublisher(self.zipkin_api_url, self.metrics_client)
+
+        bp.server_context.return_value.__enter__.return_value = context
+        context.http_client = session
+        self.baseplate = bp
+        self.session = session
+
+        self.publisher = trace_publisher.ZipkinPublisher(
+            bp, self.zipkin_api_url, self.metrics_client
+        )
 
     def test_initialization(self):
         self.assertEqual(self.publisher.endpoint, f"{self.zipkin_api_url}/spans")
-        self.publisher.session.mount.assert_called_with("http://", mock.ANY)
 
     def test_empty_batch(self):
         self.publisher.publish(SerializedBatch(item_count=0, serialized=b""))


### PR DESCRIPTION
## 💸 TL;DR
Reproducing https://github.com/reddit/baseplate.py/pull/742. This makes all sidecar types expose Prometheus metrics.

## 📜 Details
JIRA
- https://reddit.atlassian.net/browse/DEVX-753
- https://reddit.atlassian.net/browse/BASE-122

## 🧪 Testing Steps / Validation
- [x] tested with a service in snoodev - it worked insofar as it ran, though I'm not 100% sure that all of the behavior is unchanged since the service was not using the sidecars in dev before
- [x] a test in snoodev for services with each of the sidecar types
- [ ] deploy a service for real with an override to use the new versions, and closely monitor it

and only then update infrared to use these by default

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] CI tests (if present) are passing
- [x] Adheres to code style for repo
- [ ] Contributor License Agreement (CLA) completed if not a Reddit employee
