### PR TITLE
Adds support for `MultiProcessValue` ids based on env variable

### DIFF
--- a/baseplate/server/__init__.py
+++ b/baseplate/server/__init__.py
@@ -265,6 +265,13 @@ def load_app_and_run_server() -> None:
         config = read_config(args.config_file, args.server_name, args.app_name)
     assert config.server
 
+    if is_metrics_enabled(config.app):
+        from baseplate.server.prometheus import start_prometheus_exporter
+
+        start_prometheus_exporter()
+    else:
+        logger.info("Metrics are not configured, Prometheus metrics will not be exported.")
+
     configure_logging(config, args.debug)
 
     app = make_app(config.app)
@@ -273,13 +280,6 @@ def load_app_and_run_server() -> None:
 
     if einhorn.is_worker():
         einhorn.ack_startup()
-
-    if is_metrics_enabled(config.app):
-        from baseplate.server.prometheus import start_prometheus_exporter
-
-        start_prometheus_exporter()
-    else:
-        logger.info("Metrics are not configured, Prometheus metrics will not be exported.")
 
     if args.reload:
         reloader.start_reload_watcher(extra_files=[args.config_file.name])

--- a/baseplate/server/__init__.py
+++ b/baseplate/server/__init__.py
@@ -265,6 +265,8 @@ def load_app_and_run_server() -> None:
         config = read_config(args.config_file, args.server_name, args.app_name)
     assert config.server
 
+    # Prom exporter needs to start before the app starts because
+    # we need to set the prometheus id before we generate any stats
     if is_metrics_enabled(config.app):
         from baseplate.server.prometheus import start_prometheus_exporter
 

--- a/baseplate/server/prometheus.py
+++ b/baseplate/server/prometheus.py
@@ -42,11 +42,11 @@ PROMETHEUS_EXPORTER_ADDRESS = Endpoint("0.0.0.0:6060")
 METRICS_ENDPOINT = "/metrics"
 
 
-def processId():
-    id = str(os.getpid())
-    if "MULTIPROCESS_WORKER_ID" in os.environ:
-        id = os.environ.get("MULTIPROCESS_WORKER_ID")
-    return id
+def worker_id() -> str:
+    worker = os.environ.get("MULTIPROCESS_WORKER_ID")
+    if worker is None:
+        worker = str(os.getpid())
+    return worker
 
 
 def export_metrics(environ: "WSGIEnvironment", start_response: "StartResponse") -> Iterable[bytes]:
@@ -69,8 +69,8 @@ def start_prometheus_exporter(address: EndpointConfiguration = PROMETHEUS_EXPORT
         )
         sys.exit(1)
 
-    values.ValueClass = MultiProcessValue(processId)
-    atexit.register(multiprocess.mark_process_dead, processId())
+    values.ValueClass = MultiProcessValue(worker_id)
+    atexit.register(multiprocess.mark_process_dead, worker_id())
 
     server_socket = bind_socket(address)
     server = WSGIServer(

--- a/baseplate/server/prometheus.py
+++ b/baseplate/server/prometheus.py
@@ -20,11 +20,11 @@ from typing import TYPE_CHECKING
 
 from gevent.pywsgi import LoggingLogAdapter
 from gevent.pywsgi import WSGIServer
-from prometheus_client import values
 from prometheus_client import CollectorRegistry
 from prometheus_client import CONTENT_TYPE_LATEST
 from prometheus_client import generate_latest
 from prometheus_client import multiprocess
+from prometheus_client import values
 from prometheus_client.values import MultiProcessValue
 
 from baseplate.lib.config import Endpoint
@@ -45,8 +45,9 @@ METRICS_ENDPOINT = "/metrics"
 def processId():
     id = str(os.getpid())
     if "MULTIPROCESS_WORKER_ID" in os.environ:
-        id = os.environ.get('MULTIPROCESS_WORKER_ID')
+        id = os.environ.get("MULTIPROCESS_WORKER_ID")
     return id
+
 
 def export_metrics(environ: "WSGIEnvironment", start_response: "StartResponse") -> Iterable[bytes]:
     if environ["PATH_INFO"] != METRICS_ENDPOINT:


### PR DESCRIPTION
## 💸 TL;DR
<!-- What's the three sentence summary of purpose of the PR -->
When baseplate is running as part of Monoceros process restarts create too many files which make prometheus client extremely slow and eventually it timeouts.

## 📜 Details
[Design Doc](<!-- insert Google Doc link here if applicable -->)

We want to be able to provide an alternative id to prometheus client now based on an environment variable. To achieve this we set the process id to:

* `MULTIPROCESS_WORKER_ID` if provided and fallback to PID in case it doesn't exist
* Moved the prometheus client initialization before we make the server.

## 🧪 Testing Steps / Validation
<!-- add details on how this PR has been tested, include reproductions and screenshots where applicable -->

Tested in the internal reddit development platform.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] CI tests (if present) are passing
- [ ] Adheres to code style for repo
- [ ] Contributor License Agreement (CLA) completed if not a Reddit employee

Signed-off-by: Sotiris Nanopoulos <sotiris.nanopoulos@reddit.com>