### PR TITLE
SQLA: Invalidate sessions to prevent connections leak.

### DIFF
--- a/baseplate/clients/sqlalchemy.py
+++ b/baseplate/clients/sqlalchemy.py
@@ -360,4 +360,4 @@ class SQLAlchemySessionSpanObserver(SpanObserver):
         self.session = session
 
     def on_finish(self, exc_info: Optional[_ExcInfo]) -> None:
-        self.session.close()
+        self.session.invalidate()


### PR DESCRIPTION
## 💸 TL;DR
Sessions can be re-connected by issuing a statement via a reference. This should rarely be an issue given on_finish's place in the server lifecycle.

However, why have the possibility of leaking connections? Especially relevant in how some users of Baseplate have implemented Celery integrations.

## 📜 Details
Documentation here https://docs.sqlalchemy.org/en/14/orm/session_api.html#sqlalchemy.orm.Session.invalidate

## 🧪 Testing Steps / Validation
This is a very simple change. However we have ran it on reddit-service-campaign-management for a while without issues.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] CI tests (if present) are passing
- [x] Adheres to code style for repo
- [x] Contributor License Agreement (CLA) completed if not a Reddit employee
