### PR TITLE
Conform sqlalchemy to prom spec

### DIFF
--- a/baseplate/clients/sqlalchemy.py
+++ b/baseplate/clients/sqlalchemy.py
@@ -162,7 +162,7 @@ class SQLAlchemyEngineContextFactory(ContextFactory):
 
     PROM_PREFIX = "sql_client"
     PROM_POOL_PREFIX = f"{PROM_PREFIX}_pool"
-    PROM_POOL_LABELS = ["sql_pool"]
+    PROM_POOL_LABELS = ["sql_client_name"]
 
     max_connections_gauge = Gauge(
         f"{PROM_POOL_PREFIX}_max_size",

--- a/baseplate/clients/sqlalchemy.py
+++ b/baseplate/clients/sqlalchemy.py
@@ -185,7 +185,7 @@ class SQLAlchemyEngineContextFactory(ContextFactory):
     )
 
     PROM_LABELS = [
-        "sql_pool",
+        "sql_client_name",
         "sql_address",
         "sql_database",
     ]
@@ -248,7 +248,7 @@ class SQLAlchemyEngineContextFactory(ContextFactory):
     ) -> Tuple[str, Parameters]:
         """Handle the engine's before_cursor_execute event."""
         labels = {
-            "sql_pool": self.name,
+            "sql_client_name": self.name,
             "sql_address": conn.engine.url.host,
             "sql_database": conn.engine.url.database,
         }
@@ -289,7 +289,7 @@ class SQLAlchemyEngineContextFactory(ContextFactory):
         conn.info["span"] = None
 
         labels = {
-            "sql_pool": self.name,
+            "sql_client_name": self.name,
             "sql_address": conn.engine.url.host,
             "sql_database": conn.engine.url.database,
         }
@@ -308,7 +308,7 @@ class SQLAlchemyEngineContextFactory(ContextFactory):
             context.connection.info["span"] = None
 
         labels = {
-            "sql_pool": self.name,
+            "sql_client_name": self.name,
             "sql_address": context.connection.engine.url.host,
             "sql_database": context.connection.engine.url.database,
         }

--- a/tests/unit/clients/sqlalchemy_tests.py
+++ b/tests/unit/clients/sqlalchemy_tests.py
@@ -95,7 +95,7 @@ class EngineContextFactoryTest(unittest.TestCase):
 
         self.factory.report_runtime_metrics(batch)
 
-        prom_labels = {"sql_pool": "factory_name"}
+        prom_labels = {"sql_client_name": "factory_name"}
         # this serves to prove that we never set these metrics / go down the code path after the isinstance check
         self.assertEqual(REGISTRY.get_sample_value("sql_client_pool_max_size", prom_labels), None)
         self.assertEqual(
@@ -124,7 +124,7 @@ class EngineContextFactoryTest(unittest.TestCase):
 
         self.factory.report_runtime_metrics(batch)
 
-        prom_labels = {"sql_pool": "factory_name"}
+        prom_labels = {"sql_client_name": "factory_name"}
         self.assertEqual(REGISTRY.get_sample_value("sql_client_pool_max_size", prom_labels), 4)
         self.assertEqual(
             REGISTRY.get_sample_value("sql_client_pool_active_connections", prom_labels), 12
@@ -155,7 +155,7 @@ class EngineContextFactoryTest(unittest.TestCase):
         )
 
         prom_labels = {
-            "sql_pool": "factory_name",
+            "sql_client_name": "factory_name",
             "sql_address": "test_hostname",
             "sql_database": "test_database",
         }
@@ -176,7 +176,7 @@ class EngineContextFactoryTest(unittest.TestCase):
         )
 
         prom_labels = {
-            "sql_pool": "factory_name",
+            "sql_client_name": "factory_name",
             "sql_address": "test_hostname",
             "sql_database": "test_database",
         }
@@ -204,7 +204,7 @@ class EngineContextFactoryTest(unittest.TestCase):
         self.factory.on_error(exception_context)
 
         prom_labels = {
-            "sql_pool": "factory_name",
+            "sql_client_name": "factory_name",
             "sql_address": "test_hostname",
             "sql_database": "test_database",
         }


### PR DESCRIPTION
## 💸 TL;DR

