### PR TITLE
Populate Cassandra cluster name from cluster metadata

### DIFF
--- a/tests/integration/cassandra_tests.py
+++ b/tests/integration/cassandra_tests.py
@@ -160,6 +160,11 @@ class CassandraTests(unittest.TestCase):
         span_observer = server_span_observer.get_only_child()
         self.assertFalse(span_observer.on_finish_called)
 
+    def test_cluster_name_from_metadata(self):
+        with self.server_span:
+            name = self.context.cassandra.prometheus_cluster_name
+            self.assertEqual(name, "Test Cluster")
+
 
 class CassandraConcurrentTests(unittest.TestCase):
     def setUp(self):

--- a/tests/unit/clients/cassandra_tests.py
+++ b/tests/unit/clients/cassandra_tests.py
@@ -118,6 +118,7 @@ class CassandraSessionAdapterTests(unittest.TestCase):
                     "cassandra_client_name": "test",  # client name defaults to name when not provided
                     "cassandra_keyspace": "keyspace",
                     "cassandra_query_name": "",
+                    "cassandra_cluster_name": "",
                 },
             ),
             1,
@@ -134,6 +135,7 @@ class CassandraSessionAdapterTests(unittest.TestCase):
                     "cassandra_client_name": "test",
                     "cassandra_keyspace": "keyspace",
                     "cassandra_query_name": "foo_bar",
+                    "cassandra_cluster_name": "",
                 },
             ),
             1,
@@ -157,6 +159,7 @@ class CassandraSessionAdapterTests(unittest.TestCase):
                     "cassandra_client_name": "test_client_name",
                     "cassandra_keyspace": "keyspace",
                     "cassandra_query_name": "",
+                    "cassandra_cluster_name": "",
                 },
             ),
             1,
@@ -180,6 +183,57 @@ class CassandraSessionAdapterTests(unittest.TestCase):
                     "cassandra_client_name": "",
                     "cassandra_keyspace": "keyspace",
                     "cassandra_query_name": "",
+                    "cassandra_cluster_name": "",
+                },
+            ),
+            1,
+        )
+
+    def test_execute_async_prom_metrics_cluster_name_specified(self):
+        self.adapter = CassandraSessionAdapter(
+            "test",
+            self.mock_server_span,
+            self.session,
+            self.prepared_statements,
+            prometheus_client_name="",
+            prometheus_cluster_name="test_cluster_name",
+        )
+        self.session.keyspace = "keyspace"  # mocking keyspace name
+        self.adapter.execute_async("SELECT foo from bar;")
+
+        self.assertEqual(
+            REGISTRY.get_sample_value(
+                "cassandra_client_active_requests",
+                {
+                    "cassandra_client_name": "",
+                    "cassandra_keyspace": "keyspace",
+                    "cassandra_query_name": "",
+                    "cassandra_cluster_name": "test_cluster_name",
+                },
+            ),
+            1,
+        )
+
+    def test_execute_async_prom_metrics_cluster_name_empty(self):
+        self.adapter = CassandraSessionAdapter(
+            "test",
+            self.mock_server_span,
+            self.session,
+            self.prepared_statements,
+            prometheus_client_name="",
+            prometheus_cluster_name="",
+        )
+        self.session.keyspace = "keyspace"  # mocking keyspace name
+        self.adapter.execute_async("SELECT foo from bar;")
+
+        self.assertEqual(
+            REGISTRY.get_sample_value(
+                "cassandra_client_active_requests",
+                {
+                    "cassandra_client_name": "",
+                    "cassandra_keyspace": "keyspace",
+                    "cassandra_query_name": "",
+                    "cassandra_cluster_name": "",
                 },
             ),
             1,
@@ -202,6 +256,7 @@ class CassandraTests(unittest.TestCase):
             cassandra_client_name="test_client_name",
             cassandra_keyspace="keyspace",
             cassandra_query_name="",
+            cassandra_cluster_name="",
         )
 
         _on_execute_complete(
@@ -243,6 +298,7 @@ class CassandraTests(unittest.TestCase):
             cassandra_client_name="test_client_name",
             cassandra_keyspace="keyspace",
             cassandra_query_name="",
+            cassandra_cluster_name="",
         )
 
         _on_execute_failed(


### PR DESCRIPTION
The cluster name label allows us to map the client queries back to the cluster they are being executed on. It can be used to determine client query error rates and latencies broken down by cluster and map these back to specific queries similar to how `cassandra_client_name` is used.

If the metadata field is not populated, this returns an empty string. The metadata field is populated on connect and refreshed at a regular interval, however, the cluster name will not change.

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 💸 TL;DR
Introduces `cassandra_cluster_name` prometheus label for Cassandra client request metrics. 
It can be used to determine client query error rates and latencies broken down by cluster and map these back to specific queries similar to how `cassandra_client_name` is used.

If the cluster does not return the cluster name metadata field, this returns an empty string. However,
the cluster name is populated as part of the Cassandra driver's `connect` call.

## 📜 Details
[Baseplate.spec PR](https://github.snooguts.net/reddit/baseplate.spec/pull/78) 
[Jira](https://reddit.atlassian.net/browse/STRGS-417)

## 🧪 Testing Steps / Validation
Unit test and integration test introduced.

## ✅ Checks
- [x] CI tests (if present) are passing
- [x] Adheres to code style for repo
- [x] Reddit employee
