### PR TITLE
Don't fail to finalize observers if one fails

### DIFF
--- a/baseplate/__init__.py
+++ b/baseplate/__init__.py
@@ -629,7 +629,10 @@ class Span:
 
         """
         for observer in self.observers:
-            observer.on_finish(exc_info)
+            try:
+                observer.on_finish(exc_info)
+            except Exception:
+                logger.exception("Exception raised while finalizing observer")
 
         # clean up reference cycles
         self.context = None  # type: ignore


### PR DESCRIPTION
<!-- If this pull request closes an issue, please mention the issue number below -->


## 💸 TL;DR
<!-- What's the three sentence summary of purpose of the PR -->
When a request finishes, baseplate invokes `on_finish` for each observer. Sometimes these finalizers will fail and raise an exception. This causes the loop to exit early and we fail to finalize observers later in the loop. This could result in a few things including [postgres sessions not getting closed](https://github.com/reddit/baseplate.py/blob/114248987ce0e8a0ddd102c80b00ef43f4dbf14e/baseplate/clients/sqlalchemy.py#L359) timely. Raising from a finalizer also means we fail to [clean up reference cycles](https://github.com/reddit/baseplate.py/blob/114248987ce0e8a0ddd102c80b00ef43f4dbf14e/baseplate/__init__.py#L634) later in the function and leave more work for GC to pick up later.


## 📜 Details
N/A
<!-- Add additional details required for the PR: breaking changes, screenshots, external dependency changes -->

## 🧪 Testing Steps / Validation
<!-- add details on how this PR has been tested, include reproductions and screenshots where applicable -->


## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] CI tests (if present) are passing
- [x] Adheres to code style for repo
- [x] Contributor License Agreement (CLA) completed if not a Reddit employee
