### PR TITLE
Bump pytest from 7.4.4 to 8.1.1

### DIFF
--- a/requirements-transitive.txt
+++ b/requirements-transitive.txt
@@ -59,7 +59,7 @@ pathspec==0.9.0
 plaster==1.0
 plaster-pastedeploy==1.0.1
 platformdirs==4.1.0
-pluggy==0.13.1
+pluggy==1.4.0
 posix-ipc==1.0.5
 py==1.11.0
 pyasn1==0.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ pre-commit==3.5.0
 prometheus-client==0.19.0
 pydocstyle==5.1.1
 pylint==3.0.3
-pytest==7.4.4
+pytest==8.1.1
 pytest-cov==2.11.1
 pytz==2024.1
 reorder-python-imports==2.4.0


### PR DESCRIPTION
## 💸 TL;DR
Bumps pytest from 7.4.4 to 8.1.1.
* Update transitive requirements.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] CI tests (if present) are passing
- [ ] Adheres to code style for repo
- [ ] Contributor License Agreement (CLA) completed if not a Reddit employee
