### PR TITLE
Add readthedocs config file

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,13 @@
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.12"
+
+python:
+  install:
+    - requirements: requirements.txt
+
+sphinx:
+  configuration: docs/conf.py


### PR DESCRIPTION
This is required nowadays: https://blog.readthedocs.com/migrate-configuration-v2/