### PR TITLE
Update Thift Pool metrics to use class qualname

### DIFF
--- a/baseplate/clients/thrift.py
+++ b/baseplate/clients/thrift.py
@@ -142,7 +142,7 @@ class ThriftContextFactory(ContextFactory):
         )
 
     def report_runtime_metrics(self, batch: metrics.Client) -> None:
-        pool_name = self.client_cls.__name__
+        pool_name = self.client_cls.__qualname__
         self.max_connections_gauge.labels(pool_name).set(self.pool.size)
         self.active_connections_gauge.labels(pool_name).set(self.pool.checkedout)
         batch.gauge("pool.size").replace(self.pool.size)

--- a/tests/unit/clients/thrift_tests.py
+++ b/tests/unit/clients/thrift_tests.py
@@ -4,7 +4,6 @@ from contextlib import nullcontext as does_not_raise
 from unittest import mock
 
 import pytest
-import inspect
 
 from prometheus_client import REGISTRY
 from thrift.protocol.TProtocol import TProtocolException

--- a/tests/unit/clients/thrift_tests.py
+++ b/tests/unit/clients/thrift_tests.py
@@ -230,6 +230,9 @@ class TestThriftContextFactory:
         prom_labels = {
             "thrift_pool": "TestThriftContextFactory.context_factory.<locals>.Iface",
         }
-        assert context_factory.client_cls.__qualname__ == "TestThriftContextFactory.context_factory.<locals>.Iface"
+        assert (
+            context_factory.client_cls.__qualname__
+            == "TestThriftContextFactory.context_factory.<locals>.Iface"
+        )
         assert REGISTRY.get_sample_value("thrift_client_pool_max_size", prom_labels) == 4
         assert REGISTRY.get_sample_value("thrift_client_pool_active_connections", prom_labels) == 8

--- a/tests/unit/clients/thrift_tests.py
+++ b/tests/unit/clients/thrift_tests.py
@@ -4,6 +4,7 @@ from contextlib import nullcontext as does_not_raise
 from unittest import mock
 
 import pytest
+import inspect
 
 from prometheus_client import REGISTRY
 from thrift.protocol.TProtocol import TProtocolException
@@ -228,7 +229,8 @@ class TestThriftContextFactory:
     def test_thrift_server_pool_prometheus_metrics(self, context_factory):
         context_factory.report_runtime_metrics(batch=mock.MagicMock())
         prom_labels = {
-            "thrift_pool": "Iface",
+            "thrift_pool": "TestThriftContextFactory.context_factory.<locals>.Iface",
         }
+        assert context_factory.client_cls.__qualname__ == "TestThriftContextFactory.context_factory.<locals>.Iface"
         assert REGISTRY.get_sample_value("thrift_client_pool_max_size", prom_labels) == 4
         assert REGISTRY.get_sample_value("thrift_client_pool_active_connections", prom_labels) == 8


### PR DESCRIPTION
## 💸 TL;DR
Copied and updated from @ckwang8128:
The `__name__`  directive will use `Iface` as the pool label for every single thrift pool defined for a service, since the Thrift compiler uses `Client`  as the class.

We likely want `__qualname__` instead to get a more identifiable label for these pool metrics.

## 📜 Details

Going forward the label will change from `IFace` to the full object reference.
Example:
`Iface` -> `TestThriftContextFactory.context_factory.<locals>.Iface` 

## 🧪 Testing Steps / Validation
I've locally run `docker-compose run baseplate make test` and updated the thrift tests to reflect the change.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] CI tests (if present) are passing
- [x] Adheres to code style for repo
~~- [ ] Contributor License Agreement (CLA) completed if not a Reddit employee~~
