### PR TITLE
upgrade(actions): upgrade checkout and setup-python

### DIFF
--- a/.github/workflows/python-publish.yaml
+++ b/.github/workflows/python-publish.yaml
@@ -10,17 +10,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: '3.8'
 
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install setuptools==47.3.0 wheel==0.34.2 twine==3.1.1
+        python -m pip install setuptools==47.3.0 wheel==0.34.2 twine==3.1.1 requests==2.29.0
 
     - name: Build and publish
       env:


### PR DESCRIPTION
GitHub depricated Node.js to Node 16. The current versions of checkout and setup-python GitHub actions depend on a depricated version of Node.

I cut a release as a test [here](https://github.com/reddit/baseplate.py/actions/runs/4985027857), the build failed because of a bad tag, but did run. [Here](https://github.com/reddit/baseplate.py/actions/runs/4963056617) is the previous failure.

This also upgrades pins the version of requests being used during build time, this is necessary for the package to be successfully uploaded.

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 💸 TL;DR
<!-- What's the three sentence summary of purpose of the PR -->

## 📜 Details
[Design Doc](<!-- insert Google Doc link here if applicable -->)

[Jira](<!-- insert Jira link if applicable -->)

<!-- Add additional details required for the PR: breaking changes, screenshots, external dependency changes -->

## 🧪 Testing Steps / Validation
<!-- add details on how this PR has been tested, include reproductions and screenshots where applicable -->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] CI tests (if present) are passing
- [ ] Adheres to code style for repo
- [ ] Contributor License Agreement (CLA) completed if not a Reddit employee
