### PR TITLE
Update dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,8 @@
 ---
 version: 2
 updates:
+  # Note, the file `runtime.txt` is used to hint to dependabot
+  # the minimum version requirement for updates.
   - package-ecosystem: pip
     directory: "/"
     schedule:
@@ -8,3 +10,8 @@ updates:
     target-branch: develop
     labels:
       - "dependencies"
+    open-pull-requests-limit: 20
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -28,9 +28,9 @@ jobs:
         image: "zookeeper:3.4.10"
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@ab5e6d0c87105b4c9c2047343972218f562e4319 # v4.0.1
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements*.txt') }}

--- a/.github/workflows/python-publish.yaml
+++ b/.github/workflows/python-publish.yaml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
       with:
         python-version: '3.8'
 

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,0 +1,2 @@
+python-3.8
+# Specifies the python version that dependabot should use.


### PR DESCRIPTION
## 💸 TL;DR
* Increase python open PRs from default 5 to 20.
* Add dependabot updates for github actions.
* Update actions and pin versions to hash for supply chain security safety.
* Add a `runtime.txt` file to trick dependabot into thinking this is the
  required version for updates.


## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] CI tests (if present) are passing
- [ ] Adheres to code style for repo
- [ ] Contributor License Agreement (CLA) completed if not a Reddit employee
