### PR TITLE
Improve kafka logging

### DIFF
--- a/baseplate/frameworks/queue_consumer/kafka.py
+++ b/baseplate/frameworks/queue_consumer/kafka.py
@@ -177,7 +177,7 @@ class KafkaMessageHandler(MessageHandler):
                     data = self.message_unpack_fn(blob)
                 except Exception:
                     prom_success = "false"
-                    logger.error("skipping invalid message")
+                    logger.exception("skipping invalid message")
                     context.span.incr_tag(f"{self.name}.{topic}.invalid_message")
                     return
 


### PR DESCRIPTION
## 💸 TL;DR
<!-- What's the three sentence summary of purpose of the PR -->
We recently upgraded our version of `confluent-kafka`. All of our consumers stopped working and all we got was "skipping invalid message" text in sentry with no stacktrace. using `logger.exception` instead of `logger.error` should propagate the stacktrace and make this much more useful.


<!-- Add additional details required for the PR: breaking changes, screenshots, external dependency changes -->

## 🧪 Testing Steps / Validation
<!-- add details on how this PR has been tested, include reproductions and screenshots where applicable -->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] CI tests (if present) are passing
- [x] Adheres to code style for repo
- [x] Contributor License Agreement (CLA) completed if not a Reddit employee
