### PR TITLE
Add queue flushing signal handler

### DIFF
--- a/baseplate/sidecars/__init__.py
+++ b/baseplate/sidecars/__init__.py
@@ -63,7 +63,7 @@ class TimeLimitedBatch(Batch):
         if not self.batch_start:
             return 0
         return time.time() - self.batch_start
-    
+
     @property
     def is_ready(self) -> bool:
         if self.age >= self.max_age:

--- a/baseplate/sidecars/__init__.py
+++ b/baseplate/sidecars/__init__.py
@@ -63,6 +63,12 @@ class TimeLimitedBatch(Batch):
         if not self.batch_start:
             return 0
         return time.time() - self.batch_start
+    
+    @property
+    def is_ready(self) -> bool:
+        if self.age >= self.max_age:
+            return True
+        return False
 
     def add(self, item: Optional[bytes]) -> None:
         if self.age >= self.max_age:

--- a/baseplate/sidecars/__init__.py
+++ b/baseplate/sidecars/__init__.py
@@ -66,9 +66,7 @@ class TimeLimitedBatch(Batch):
 
     @property
     def is_ready(self) -> bool:
-        if self.age >= self.max_age:
-            return True
-        return False
+        return self.age >= self.max_age
 
     def add(self, item: Optional[bytes]) -> None:
         if self.age >= self.max_age:

--- a/baseplate/sidecars/__init__.py
+++ b/baseplate/sidecars/__init__.py
@@ -64,10 +64,6 @@ class TimeLimitedBatch(Batch):
             return 0
         return time.time() - self.batch_start
 
-    @property
-    def is_ready(self) -> bool:
-        return self.age >= self.max_age
-
     def add(self, item: Optional[bytes]) -> None:
         if self.age >= self.max_age:
             raise BatchFull

--- a/baseplate/sidecars/event_publisher.py
+++ b/baseplate/sidecars/event_publisher.py
@@ -245,7 +245,7 @@ def publish_events() -> None:
                 continue
             except BatchFull:
                 pass
-            
+
             serialize_and_publish_batch(publisher, batcher)
             batcher.add(message)
         sys.exit(0)

--- a/baseplate/sidecars/event_publisher.py
+++ b/baseplate/sidecars/event_publisher.py
@@ -240,9 +240,13 @@ def publish_events() -> None:
                     serialize_and_publish_batch(publisher, batcher)
                 break
 
-            if batcher.is_ready:
-                serialize_and_publish_batch(publisher, batcher)
-            batcher.add(message)
+            try:
+                batcher.add(message)
+                continue
+            except BatchFull:
+                pass
+            
+            serialize_and_publish_batch(publisher, batcher)
         sys.exit(0)
 
     for sig in (signal.SIGINT, signal.SIGTERM):
@@ -257,9 +261,13 @@ def publish_events() -> None:
         except TimedOutError:
             message = None
 
-        if batcher.is_ready:
-            serialize_and_publish_batch(publisher, batcher)
-        batcher.add(message)
+        try:
+            batcher.add(message)
+            continue
+        except BatchFull:
+            pass
+
+        serialize_and_publish_batch(publisher, batcher)
 
 
 if __name__ == "__main__":

--- a/baseplate/sidecars/event_publisher.py
+++ b/baseplate/sidecars/event_publisher.py
@@ -247,6 +247,7 @@ def publish_events() -> None:
                 pass
             
             serialize_and_publish_batch(publisher, batcher)
+            batcher.add(message)
         sys.exit(0)
 
     for sig in (signal.SIGINT, signal.SIGTERM):
@@ -268,6 +269,7 @@ def publish_events() -> None:
             pass
 
         serialize_and_publish_batch(publisher, batcher)
+        batcher.add(message)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 💸 TL;DR
<!-- What's the three sentence summary of purpose of the PR -->
Add a queue flushing signal handler, so when the event publisher receives a SIGINT/SIGTERM signal it'll continue flushing the queue, so events aren't dropped on shutdown.

## 📜 Details
[Design Doc](<!-- insert Google Doc link here if applicable -->)

[Jira](<!-- insert Jira link if applicable -->)

<!-- Add additional details required for the PR: breaking changes, screenshots, external dependency changes -->

## 🧪 Testing Steps / Validation
<!-- add details on how this PR has been tested, include reproductions and screenshots where applicable -->

Tested using the included `Dockerfile` using the following steps:
```
docker run --sysctl fs.mqueue.msg_max=10000 --sysctl fs.mqueue.msgsize_max=102400 -it -v ~/baseplate.py:/src --ulimit msgqueue=-1 c725da7d50d0
python -m baseplate.sidecars.event_publisher --queue-name test --debug test.ini

# In a separate tab, exec into the container
docker exec -it 07e5b9a2bb37 /bin/bash
python
# Within Python, ran the code below
from baseplate.lib.message_queue import MessageQueue
import time

queue_name = "test"

event_queue = MessageQueue(
        "/events-" + queue_name,
        max_messages=10000,
        max_message_size=102400,
    )


message = b'[{"source":"test","action":"test","noun":"test","client_timestamp":1683823393779,"uuid":"20de9dec-6632-44fa-a3a3-ca29d177776d","action_info":{"reason":"test"}}]'

current_time = time.time()
while time.time() - current_time < 5:
    event_queue.put(message)
```

This screenshot below shows the reproduction of a bug where we would exit from a `BatchFull` exception:
![Screenshot 2023-05-16 at 5 16 01 PM](https://github.com/reddit/baseplate.py/assets/10442624/590df6df-0464-4283-b3ef-0f94ddd6d406)

This screenshot below shows that the `BatchFull` exception is no longer present using the same steps above and sending a SIGINT to `event_publisher` will still cause it to wait for the POSIX queue to be empty before exiting:
![Screenshot 2023-05-16 at 5 21 55 PM](https://github.com/reddit/baseplate.py/assets/10442624/90c12527-419a-44a8-9078-10d09972a1c0)



## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] CI tests (if present) are passing
- [ ] Adheres to code style for repo
- [ ] Contributor License Agreement (CLA) completed if not a Reddit employee
