### PR TITLE
Do not use deprecated utcnow in ipython log line:

### DIFF
--- a/baseplate/server/__init__.py
+++ b/baseplate/server/__init__.py
@@ -438,6 +438,11 @@ def load_and_run_shell() -> None:
             # IPython 4 and below
             from IPython import Config
 
+        # test for UTC availability from the datetime package
+        import datetime as dt
+
+        datetime_exec = "now(datetime.UTC)" if getattr(dt, "UTC", False) else "utcnow()"
+
         ipython_config = Config()
         ipython_config.InteractiveShellApp.exec_lines = [
             # monkeypatch IPython's log-write() to enable formatted input logging, copying original code:
@@ -451,7 +456,7 @@ def load_and_run_shell() -> None:
                     write = self.logfile.write
                     if kind=='input':
                         # Generate an RFC 5424 compliant syslog format
-                        write(f'<13>1 {{datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S.%fZ")}} {{os.uname().nodename}} baseplate-shell {{os.getpid()}} {{message_id}} - {{data}}')
+                        write(f'<13>1 {{datetime.datetime.{datetime_exec}.strftime("%Y-%m-%dT%H:%M:%S.%fZ")}} {{os.uname().nodename}} baseplate-shell {{os.getpid()}} {{message_id}} - {{data}}')
                     elif kind=='output' and self.log_output:
                         odata = u'\\n'.join([u'#[Out]# %s' % s
                                         for s in data.splitlines()])


### PR DESCRIPTION
Closes #893

## 💸 TL;DR
See issue 893.

## 🧪 Testing Steps / Validation
```python
a = datetime.datetime.now(datetime.UTC).replace(tzinfo=None).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
b = datetime.datetime.now(datetime.UTC).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
c = datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S.%fZ")

print("\n".join((a,b,c)))

# 2024-04-29T19:06:01.275418Z
# 2024-04-29T19:06:01.275460Z
# 2024-04-29T19:06:01.275501Z
```

Python 3.8:
![Screenshot 2024-04-29 at 2 47 09 PM](https://github.com/reddit/baseplate.py/assets/134332337/df6ecff8-5af4-4882-8107-fe65b20bae68)

Python 3.12:
![Screenshot 2024-04-29 at 2 47 33 PM](https://github.com/reddit/baseplate.py/assets/134332337/82b593eb-cdbb-4974-b49e-ced791e88d30)


## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] CI tests (if present) are passing
- [x] Adheres to code style for repo
- [x] Contributor License Agreement (CLA) completed if not a Reddit employee
