### PR TITLE
Event-Publisher Flush Queue on Shutdown

### DIFF
--- a/baseplate/sidecars/__init__.py
+++ b/baseplate/sidecars/__init__.py
@@ -63,7 +63,7 @@ class TimeLimitedBatch(Batch):
         if not self.batch_start:
             return 0
         return time.time() - self.batch_start
-    
+
     @property
     def is_ready(self) -> bool:
         if self.age >= self.max_age:

--- a/baseplate/sidecars/__init__.py
+++ b/baseplate/sidecars/__init__.py
@@ -63,6 +63,12 @@ class TimeLimitedBatch(Batch):
         if not self.batch_start:
             return 0
         return time.time() - self.batch_start
+    
+    @property
+    def is_ready(self) -> bool:
+        if self.age >= self.max_age:
+            return True
+        return False
 
     def add(self, item: Optional[bytes]) -> None:
         if self.age >= self.max_age:

--- a/baseplate/sidecars/__init__.py
+++ b/baseplate/sidecars/__init__.py
@@ -66,9 +66,7 @@ class TimeLimitedBatch(Batch):
 
     @property
     def is_ready(self) -> bool:
-        if self.age >= self.max_age:
-            return True
-        return False
+        return self.age >= self.max_age
 
     def add(self, item: Optional[bytes]) -> None:
         if self.age >= self.max_age:


### PR DESCRIPTION
<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 💸 TL;DR
<!-- What's the three sentence summary of purpose of the PR -->
Event-Publisher sidecar is not flushing the entire POSIX queue when receiving a SIGINT or SIGTERM. This PR creates a signal handler which will flush the queue whenever a SIGINT or SIGTERM is received. If this is not addressed, some applications that use the Event Publisher sidecar may experience dropped messages if their Event Publisher sidecar is terminated and the queue still has messages (ex: during a deployment).

## 📜 Details
[Design Doc](<!-- insert Google Doc link here if applicable -->)

[Jira](<!-- insert Jira link if applicable -->)

<!-- Add additional details required for the PR: breaking changes, screenshots, external dependency changes -->

## 🧪 Testing Steps / Validation
<!-- add details on how this PR has been tested, include reproductions and screenshots where applicable -->
Reproduced the issue by running the event-publisher, filling up the event queue, and adding events to the queue after each polling cycle by modifying the event-publisher
```
    try:
        [event_queue.put("{}",timeout=QUEUE_TIMEOUT) for i in range(0,10)]
    except:
        pass
    
    while True:
        message: Optional[bytes]

        try:
            message = event_queue.get(timeout=QUEUE_TIMEOUT)
            event_queue.put("{}",timeout=QUEUE_TIMEOUT)
        except TimedOutError:
            message = None

        if batcher.is_ready:
            serialize_and_publish_batch(publisher, batcher)
        batcher.add(message)
```
This keeps the queue saturated with something.
Then, force-closed the event-publisher using `ctrl-c`. 

Afterwards, check the POSIX queue to see if there are messages left over:
```
>>> from baseplate.lib.message_queue import MessageQueue

        "/events-" + "test",
        max_messages=10,
        max_message_size=8192,
    )
message = event_queue.get(timeout=QUEUE_TIMEOUT)>>> QUEUE_TIMEOUT = 0.2
>>> event_queue = MessageQueue(
...         "/events-" + "test",
...         max_messages=10,
...         max_message_size=8192,
...     )
>>> message = event_queue.get(timeout=QUEUE_TIMEOUT)
```
If we don't see a timeout, then we know that there was a message that was retrieved.

![Screenshot 2023-01-25 at 4 14 38 PM](https://user-images.githubusercontent.com/10442624/214723522-b890406f-e9cb-40a2-9e96-6f44a74ed2df.png)
Note that the bad request above should not impact the test because the client error will only result in the messages being discarded due to a network error which is not the objective of this test.


To test the solution, the same test was done with the flush_queue_signal_handler() set for SIGINT and SIGTERM. As can be seen below, a TimedOutError was received when trying to get a message from the queue signaling that the queue was empty and flushed correctly.
![Screenshot 2023-01-25 at 4 21 13 PM](https://user-images.githubusercontent.com/10442624/214725024-94a17b06-b9cf-4f17-9ca5-5e9445a7dd04.png)

These tests were both repeated a few times.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] CI tests (if present) are passing
- [ ] Adheres to code style for repo
- [ ] Contributor License Agreement (CLA) completed if not a Reddit employee