The SqlAlchemy library is old and emits events not compliant with the [prometheus metrics spec](https://github.snooguts.net/reddit/baseplate.spec/blob/master/component-apis/prom-metrics.md#sql). Specifically, `sql_client_name` is missing and instead this library provides `sql_pool` which appeared in an older version of the spec. This updates the metrics to be compliant with spec and usable by the baseplate service health dashboard.

## 📜 Details

Example SQL metrics emitted by a client of this library:
```
$ curl -s localhost:6060/metrics | grep sql
# HELP sql_client_latency_seconds Latency histogram of calls to database
# TYPE sql_client_latency_seconds histogram
sql_client_latency_seconds_sum{sql_address="postgresql",sql_database="reputation",sql_pool="sqlalchemy",sql_success="true"} 0.004516069000601419
sql_client_latency_seconds_bucket{le="0.0001",sql_address="postgresql",sql_database="reputation",sql_pool="sqlalchemy",sql_success="true"} 0.0
sql_client_latency_seconds_bucket{le="0.0005",sql_address="postgresql",sql_database="reputation",sql_pool="sqlalchemy",sql_success="true"} 0.0
sql_client_latency_seconds_bucket{le="0.001",sql_address="postgresql",sql_database="reputation",sql_pool="sqlalchemy",sql_success="true"} 2.0
sql_client_latency_seconds_bucket{le="0.0025",sql_address="postgresql",sql_database="reputation",sql_pool="sqlalchemy",sql_success="true"} 4.0
sql_client_latency_seconds_bucket{le="0.005",sql_address="postgresql",sql_database="reputation",sql_pool="sqlalchemy",sql_success="true"} 4.0
sql_client_latency_seconds_bucket{le="0.01",sql_address="postgresql",sql_database="reputation",sql_pool="sqlalchemy",sql_success="true"} 4.0
sql_client_latency_seconds_bucket{le="0.025",sql_address="postgresql",sql_database="reputation",sql_pool="sqlalchemy",sql_success="true"} 4.0
sql_client_latency_seconds_bucket{le="0.05",sql_address="postgresql",sql_database="reputation",sql_pool="sqlalchemy",sql_success="true"} 4.0
sql_client_latency_seconds_bucket{le="0.1",sql_address="postgresql",sql_database="reputation",sql_pool="sqlalchemy",sql_success="true"} 4.0
sql_client_latency_seconds_bucket{le="0.25",sql_address="postgresql",sql_database="reputation",sql_pool="sqlalchemy",sql_success="true"} 4.0
sql_client_latency_seconds_bucket{le="0.5",sql_address="postgresql",sql_database="reputation",sql_pool="sqlalchemy",sql_success="true"} 4.0
sql_client_latency_seconds_bucket{le="1.0",sql_address="postgresql",sql_database="reputation",sql_pool="sqlalchemy",sql_success="true"} 4.0
sql_client_latency_seconds_bucket{le="5.0",sql_address="postgresql",sql_database="reputation",sql_pool="sqlalchemy",sql_success="true"} 4.0
sql_client_latency_seconds_bucket{le="15.0",sql_address="postgresql",sql_database="reputation",sql_pool="sqlalchemy",sql_success="true"} 4.0
sql_client_latency_seconds_bucket{le="30.0",sql_address="postgresql",sql_database="reputation",sql_pool="sqlalchemy",sql_success="true"} 4.0
sql_client_latency_seconds_bucket{le="+Inf",sql_address="postgresql",sql_database="reputation",sql_pool="sqlalchemy",sql_success="true"} 4.0
sql_client_latency_seconds_count{sql_address="postgresql",sql_database="reputation",sql_pool="sqlalchemy",sql_success="true"} 4.0
# HELP sql_client_requests_total Total number of sql requests
# TYPE sql_client_requests_total counter
sql_client_requests_total{sql_address="postgresql",sql_database="reputation",sql_pool="sqlalchemy",sql_success="true"} 4.0
# HELP sql_client_active_requests total requests that are in-flight
# TYPE sql_client_active_requests gauge
sql_client_active_requests{sql_address="postgresql",sql_database="reputation",sql_pool="sqlalchemy"} 0.0
```
## 🧪 Testing Steps / Validation
I will require this branch in karma service and verify in my local snoodev.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] CI tests (if present) are passing
- [ ] Adheres to code style for repo
- [ ] Contributor License Agreement (CLA) completed if not a Reddit employee
