### PR TITLE
CSI Additions

### DIFF
--- a/baseplate/lib/secrets.py
+++ b/baseplate/lib/secrets.py
@@ -495,6 +495,8 @@ class VaultCSISecretsStore(SecretsStore):
         backoff: Optional[float] = None,
     ):  # pylint: disable=super-init-not-called
         self.path = Path(path)
+        if not self.path.is_dir():
+            raise ValueError(f"{self.path} must be a directory")
         self.cache = {}
         self.data_symlink = self.path.joinpath("..data")
 

--- a/baseplate/lib/secrets.py
+++ b/baseplate/lib/secrets.py
@@ -495,11 +495,13 @@ class VaultCSISecretsStore(SecretsStore):
         backoff: Optional[float] = None,
     ):  # pylint: disable=super-init-not-called
         self.path = Path(path)
-        if not self.path.is_dir():
-            raise ValueError(f"{self.path} must be a directory")
+        self.parser = parser
         self.cache = {}
         self.data_symlink = self.path.joinpath("..data")
-        self.parser = parser
+        if not self.path.is_dir():
+            raise ValueError(f"Expected {self.path} to be a directory.")
+        if not self.data_symlink.is_dir():
+            raise ValueError(f"Expected {self.data_symlink} to be a directory. Verify {self.path} is the root of the Vault CSI mount.")
 
     def get_vault_url(self) -> str:
         raise NotImplementedError


### PR DESCRIPTION
We spoke about dynamically changing the default `config.path` based on the `config.provider`. Unfortunately there does not seem to be a way to tell if the `config.path` is the _default_, or if somebody provided the same value as the default.

My only idea is that we do something akin to this:
```py
default = "**DEFAULT**"
path = config.Optional(config.String, default=default)
provider = config.Optional(config.String, default="vault")
if provider == "vault_csi":
    path = "/mnt/secrets"
else:
   path = "/var/local/secrets.json"
```

But I worry that we're gonna find something somewhere else that ends up trying to use `**DEFAULT**` as a filepath