### PR TITLE
Fix accessing non-existent Span object

### DIFF
--- a/baseplate/clients/sqlalchemy.py
+++ b/baseplate/clients/sqlalchemy.py
@@ -298,9 +298,10 @@ class SQLAlchemyEngineContextFactory(ContextFactory):
 
     def on_error(self, context: ExceptionContext) -> None:
         """Handle the event which happens on exceptions during execution."""
-        exc_info = (type(context.original_exception), context.original_exception, None)
-        context.connection.info["span"].finish(exc_info=exc_info)
-        context.connection.info["span"] = None
+        if "span" in context.connection.info and context.connection.info["span"] is not None:
+            exc_info = (type(context.original_exception), context.original_exception, None)
+            context.connection.info["span"].finish(exc_info=exc_info)
+            context.connection.info["span"] = None
 
         labels = {
             "sql_pool": self.name,

--- a/tests/unit/clients/sqlalchemy_tests.py
+++ b/tests/unit/clients/sqlalchemy_tests.py
@@ -200,6 +200,7 @@ class EngineContextFactoryTest(unittest.TestCase):
         exception_context = mock.MagicMock()
         exception_context.connection.engine.url.host = "test_hostname"
         exception_context.connection.engine.url.database = "test_database"
+        exception_context.connection.info["span"] = None
         self.factory.on_error(exception_context)
 
         prom_labels = {


### PR DESCRIPTION
## 💸 TL;DR
PR fixes an issue of accessing non-existent `Span` object in `on_error` event callback.

## 📜 Details
Even if it is appearing that `Span` object is created in `on_before_execute` in might happened that other exceptions/errors can be raised before that, which triggers `on_error` event but not `on_before_execute`. That leads to `AttributeError('NoneType' object has no attribute 'finish')` exception in the traceback. As an example, if a wrong typed value passed and `ValueError` raised on forming a query, that happens.

PR prevents this situation by checking `Span` object, before doing anything with it. 

## 🧪 Testing Steps / Validation
- [x] Added test case

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] CI tests (if present) are passing
- [x] Adheres to code style for repo
- [x] Contributor License Agreement (CLA) completed if not a Reddit employee
