### PR TITLE
Move instrumentation back to modules instead of __init__

### DIFF
--- a/baseplate/clients/requests.py
+++ b/baseplate/clients/requests.py
@@ -25,6 +25,10 @@ from baseplate.lib import config
 from baseplate.lib.prometheus_metrics import default_latency_buckets
 from baseplate.lib.prometheus_metrics import getHTTPSuccessLabel
 
+from opentelemetry.instrumentation.requests import RequestsInstrumentor
+
+RequestsInstrumentor.instrument()
+
 
 def http_adapter_from_config(
     app_config: config.RawConfig, prefix: str, **kwargs: Any

--- a/baseplate/frameworks/pyramid/__init__.py
+++ b/baseplate/frameworks/pyramid/__init__.py
@@ -17,6 +17,8 @@ import pyramid.tweens
 import webob.request
 
 from opentelemetry import trace
+from opentelemetry.instrumentation.pyramid import PyramidInstrumentor
+
 from prometheus_client import Counter
 from prometheus_client import Gauge
 from prometheus_client import Histogram
@@ -36,6 +38,8 @@ from baseplate.lib.prometheus_metrics import getHTTPSuccessLabel
 from baseplate.thrift.ttypes import IsHealthyProbe
 
 logger = logging.getLogger(__name__)
+
+PyramidInstrumentor().instrument()
 
 
 class SpanFinishingAppIterWrapper(Iterable):

--- a/baseplate/server/__init__.py
+++ b/baseplate/server/__init__.py
@@ -44,8 +44,6 @@ from opentelemetry import propagate
 from opentelemetry import trace
 from opentelemetry.context import Context
 from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
-from opentelemetry.instrumentation.pyramid import PyramidInstrumentor
-from opentelemetry.instrumentation.requests import RequestsInstrumentor
 from opentelemetry.propagators.composite import CompositePropagator
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.resources import SERVICE_NAME
@@ -289,17 +287,11 @@ def configure_tracing(config: Configuration) -> None:
                 )
             )
             trace.set_tracer_provider(provider)
-            otel_tracing_autoinstrumentation()
             logger.info("Tracing Configured")
         else:
             logger.warning(
                 "Tracing disabled: service_name and endpoint are required fields in the tracing config."
             )
-
-
-def otel_tracing_autoinstrumentation() -> None:
-    PyramidInstrumentor().instrument()
-    RequestsInstrumentor().instrument()
 
 
 def make_listener(endpoint: EndpointConfiguration) -> socket.socket:


### PR DESCRIPTION
This is just targeting our working branch for opentelemetry. @chriskuehl and @KTAtkinson asked to have the instrumentation moved out of the top level modules so that they didn't go into effect on import.

I'm honestly not 100% sure what the problem is but it seems to be something around the ssl library getting loaded before it can be monkey patched. This then breaks urllib3.

This PR reverts the change, but if you have a better suggestion I'm all ears and can try to help validate it.