### PR TITLE
initialize gevent loop in baseplate scripts

### DIFF
--- a/bin/baseplate-script
+++ b/bin/baseplate-script
@@ -12,10 +12,15 @@ from baseplate.server.monkey import patch_stdlib_queues
 patch_all()
 patch_stdlib_queues()
 
-# grpc gevent patching
-import grpc.experimental.gevent as grpc_gevent  # noreorder
+# grpc gevent patching.
+# only patch if server does have gRPC as a dependency as this is
+# not needed for thrift or http only servers.
+try:
+    import grpc.experimental.gevent as grpc_gevent  # noreorder
+    grpc_gevent.init_gevent()
+except ImportError:
+    pass
 
-grpc_gevent.init_gevent()
 
 from baseplate.server import load_and_run_script
 

--- a/bin/baseplate-script
+++ b/bin/baseplate-script
@@ -12,6 +12,11 @@ from baseplate.server.monkey import patch_stdlib_queues
 patch_all()
 patch_stdlib_queues()
 
+# grpc gevent patching
+import grpc.experimental.gevent as grpc_gevent  # noreorder
+
+grpc_gevent.init_gevent()
+
 from baseplate.server import load_and_run_script
 
 load_and_run_script()

--- a/bin/baseplate-serve
+++ b/bin/baseplate-serve
@@ -12,10 +12,14 @@ from baseplate.server.monkey import patch_stdlib_queues
 patch_all()
 patch_stdlib_queues()
 
-# grpc gevent patching
-import grpc.experimental.gevent as grpc_gevent  # noreorder
-
-grpc_gevent.init_gevent()
+# grpc gevent patching.
+# only patch if server does have gRPC as a dependency as this is
+# not needed for thrift or http only servers.
+try:
+    import grpc.experimental.gevent as grpc_gevent  # noreorder
+    grpc_gevent.init_gevent()
+except ImportError:
+    pass
 
 from baseplate.server import load_app_and_run_server
 

--- a/bin/baseplate-serve
+++ b/bin/baseplate-serve
@@ -12,6 +12,11 @@ from baseplate.server.monkey import patch_stdlib_queues
 patch_all()
 patch_stdlib_queues()
 
+# grpc gevent patching
+import grpc.experimental.gevent as grpc_gevent  # noreorder
+
+grpc_gevent.init_gevent()
+
 from baseplate.server import load_app_and_run_server
 
 load_app_and_run_server()

--- a/bin/baseplate-shell
+++ b/bin/baseplate-shell
@@ -12,10 +12,14 @@ from baseplate.server.monkey import patch_stdlib_queues
 patch_all()
 patch_stdlib_queues()
 
-# grpc gevent patching
-import grpc.experimental.gevent as grpc_gevent  # noreorder
-
-grpc_gevent.init_gevent()
+# grpc gevent patching.
+# only patch if server does have gRPC as a dependency as this is
+# not needed for thrift or http only servers.
+try:
+    import grpc.experimental.gevent as grpc_gevent  # noreorder
+    grpc_gevent.init_gevent()
+except ImportError:
+    pass
 
 from baseplate.server import load_and_run_shell
 

--- a/bin/baseplate-shell
+++ b/bin/baseplate-shell
@@ -12,6 +12,11 @@ from baseplate.server.monkey import patch_stdlib_queues
 patch_all()
 patch_stdlib_queues()
 
+# grpc gevent patching
+import grpc.experimental.gevent as grpc_gevent  # noreorder
+
+grpc_gevent.init_gevent()
+
 from baseplate.server import load_and_run_shell
 
 load_and_run_shell()

--- a/bin/baseplate-tshell
+++ b/bin/baseplate-tshell
@@ -12,6 +12,11 @@ from baseplate.server.monkey import patch_stdlib_queues
 patch_all()
 patch_stdlib_queues()
 
+# grpc gevent patching
+import grpc.experimental.gevent as grpc_gevent  # noreorder
+
+grpc_gevent.init_gevent()
+
 from baseplate.server import load_and_run_shell
 
 print("baseplate-tshell has been renamed to baseplate-shell. Please use that in the future!")

--- a/bin/baseplate-tshell
+++ b/bin/baseplate-tshell
@@ -12,10 +12,14 @@ from baseplate.server.monkey import patch_stdlib_queues
 patch_all()
 patch_stdlib_queues()
 
-# grpc gevent patching
-import grpc.experimental.gevent as grpc_gevent  # noreorder
-
-grpc_gevent.init_gevent()
+# grpc gevent patching.
+# only patch if server does have gRPC as a dependency as this is
+# not needed for thrift or http only servers.
+try:
+    import grpc.experimental.gevent as grpc_gevent  # noreorder
+    grpc_gevent.init_gevent()
+except ImportError:
+    pass
 
 from baseplate.server import load_and_run_shell
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@
 black==21.10b0
 boto3==1.21.20
 flake8==5.0.4
+gevent==21.1.2
 lxml==4.6.5
 mypy==0.910
 prometheus-client==0.14.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,6 @@
 black==21.10b0
 boto3==1.21.20
 flake8==5.0.4
-gevent==21.1.2
 lxml==4.6.5
 mypy==0.910
 prometheus-client==0.14.1


### PR DESCRIPTION
<!-- If this pull request closes an issue, please mention the issue number below -->

## 💸 TL;DR
<!-- What's the three sentence summary of purpose of the PR -->
The various baseplate-<action> scripts are the entry point to our running servers, and this is were we patch the stdlib to work well with gevent.   When working with gRPC, there is additional patching that needs to to be done in these scripts.  This is a third sentence so as to be technically correct.

## 📜 Details
[Jira](https://reddit.atlassian.net/browse/MESH-1327 )

<!-- Add additional details required for the PR: breaking changes, screenshots, external dependency changes -->
We've currently been doing the `grpc_gevent.init_gevent()` patching in the various service's `__init__.py` files, but we've seen performance issues and python profiling graphs that indicated this patch wasn't having the intended affect.  The thrift client performance is significantly (2x or more) better and more consistent than the grpc client of the same server.

After some live debugging and profiling with pyspy, it looked like all the grpc calls were still outside the main server's event loop. According to various gh issues and docs, `init_gevent`:

```
This must be called AFTER the python standard lib has been patched, but BEFORE creating and gRPC objects.
```

We suspect calling this in the __init__ file was not sufficiently early to get the patching done right, so moving it here in an attempt to get it done as early and seamlessly as possible for users.  

I think adding this here creates a hard requirement of grpc for all servers, so happy to wrap this in a `try/except` to handle cases where they don't bring it in - but open to suggestions/preference for how to handle this.  

## 🧪 Testing Steps / Validation
<!-- add details on how this PR has been tested, include reproductions and screenshots where applicable -->
Installed this into services running in snoodev and did see some measurable performance improvements under conditions of high load for the client/servers.  

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] CI tests (if present) are passing
- [ ] Adheres to code style for repo
- [ ] Contributor License Agreement (CLA) completed if not a Reddit employee
