### PR TITLE
Fix issue with InternalRequestsClient when edge context is None

### DIFF
--- a/baseplate/clients/requests.py
+++ b/baseplate/clients/requests.py
@@ -308,7 +308,8 @@ class InternalBaseplateSession(BaseplateSession):
         except AttributeError:
             pass
         else:
-            request.headers["X-Edge-Request"] = base64.b64encode(edge_context).decode()
+            if edge_context:
+                request.headers["X-Edge-Request"] = base64.b64encode(edge_context).decode()
 
 
 class RequestsContextFactory(ContextFactory):

--- a/tests/integration/requests_tests.py
+++ b/tests/integration/requests_tests.py
@@ -149,6 +149,17 @@ def test_internal_client_sends_headers(http_server):
         assert http_server.requests[0].span.id != context.span.id
         assert http_server.requests[0].raw_edge_context == b"test payload"
 
+        setattr(context, "raw_edge_context", None)
+        response = context.internal.get(http_server.url)
+
+        assert response.status_code == 204
+        assert response.text == ""
+        assert http_server.requests[1].method == "GET"
+        assert http_server.requests[1].span.trace_id == context.span.trace_id
+        assert http_server.requests[1].span.parent_id == context.span.id
+        assert http_server.requests[1].span.id != context.span.id
+        assert http_server.requests[1].raw_edge_context is None
+
 
 def test_external_client_doesnt_send_headers(http_server):
     baseplate = Baseplate(

--- a/tests/integration/requests_tests.py
+++ b/tests/integration/requests_tests.py
@@ -149,16 +149,22 @@ def test_internal_client_sends_headers(http_server):
         assert http_server.requests[0].span.id != context.span.id
         assert http_server.requests[0].raw_edge_context == b"test payload"
 
+
+def test_internal_client_sends_headers_with_none_edge_context(http_server):
+    baseplate = Baseplate()
+    baseplate.configure_context({"internal": InternalRequestsClient()})
+
+    with baseplate.server_context("test") as context:
         setattr(context, "raw_edge_context", None)
         response = context.internal.get(http_server.url)
 
         assert response.status_code == 204
         assert response.text == ""
-        assert http_server.requests[1].method == "GET"
-        assert http_server.requests[1].span.trace_id == context.span.trace_id
-        assert http_server.requests[1].span.parent_id == context.span.id
-        assert http_server.requests[1].span.id != context.span.id
-        assert http_server.requests[1].raw_edge_context is None
+        assert http_server.requests[0].method == "GET"
+        assert http_server.requests[0].span.trace_id == context.span.trace_id
+        assert http_server.requests[0].span.parent_id == context.span.id
+        assert http_server.requests[0].span.id != context.span.id
+        assert http_server.requests[0].raw_edge_context is None
 
 
 def test_external_client_doesnt_send_headers(http_server):


### PR DESCRIPTION
## 💸 TL;DR
For some requests it is possible for a `context.raw_edge_request` to be `None` leading to an error thrown by `base64.b64encode()` when using `InternalRequestsClient`. This PR addresses this issue, and adds a failing case for the existing implementation.
 
## 📜 Details
Attempting to use the InternalRequestsClient and we ran into the error `TypeError: a bytes-like object is required, not 'NoneType'` at the following location:

```
../baseplate/clients/requests.py:170: in get
    return self.request("GET", url, **kwargs)
../baseplate/clients/requests.py:238: in request
    return self.send(prepared, **send_kwargs)
../baseplate/clients/requests.py:259: in send
    self._add_span_context(span, request)
../baseplate/clients/requests.py:311: in _add_span_context
    request.headers["X-Edge-Request"] = base64.b64encode(edge_context).decode()
```

We can work around this by not using the client for these types of requests, but this should correct the issue in baseplate.

## 🧪 Testing Steps / Validation
Adds a case to `test_internal_client_sends_headers` that fails on current `develop`.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] CI tests (if present) are passing
- [x] Adheres to code style for repo
- [ ] Contributor License Agreement (CLA) completed if not a Reddit employee
