### PR TITLE
Thrift metrics: omit status codes for exceptions with a non-int code

### DIFF
--- a/tests/unit/clients/thrift_tests.py
+++ b/tests/unit/clients/thrift_tests.py
@@ -66,6 +66,11 @@ class EnumerateServiceMethodsTests(unittest.TestCase):
             list(thrift._enumerate_service_methods(ExampleClient))
 
 
+class NonBaseplateExceptionWithCode(Exception):
+    def __init__(self):
+        self.code = lambda: "fake method"
+
+
 class TestPrometheusMetrics:
     def setup(self):
         REQUEST_LATENCY.clear()
@@ -126,6 +131,14 @@ class TestPrometheusMetrics:
                 "",
                 "",
                 pytest.raises(Exception),
+            ),
+            # Ensure that we don't poison prom metrics with non-baseplate status codes
+            (
+                NonBaseplateExceptionWithCode(),
+                "NonBaseplateExceptionWithCode",
+                "",
+                "",
+                pytest.raises(NonBaseplateExceptionWithCode),
             ),
         ],
     )


### PR DESCRIPTION
## 💸 TL;DR
If an exception has a `code` property that is not actually derived from a baseplate ErrorCode, we currently muddy our prometheus labels with invalid values. This goes a step further to reduce the risk of this occurring by checking for integers, which `ErrorCode`'s thrift definition would require.

## 📜 Details
Context available in this thread for employees: https://reddit.slack.com/archives/C070ARBL3M2/p1713888048834589

## 🧪 Testing Steps / Validation
Unit tested

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] CI tests (if present) are passing
- [x] Adheres to code style for repo
- [ ] Contributor License Agreement (CLA) completed if not a Reddit employee
