### PR TITLE
docs(file_watcher): Atomic writes to watched files

### DIFF
--- a/baseplate/lib/file_watcher.py
+++ b/baseplate/lib/file_watcher.py
@@ -2,6 +2,11 @@
 
 The contents of the file are re-loaded and parsed only when necessary.
 
+Warning! Writes to watched files must be atomic, otherwise the client might read
+a currupt or partly written data file. One way to avoid this issue is to write all
+the desired data to a temporary file and move the complete temp file over the old
+file.
+
 For example, a JSON file like the following:
 
 .. highlight:: ini


### PR DESCRIPTION
Add documentation pointing out that if writes to watched files aren't atomic, file contents observed by clients may be corrupted.

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 💸 TL;DR
<!-- What's the three sentence summary of purpose of the PR -->

## 📜 Details
[Design Doc](<!-- insert Google Doc link here if applicable -->)

[Jira](<!-- insert Jira link if applicable -->)

<!-- Add additional details required for the PR: breaking changes, screenshots, external dependency changes -->

## 🧪 Testing Steps / Validation
<!-- add details on how this PR has been tested, include reproductions and screenshots where applicable -->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] CI tests (if present) are passing
- [ ] Adheres to code style for repo
- [ ] Contributor License Agreement (CLA) completed if not a Reddit employee
