### PR TITLE
allow for empty X-Parent

### DIFF
--- a/baseplate/__init__.py
+++ b/baseplate/__init__.py
@@ -130,9 +130,9 @@ class TraceInfo(NamedTuple):
     @classmethod
     def from_upstream(
         cls,
-        trace_id: Optional[str],
+        trace_id: str,
         parent_id: Optional[str],
-        span_id: Optional[str],
+        span_id: str,
         sampled: Optional[bool],
         flags: Optional[int],
     ) -> "TraceInfo":
@@ -152,9 +152,6 @@ class TraceInfo(NamedTuple):
 
         if span_id is None:
             raise ValueError("invalid span_id")
-
-        if parent_id is None:
-            raise ValueError("invalid parent_id")
 
         if sampled is not None and not isinstance(sampled, bool):
             raise ValueError("invalid sampled value")

--- a/baseplate/frameworks/pyramid/__init__.py
+++ b/baseplate/frameworks/pyramid/__init__.py
@@ -402,7 +402,7 @@ class BaseplateConfigurator:
         flags = headers.get("X-Flags", None)
         return TraceInfo.from_upstream(
             headers["X-Trace"],
-            headers["X-Parent"],
+            headers.get("X-Parent", None),
             headers["X-Span"],
             sampled,
             int(flags) if flags is not None else None,

--- a/baseplate/frameworks/thrift/__init__.py
+++ b/baseplate/frameworks/thrift/__init__.py
@@ -205,7 +205,7 @@ def baseplateify_processor(
                 flags = headers.get(b"Flags", None)
                 trace_info = TraceInfo.from_upstream(
                     headers[b"Trace"].decode(),
-                    headers[b"Parent"].decode(),
+                    headers.get(b"Parent", b"").decode(),
                     headers[b"Span"].decode(),
                     sampled,
                     int(flags) if flags is not None else None,

--- a/tests/unit/core_tests.py
+++ b/tests/unit/core_tests.py
@@ -348,9 +348,7 @@ class TraceInfoTests(unittest.TestCase):
         self.assertIsNone(span.flags)
 
     def test_from_upstream_handles_no_parent(self):
-        """
-        Verify that `parent_id` can be left out without raising an exception.
-        """
+        """Verify that `parent_id` can be left out without raising an exception."""
         span = TraceInfo.from_upstream(1, None, 3, None, None)
         self.assertIsNone(span.parent_id)
         self.assertIsNotNone(span.trace_id)

--- a/tests/unit/core_tests.py
+++ b/tests/unit/core_tests.py
@@ -348,5 +348,10 @@ class TraceInfoTests(unittest.TestCase):
         self.assertIsNone(span.flags)
 
     def test_from_upstream_handles_no_parent(self):
+        """
+        Verify that `parent_id` can be left out without raising an exception.
+        """
         span = TraceInfo.from_upstream(1, None, 3, None, None)
         self.assertIsNone(span.parent_id)
+        self.assertIsNotNone(span.trace_id)
+        self.assertIsNotNone(span.span_id)

--- a/tests/unit/core_tests.py
+++ b/tests/unit/core_tests.py
@@ -319,6 +319,11 @@ class TraceInfoTests(unittest.TestCase):
         new_trace_info = TraceInfo.new()
         self.assertIsNone(new_trace_info.parent_id)
 
+    def test_new_sets_trace_and_span_ids(self):
+        new_trace_info = TraceInfo.new()
+        self.assertIsNotNone(new_trace_info.trace_id)
+        self.assertIsNotNone(new_trace_info.span_id)
+
     def test_new_does_not_set_flags(self):
         new_trace_info = TraceInfo.new()
         self.assertIsNone(new_trace_info.flags)
@@ -341,3 +346,7 @@ class TraceInfoTests(unittest.TestCase):
         span = TraceInfo.from_upstream(1, 2, 3, None, None)
         self.assertIsNone(span.sampled)
         self.assertIsNone(span.flags)
+
+    def test_from_upstream_handles_no_parent(self):
+        span = TraceInfo.from_upstream(1, None, 3, None, None)
+        self.assertIsNone(span.parent_id)


### PR DESCRIPTION
also tighten up optionality of params

## 💸 TL;DR
The `X-Parent` header could be empty, and will be for the root span. This PR allows for that.

## 📜 Details

## 🧪 Testing Steps / Validation

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] CI tests (if present) are passing
- [x] Adheres to code style for repo
- [x] Contributor License Agreement (CLA) completed if not a Reddit employee
