### PR TITLE
Revert "exposing prometheus metrics from event-publisher sidecar (#742)"

### DIFF
--- a/baseplate/sidecars/event_publisher.py
+++ b/baseplate/sidecars/event_publisher.py
@@ -1,16 +1,3 @@
-# pylint: disable=wrong-import-position,wrong-import-order
-from gevent.monkey import patch_all
-
-from baseplate.server.monkey import patch_stdlib_queues
-
-# In order to allow Prometheus to scrape metrics, we need to concurrently
-# handle requests to '/metrics' along with the sidecar's execution.
-# Monkey patching is used to replace the stdlib sequential versions of functions
-# with concurrent versions. It must happen as soon as possible, before the
-# sequential versions are imported.
-patch_all()
-patch_stdlib_queues()
-
 import argparse
 import configparser
 import email.utils
@@ -23,8 +10,6 @@ from typing import Any
 from typing import List
 from typing import Optional
 
-import gevent
-from prometheus_client import Counter, Histogram
 import requests
 
 from baseplate import __version__ as baseplate_version
@@ -37,7 +22,6 @@ from baseplate.lib.message_queue import TimedOutError
 from baseplate.lib.metrics import metrics_client_from_config
 from baseplate.lib.retry import RetryPolicy
 from baseplate.server import EnvironmentInterpolation
-from baseplate.server.prometheus import start_prometheus_exporter_for_sidecar
 from baseplate.sidecars import Batch
 from baseplate.sidecars import BatchFull
 from baseplate.sidecars import SerializedBatch
@@ -114,11 +98,6 @@ class V2JBatch(V2Batch):
         return SerializedBatch(item_count=len(self._items), serialized=serialized)
 
 
-publishCountTotal = Counter("event_publish_total", "total count of published events")
-publishLatency = Histogram("event_publish_latency", "latency for publishing a batch of events")
-publishErrors = Counter("event_publish_errors", "total count of published events", ["error_type"])
-
-
 class BatchPublisher:
     def __init__(self, metrics_client: metrics.Client, cfg: Any):
         self.metrics = metrics_client
@@ -151,18 +130,16 @@ class BatchPublisher:
         for _ in RetryPolicy.new(budget=MAX_RETRY_TIME, backoff=RETRY_BACKOFF):
             try:
                 with self.metrics.timer("post"):
-                    with publishLatency.time():
-                        response = self.session.post(
-                            self.url,
-                            headers=headers,
-                            data=compressed_payload,
-                            timeout=POST_TIMEOUT,
-                            # http://docs.python-requests.org/en/latest/user/advanced/#keep-alive
-                            stream=False,
-                        )
+                    response = self.session.post(
+                        self.url,
+                        headers=headers,
+                        data=compressed_payload,
+                        timeout=POST_TIMEOUT,
+                        # http://docs.python-requests.org/en/latest/user/advanced/#keep-alive
+                        stream=False,
+                    )
                 response.raise_for_status()
             except requests.HTTPError as exc:
-                publishErrors.labels(error_type="http").inc()
                 self.metrics.counter("error.http").increment()
 
                 # we should crash if it's our fault
@@ -175,11 +152,9 @@ class BatchPublisher:
                 else:
                     logger.exception("HTTP Request failed.")
             except OSError:
-                publishErrors.labels(error_type="io").inc()
                 self.metrics.counter("error.io").increment()
                 logger.exception("HTTP Request failed")
             else:
-                publishCountTotal.inc(payload.item_count)
                 self.metrics.counter("sent").increment(payload.item_count)
                 return
 
@@ -240,8 +215,6 @@ def publish_events() -> None:
     publisher = BatchPublisher(metrics_client, cfg)
 
     while True:
-        # allow other routines to execute (specifically handling requests to /metrics)
-        gevent.sleep(0)
         message: Optional[bytes]
 
         try:
@@ -265,5 +238,4 @@ def publish_events() -> None:
 
 
 if __name__ == "__main__":
-    start_prometheus_exporter_for_sidecar()
     publish_events()


### PR DESCRIPTION
This reverts commit 15c5d920b6dfd0349739dfa32663365282d74bd5.

Reverting the changes to the event publisher in #742 for now, so as not to block other releases of baseplate.py (or include it in them).

I'll leave in the other changes around pylint and the common prometheus exporter setup.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] CI tests (if present) are passing
- [ ] Adheres to code style for repo
- [ ] Contributor License Agreement (CLA) completed if not a Reddit employee
