### PR TITLE
Raise a `SlotNotCoveredError` in rediscluster if slot doesnt exist

### DIFF
--- a/baseplate/clients/redis_cluster.py
+++ b/baseplate/clients/redis_cluster.py
@@ -222,8 +222,13 @@ class ClusterWithReadReplicasBlockingConnectionPool(rediscluster.ClusterBlocking
         If the command is a read command we'll try to return a random node.
         If there are no replicas or this isn't a read command we'll return the primary.
         """
-        if read_command:
-            return random.choice(self.nodes.slots[slot])
+        try:
+            if read_command:
+                return random.choice(self.nodes.slots[slot])
+        except KeyError:
+            raise rediscluster.exceptions.SlotNotCoveredError(
+                f"Slot {slot} not covered by the cluster"
+            )
 
         # This isn't a read command, so return the primary (first node)
         return self.nodes.slots[slot][0]


### PR DESCRIPTION
## 💸 TL;DR
Fixes a bug that causes `redis-cluster` client to fail to refresh the topology when a failover occurs in the Redis cluster.
## 📜 Details
The redis-py-cluster library does not properly handle a KeyError from `get_node_by_slot`. In their code they convert KeyError's to `SlotNotCoveredError` triggering a topology refresh, we should do the same in our derived class that overrides `get_node_by_slot`.

See https://github.com/Grokzen/redis-py-cluster/blob/8a8102a9d758d61a7ec1e2ac9050fcd34029ff3f/rediscluster/connection.py#L378 for how this is implemented in the client library.

## 🧪 Testing Steps / Validation
<!-- add details on how this PR has been tested, include reproductions and screenshots where applicable -->
Tested baseplate.py client in test pod connected to cluster performing failover.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] CI tests (if present) are passing
- [x] Adheres to code style for repo
- [x] Contributor License Agreement (CLA) completed if not a Reddit employee
