### PR TITLE
InOrderConsumer doesn't work as intended. 

### DIFF
--- a/baseplate/frameworks/queue_consumer/kafka.py
+++ b/baseplate/frameworks/queue_consumer/kafka.py
@@ -488,6 +488,7 @@ class InOrderConsumerFactory(_BaseKafkaQueueConsumerFactory):
             prometheus_client_name=self.prometheus_client_name,
         )
 
+
 class FastConsumerFactory(_BaseKafkaQueueConsumerFactory):
     """Factory for running a :py:class:`~baseplate.server.queue_consumer.QueueConsumerServer` using Kafka.
 

--- a/baseplate/frameworks/queue_consumer/kafka.py
+++ b/baseplate/frameworks/queue_consumer/kafka.py
@@ -404,7 +404,9 @@ class InOrderConsumerFactory(_BaseKafkaQueueConsumerFactory):
     This will run a single `KafkaConsumerWorker` that reads messages from Kafka and
     puts them into an internal work queue. Then it will run a single `KafkaMessageHandler`
     that reads messages from the internal work queue, processes them with the
-    `handler_fn`, and then commits each message's offset to Kafka.
+    `handler_fn`, and then commits each message's offset to the kafka consumer's internal state.
+
+    The Kafka Consumer will commit the offsets back to Kafka based on the auto.commit.interval.ms default which is 5 seconds
 
     This one-at-a-time, in-order processing ensures that when a failure happens
     during processing we don't commit its offset (or the offset of any later
@@ -424,12 +426,14 @@ class InOrderConsumerFactory(_BaseKafkaQueueConsumerFactory):
     Message processing in Kafka to enable exactly once starts at the Producer enabling transactions,
     and downstream consumers enabling reading exclusively from the committed offsets within a transactions.
 
-    Secondly, without defined keys in the messages from the producer, messages will be sent in a round robin fashion to all partitions in the topic. This means that newer messages could be consumed before older ones if the consumer of those partitions with newer messages are faster.
+    Secondly, without defined keys in the messages from the producer, messages will be sent in a round robin fashion to all partitions in the topic.
+    This means that newer messages could be consumed before older ones if the consumer of those partitions with newer messages are faster.
 
     Some improvements are made instead that retain the current behaviour, but don't put as much pressure on Kafka by committing every single offset.
 
-
-    Instead of committing every single message's offset back to Kafka, the consumer now commits each offset to it's local offset store, and commits the highest seen value for each partition at a defined interval (auto.commit.interval.ms). "enable.auto.offset.store" is set to false to give our application explicit control of when to store offsets.
+    Instead of committing every single message's offset back to Kafka,
+    the consumer now commits each offset to it's local offset store, and commits the highest seen value for each partition at a defined interval (auto.commit.interval.ms).
+    "enable.auto.offset.store" is set to false to give our application explicit control of when to store offsets.
     """
 
     # we need to ensure that only a single message handler worker exists (max_concurrency = 1)

--- a/baseplate/frameworks/queue_consumer/kafka.py
+++ b/baseplate/frameworks/queue_consumer/kafka.py
@@ -358,16 +358,14 @@ class _BaseKafkaQueueConsumerFactory(QueueConsumerFactory):
 
         # pylint: disable=unused-argument
         def log_assign(
-            consumer: confluent_kafka.Consumer,
-            partitions: List[confluent_kafka.TopicPartition],
+            consumer: confluent_kafka.Consumer, partitions: List[confluent_kafka.TopicPartition]
         ) -> None:
             for topic_partition in partitions:
                 logger.info("assigned %s/%s", topic_partition.topic, topic_partition.partition)
 
         # pylint: disable=unused-argument
         def log_revoke(
-            consumer: confluent_kafka.Consumer,
-            partitions: List[confluent_kafka.TopicPartition],
+            consumer: confluent_kafka.Consumer, partitions: List[confluent_kafka.TopicPartition]
         ) -> None:
             for topic_partition in partitions:
                 logger.info("revoked %s/%s", topic_partition.topic, topic_partition.partition)
@@ -421,17 +419,6 @@ class InOrderConsumerFactory(_BaseKafkaQueueConsumerFactory):
     If you need more control, you can create the :py:class:`~confluent_kafka.Consumer`
     yourself and use the constructor directly.
 
-    UPDATE: The InOrderConsumerFactory can NEVER achieve in-order, exactly once message processing.
-
-    Message processing in Kafka to enable exactly once starts at the Producer enabling transactions,
-    and downstream consumers enabling reading exclusively from the committed offsets within a transactions.
-
-    Secondly, without defined keys in the messages from the producer, messages will be sent in a round robin fashion to all partitions in the topic. This means that newer messages could be consumed before older ones if the consumer of those partitions with newer messages are faster.
-
-    Some improvements are made instead that retain the current behaviour, but don't put as much pressure on Kafka by committing every single offset.
-
-
-    Instead of committing every single message's offset back to Kafka, the consumer now commits each offset to it's local offset store, and commits the highest seen value for each partition at a defined interval (auto.commit.interval.ms). "enable.auto.offset.store" is set to false to give our application explicit control of when to store offsets.
     """
 
     # we need to ensure that only a single message handler worker exists (max_concurrency = 1)
@@ -457,9 +444,8 @@ class InOrderConsumerFactory(_BaseKafkaQueueConsumerFactory):
             # after message processing, to make sure offsets are not auto-committed
             # prior to processing has finished.
             "max.poll.interval.ms": 300000,
-            # Enable offset autocommit, but disable offset store.
-            "enable.auto.commit": "true",
-            "enable.auto.offset.store": "false",
+            # disable offset autocommit, we'll manually commit.
+            "enable.auto.commit": "false",
         }
 
     def build_message_handler(self) -> KafkaMessageHandler:
@@ -478,7 +464,7 @@ class InOrderConsumerFactory(_BaseKafkaQueueConsumerFactory):
                 message.offset(),
             )
             with context.span.make_child("kafka.commit"):
-                self.consumer.store_offsets(message=message)
+                self.consumer.commit(message=message, asynchronous=False)
 
         return KafkaMessageHandler(
             self.baseplate,
@@ -541,8 +527,7 @@ class FastConsumerFactory(_BaseKafkaQueueConsumerFactory):
     # pylint: disable=unused-argument
     @staticmethod
     def _commit_callback(
-        err: confluent_kafka.KafkaError,
-        topic_partition_list: List[confluent_kafka.TopicPartition],
+        err: confluent_kafka.KafkaError, topic_partition_list: List[confluent_kafka.TopicPartition]
     ) -> None:
         # called after automatic commits
         for topic_partition in topic_partition_list:
@@ -552,10 +537,7 @@ class FastConsumerFactory(_BaseKafkaQueueConsumerFactory):
 
             if topic_partition.error:
                 logger.error(
-                    "commit error topic %s partition %s offset %s",
-                    topic,
-                    partition,
-                    offset,
+                    "commit error topic %s partition %s offset %s", topic, partition, offset
                 )
             elif offset == confluent_kafka.OFFSET_INVALID:
                 # we receive offsets for all partitions. an offset value of
@@ -563,10 +545,7 @@ class FastConsumerFactory(_BaseKafkaQueueConsumerFactory):
                 pass
             else:
                 logger.debug(
-                    "commit success topic %s partition %s offset %s",
-                    topic,
-                    partition,
-                    offset,
+                    "commit success topic %s partition %s offset %s", topic, partition, offset
                 )
 
     @classmethod

--- a/tests/unit/frameworks/queue_consumer/kafka_tests.py
+++ b/tests/unit/frameworks/queue_consumer/kafka_tests.py
@@ -74,16 +74,12 @@ class TestKafkaMessageHandler:
 
     @mock.patch("baseplate.frameworks.queue_consumer.kafka.time")
     @pytest.mark.parametrize("prometheus_client_name", [None, "my_kafka_client_name"])
-    def test_handle(
-        self, time, context, span, baseplate, name, message, prometheus_client_name
-    ):
+    def test_handle(self, time, context, span, baseplate, name, message, prometheus_client_name):
         time.time.return_value = 2.0
         time.perf_counter.side_effect = [1, 2]
 
         prom_labels = KafkaConsumerPrometheusLabels(
-            kafka_client_name=prometheus_client_name
-            if prometheus_client_name is not None
-            else "",
+            kafka_client_name=prometheus_client_name if prometheus_client_name is not None else "",
             kafka_topic="topic_1",
         )
 
@@ -157,15 +153,10 @@ class TestKafkaMessageHandler:
             == 1
         )
         assert (
-            REGISTRY.get_sample_value(
-                f"{KAFKA_ACTIVE_MESSAGES._name}", prom_labels._asdict()
-            )
-            == 0
+            REGISTRY.get_sample_value(f"{KAFKA_ACTIVE_MESSAGES._name}", prom_labels._asdict()) == 0
         )
 
-    def test_handle_no_endpoint_timestamp(
-        self, context, span, baseplate, name, message
-    ):
+    def test_handle_no_endpoint_timestamp(self, context, span, baseplate, name, message):
         handler_fn = mock.Mock()
         message_unpack_fn = mock.Mock(return_value={"body": "some text"})
         on_success_fn = mock.Mock()
@@ -178,9 +169,7 @@ class TestKafkaMessageHandler:
             kafka_topic="topic_1",
         )
 
-        handler = KafkaMessageHandler(
-            baseplate, name, handler_fn, message_unpack_fn, on_success_fn
-        )
+        handler = KafkaMessageHandler(baseplate, name, handler_fn, message_unpack_fn, on_success_fn)
         handler.handle(message)
 
         baseplate.make_context_object.assert_called_once()
@@ -221,10 +210,7 @@ class TestKafkaMessageHandler:
             == 1
         )
         assert (
-            REGISTRY.get_sample_value(
-                f"{KAFKA_ACTIVE_MESSAGES._name}", prom_labels._asdict()
-            )
-            == 0
+            REGISTRY.get_sample_value(f"{KAFKA_ACTIVE_MESSAGES._name}", prom_labels._asdict()) == 0
         )
 
     def test_handle_kafka_error(self, context, span, baseplate, name, message):
@@ -237,9 +223,7 @@ class TestKafkaMessageHandler:
         error_mock.str.return_value = "kafka error"
         message.error.return_value = error_mock
 
-        handler = KafkaMessageHandler(
-            baseplate, name, handler_fn, message_unpack_fn, on_success_fn
-        )
+        handler = KafkaMessageHandler(baseplate, name, handler_fn, message_unpack_fn, on_success_fn)
 
         prom_labels = KafkaConsumerPrometheusLabels(
             kafka_client_name="",
@@ -274,10 +258,7 @@ class TestKafkaMessageHandler:
             == 1
         )
         assert (
-            REGISTRY.get_sample_value(
-                f"{KAFKA_ACTIVE_MESSAGES._name}", prom_labels._asdict()
-            )
-            == 0
+            REGISTRY.get_sample_value(f"{KAFKA_ACTIVE_MESSAGES._name}", prom_labels._asdict()) == 0
         )
 
     def test_handle_unpack_error(self, context, span, baseplate, name, message):
@@ -287,9 +268,7 @@ class TestKafkaMessageHandler:
 
         context.span = span
 
-        handler = KafkaMessageHandler(
-            baseplate, name, handler_fn, message_unpack_fn, on_success_fn
-        )
+        handler = KafkaMessageHandler(baseplate, name, handler_fn, message_unpack_fn, on_success_fn)
 
         prom_labels = KafkaConsumerPrometheusLabels(
             kafka_client_name="",
@@ -334,10 +313,7 @@ class TestKafkaMessageHandler:
             == 1
         )
         assert (
-            REGISTRY.get_sample_value(
-                f"{KAFKA_ACTIVE_MESSAGES._name}", prom_labels._asdict()
-            )
-            == 0
+            REGISTRY.get_sample_value(f"{KAFKA_ACTIVE_MESSAGES._name}", prom_labels._asdict()) == 0
         )
 
     def test_handle_handler_error(self, context, span, baseplate, name, message):
@@ -347,9 +323,7 @@ class TestKafkaMessageHandler:
         )
         on_success_fn = mock.Mock()
 
-        handler = KafkaMessageHandler(
-            baseplate, name, handler_fn, message_unpack_fn, on_success_fn
-        )
+        handler = KafkaMessageHandler(baseplate, name, handler_fn, message_unpack_fn, on_success_fn)
 
         prom_labels = KafkaConsumerPrometheusLabels(
             kafka_client_name="",
@@ -396,10 +370,7 @@ class TestKafkaMessageHandler:
             == 1
         )
         assert (
-            REGISTRY.get_sample_value(
-                f"{KAFKA_ACTIVE_MESSAGES._name}", prom_labels._asdict()
-            )
-            == 0
+            REGISTRY.get_sample_value(f"{KAFKA_ACTIVE_MESSAGES._name}", prom_labels._asdict()) == 0
         )
 
 
@@ -425,11 +396,7 @@ class TestInOrderConsumerFactory:
     ):
         mock_consumer = mock.Mock()
         mock_consumer.list_topics.return_value = mock.Mock(
-            topics={
-                "topic_1": mock.Mock(),
-                "topic_2": mock.Mock(),
-                "topic_3": mock.Mock(),
-            }
+            topics={"topic_1": mock.Mock(), "topic_2": mock.Mock(), "topic_3": mock.Mock()}
         )
         kafka_consumer.return_value = mock_consumer
         extra_config = {"queued.max.messages.kbytes": 10000}
@@ -462,11 +429,7 @@ class TestInOrderConsumerFactory:
     ):
         mock_consumer = mock.Mock()
         mock_consumer.list_topics.return_value = mock.Mock(
-            topics={
-                "topic_1": mock.Mock(),
-                "topic_2": mock.Mock(),
-                "topic_3": mock.Mock(),
-            }
+            topics={"topic_1": mock.Mock(), "topic_2": mock.Mock(), "topic_3": mock.Mock()}
         )
         kafka_consumer.return_value = mock_consumer
         extra_config = {"queued.max.messages.kbytes": 100}
@@ -492,16 +455,10 @@ class TestInOrderConsumerFactory:
         mock_consumer.subscribe.assert_not_called()
 
     @mock.patch("confluent_kafka.Consumer")
-    def test_init(
-        self, kafka_consumer, name, baseplate, bootstrap_servers, group_id, topics
-    ):
+    def test_init(self, kafka_consumer, name, baseplate, bootstrap_servers, group_id, topics):
         mock_consumer = mock.Mock()
         mock_consumer.list_topics.return_value = mock.Mock(
-            topics={
-                "topic_1": mock.Mock(),
-                "topic_2": mock.Mock(),
-                "topic_3": mock.Mock(),
-            }
+            topics={"topic_1": mock.Mock(), "topic_2": mock.Mock(), "topic_3": mock.Mock()}
         )
         kafka_consumer.return_value = mock_consumer
 
@@ -526,18 +483,12 @@ class TestInOrderConsumerFactory:
         assert factory.consumer == mock_consumer
 
     @pytest.fixture
-    def make_queue_consumer_factory(
-        self, name, baseplate, bootstrap_servers, group_id, topics
-    ):
+    def make_queue_consumer_factory(self, name, baseplate, bootstrap_servers, group_id, topics):
         @mock.patch("confluent_kafka.Consumer")
         def _make_queue_consumer_factory(kafka_consumer, health_check_fn=None):
             mock_consumer = mock.Mock()
             mock_consumer.list_topics.return_value = mock.Mock(
-                topics={
-                    "topic_1": mock.Mock(),
-                    "topic_2": mock.Mock(),
-                    "topic_3": mock.Mock(),
-                }
+                topics={"topic_1": mock.Mock(), "topic_2": mock.Mock(), "topic_3": mock.Mock()}
             )
             kafka_consumer.return_value = mock_consumer
 
@@ -595,17 +546,11 @@ class TestFastConsumerFactory:
     ):
         mock_consumer = mock.Mock()
         mock_consumer.list_topics.return_value = mock.Mock(
-            topics={
-                "topic_1": mock.Mock(),
-                "topic_2": mock.Mock(),
-                "topic_3": mock.Mock(),
-            }
+            topics={"topic_1": mock.Mock(), "topic_2": mock.Mock(), "topic_3": mock.Mock()}
         )
         kafka_consumer.return_value = mock_consumer
 
-        _consumer = FastConsumerFactory.make_kafka_consumer(
-            bootstrap_servers, group_id, topics
-        )
+        _consumer = FastConsumerFactory.make_kafka_consumer(bootstrap_servers, group_id, topics)
 
         assert _consumer == mock_consumer
 
@@ -633,18 +578,12 @@ class TestFastConsumerFactory:
     ):
         mock_consumer = mock.Mock()
         mock_consumer.list_topics.return_value = mock.Mock(
-            topics={
-                "topic_1": mock.Mock(),
-                "topic_2": mock.Mock(),
-                "topic_3": mock.Mock(),
-            }
+            topics={"topic_1": mock.Mock(), "topic_2": mock.Mock(), "topic_3": mock.Mock()}
         )
         kafka_consumer.return_value = mock_consumer
 
         with pytest.raises(AssertionError):
-            FastConsumerFactory.make_kafka_consumer(
-                bootstrap_servers, group_id, ["topic_4"]
-            )
+            FastConsumerFactory.make_kafka_consumer(bootstrap_servers, group_id, ["topic_4"])
 
         kafka_consumer.assert_called_once_with(
             {
@@ -664,16 +603,10 @@ class TestFastConsumerFactory:
         mock_consumer.subscribe.assert_not_called()
 
     @mock.patch("confluent_kafka.Consumer")
-    def test_init(
-        self, kafka_consumer, name, baseplate, bootstrap_servers, group_id, topics
-    ):
+    def test_init(self, kafka_consumer, name, baseplate, bootstrap_servers, group_id, topics):
         mock_consumer = mock.Mock()
         mock_consumer.list_topics.return_value = mock.Mock(
-            topics={
-                "topic_1": mock.Mock(),
-                "topic_2": mock.Mock(),
-                "topic_3": mock.Mock(),
-            }
+            topics={"topic_1": mock.Mock(), "topic_2": mock.Mock(), "topic_3": mock.Mock()}
         )
         kafka_consumer.return_value = mock_consumer
 
@@ -698,18 +631,12 @@ class TestFastConsumerFactory:
         assert factory.consumer == mock_consumer
 
     @pytest.fixture
-    def make_queue_consumer_factory(
-        self, name, baseplate, bootstrap_servers, group_id, topics
-    ):
+    def make_queue_consumer_factory(self, name, baseplate, bootstrap_servers, group_id, topics):
         @mock.patch("confluent_kafka.Consumer")
         def _make_queue_consumer_factory(kafka_consumer, health_check_fn=None):
             mock_consumer = mock.Mock()
             mock_consumer.list_topics.return_value = mock.Mock(
-                topics={
-                    "topic_1": mock.Mock(),
-                    "topic_2": mock.Mock(),
-                    "topic_3": mock.Mock(),
-                }
+                topics={"topic_1": mock.Mock(), "topic_2": mock.Mock(), "topic_3": mock.Mock()}
             )
             kafka_consumer.return_value = mock_consumer
 
@@ -776,11 +703,7 @@ class TestKafkaConsumerWorker:
             stopped_value.side_effect = [False, False, False, True]
             consumer_worker.run()
 
-        baseplate.make_context_object.mock_calls == [
-            mock.call(),
-            mock.call(),
-            mock.call(),
-        ]
+        baseplate.make_context_object.mock_calls == [mock.call(), mock.call(), mock.call()]
         baseplate.make_server_span.mock_calls == [
             mock.call(context, f"{name}.pump"),
             mock.call(context, f"{name}.pump"),
@@ -803,10 +726,7 @@ class TestKafkaConsumerWorker:
         ]
 
         time.sleep.assert_called_once_with(1)
-        assert consumer_worker.work_queue.put.mock_calls == [
-            mock.call(msg1),
-            mock.call(msg2),
-        ]
+        assert consumer_worker.work_queue.put.mock_calls == [mock.call(msg1), mock.call(msg2)]
 
     def test_stop(self, consumer_worker):
         consumer_worker.stop()

--- a/tests/unit/frameworks/queue_consumer/kafka_tests.py
+++ b/tests/unit/frameworks/queue_consumer/kafka_tests.py
@@ -74,12 +74,16 @@ class TestKafkaMessageHandler:
 
     @mock.patch("baseplate.frameworks.queue_consumer.kafka.time")
     @pytest.mark.parametrize("prometheus_client_name", [None, "my_kafka_client_name"])
-    def test_handle(self, time, context, span, baseplate, name, message, prometheus_client_name):
+    def test_handle(
+        self, time, context, span, baseplate, name, message, prometheus_client_name
+    ):
         time.time.return_value = 2.0
         time.perf_counter.side_effect = [1, 2]
 
         prom_labels = KafkaConsumerPrometheusLabels(
-            kafka_client_name=prometheus_client_name if prometheus_client_name is not None else "",
+            kafka_client_name=prometheus_client_name
+            if prometheus_client_name is not None
+            else "",
             kafka_topic="topic_1",
         )
 
@@ -153,10 +157,15 @@ class TestKafkaMessageHandler:
             == 1
         )
         assert (
-            REGISTRY.get_sample_value(f"{KAFKA_ACTIVE_MESSAGES._name}", prom_labels._asdict()) == 0
+            REGISTRY.get_sample_value(
+                f"{KAFKA_ACTIVE_MESSAGES._name}", prom_labels._asdict()
+            )
+            == 0
         )
 
-    def test_handle_no_endpoint_timestamp(self, context, span, baseplate, name, message):
+    def test_handle_no_endpoint_timestamp(
+        self, context, span, baseplate, name, message
+    ):
         handler_fn = mock.Mock()
         message_unpack_fn = mock.Mock(return_value={"body": "some text"})
         on_success_fn = mock.Mock()
@@ -169,7 +178,9 @@ class TestKafkaMessageHandler:
             kafka_topic="topic_1",
         )
 
-        handler = KafkaMessageHandler(baseplate, name, handler_fn, message_unpack_fn, on_success_fn)
+        handler = KafkaMessageHandler(
+            baseplate, name, handler_fn, message_unpack_fn, on_success_fn
+        )
         handler.handle(message)
 
         baseplate.make_context_object.assert_called_once()
@@ -210,7 +221,10 @@ class TestKafkaMessageHandler:
             == 1
         )
         assert (
-            REGISTRY.get_sample_value(f"{KAFKA_ACTIVE_MESSAGES._name}", prom_labels._asdict()) == 0
+            REGISTRY.get_sample_value(
+                f"{KAFKA_ACTIVE_MESSAGES._name}", prom_labels._asdict()
+            )
+            == 0
         )
 
     def test_handle_kafka_error(self, context, span, baseplate, name, message):
@@ -223,7 +237,9 @@ class TestKafkaMessageHandler:
         error_mock.str.return_value = "kafka error"
         message.error.return_value = error_mock
 
-        handler = KafkaMessageHandler(baseplate, name, handler_fn, message_unpack_fn, on_success_fn)
+        handler = KafkaMessageHandler(
+            baseplate, name, handler_fn, message_unpack_fn, on_success_fn
+        )
 
         prom_labels = KafkaConsumerPrometheusLabels(
             kafka_client_name="",
@@ -258,7 +274,10 @@ class TestKafkaMessageHandler:
             == 1
         )
         assert (
-            REGISTRY.get_sample_value(f"{KAFKA_ACTIVE_MESSAGES._name}", prom_labels._asdict()) == 0
+            REGISTRY.get_sample_value(
+                f"{KAFKA_ACTIVE_MESSAGES._name}", prom_labels._asdict()
+            )
+            == 0
         )
 
     def test_handle_unpack_error(self, context, span, baseplate, name, message):
@@ -268,7 +287,9 @@ class TestKafkaMessageHandler:
 
         context.span = span
 
-        handler = KafkaMessageHandler(baseplate, name, handler_fn, message_unpack_fn, on_success_fn)
+        handler = KafkaMessageHandler(
+            baseplate, name, handler_fn, message_unpack_fn, on_success_fn
+        )
 
         prom_labels = KafkaConsumerPrometheusLabels(
             kafka_client_name="",
@@ -313,7 +334,10 @@ class TestKafkaMessageHandler:
             == 1
         )
         assert (
-            REGISTRY.get_sample_value(f"{KAFKA_ACTIVE_MESSAGES._name}", prom_labels._asdict()) == 0
+            REGISTRY.get_sample_value(
+                f"{KAFKA_ACTIVE_MESSAGES._name}", prom_labels._asdict()
+            )
+            == 0
         )
 
     def test_handle_handler_error(self, context, span, baseplate, name, message):
@@ -323,7 +347,9 @@ class TestKafkaMessageHandler:
         )
         on_success_fn = mock.Mock()
 
-        handler = KafkaMessageHandler(baseplate, name, handler_fn, message_unpack_fn, on_success_fn)
+        handler = KafkaMessageHandler(
+            baseplate, name, handler_fn, message_unpack_fn, on_success_fn
+        )
 
         prom_labels = KafkaConsumerPrometheusLabels(
             kafka_client_name="",
@@ -370,7 +396,10 @@ class TestKafkaMessageHandler:
             == 1
         )
         assert (
-            REGISTRY.get_sample_value(f"{KAFKA_ACTIVE_MESSAGES._name}", prom_labels._asdict()) == 0
+            REGISTRY.get_sample_value(
+                f"{KAFKA_ACTIVE_MESSAGES._name}", prom_labels._asdict()
+            )
+            == 0
         )
 
 
@@ -396,7 +425,11 @@ class TestInOrderConsumerFactory:
     ):
         mock_consumer = mock.Mock()
         mock_consumer.list_topics.return_value = mock.Mock(
-            topics={"topic_1": mock.Mock(), "topic_2": mock.Mock(), "topic_3": mock.Mock()}
+            topics={
+                "topic_1": mock.Mock(),
+                "topic_2": mock.Mock(),
+                "topic_3": mock.Mock(),
+            }
         )
         kafka_consumer.return_value = mock_consumer
         extra_config = {"queued.max.messages.kbytes": 10000}
@@ -429,7 +462,11 @@ class TestInOrderConsumerFactory:
     ):
         mock_consumer = mock.Mock()
         mock_consumer.list_topics.return_value = mock.Mock(
-            topics={"topic_1": mock.Mock(), "topic_2": mock.Mock(), "topic_3": mock.Mock()}
+            topics={
+                "topic_1": mock.Mock(),
+                "topic_2": mock.Mock(),
+                "topic_3": mock.Mock(),
+            }
         )
         kafka_consumer.return_value = mock_consumer
         extra_config = {"queued.max.messages.kbytes": 100}
@@ -455,10 +492,16 @@ class TestInOrderConsumerFactory:
         mock_consumer.subscribe.assert_not_called()
 
     @mock.patch("confluent_kafka.Consumer")
-    def test_init(self, kafka_consumer, name, baseplate, bootstrap_servers, group_id, topics):
+    def test_init(
+        self, kafka_consumer, name, baseplate, bootstrap_servers, group_id, topics
+    ):
         mock_consumer = mock.Mock()
         mock_consumer.list_topics.return_value = mock.Mock(
-            topics={"topic_1": mock.Mock(), "topic_2": mock.Mock(), "topic_3": mock.Mock()}
+            topics={
+                "topic_1": mock.Mock(),
+                "topic_2": mock.Mock(),
+                "topic_3": mock.Mock(),
+            }
         )
         kafka_consumer.return_value = mock_consumer
 
@@ -483,12 +526,18 @@ class TestInOrderConsumerFactory:
         assert factory.consumer == mock_consumer
 
     @pytest.fixture
-    def make_queue_consumer_factory(self, name, baseplate, bootstrap_servers, group_id, topics):
+    def make_queue_consumer_factory(
+        self, name, baseplate, bootstrap_servers, group_id, topics
+    ):
         @mock.patch("confluent_kafka.Consumer")
         def _make_queue_consumer_factory(kafka_consumer, health_check_fn=None):
             mock_consumer = mock.Mock()
             mock_consumer.list_topics.return_value = mock.Mock(
-                topics={"topic_1": mock.Mock(), "topic_2": mock.Mock(), "topic_3": mock.Mock()}
+                topics={
+                    "topic_1": mock.Mock(),
+                    "topic_2": mock.Mock(),
+                    "topic_3": mock.Mock(),
+                }
             )
             kafka_consumer.return_value = mock_consumer
 
@@ -546,11 +595,17 @@ class TestFastConsumerFactory:
     ):
         mock_consumer = mock.Mock()
         mock_consumer.list_topics.return_value = mock.Mock(
-            topics={"topic_1": mock.Mock(), "topic_2": mock.Mock(), "topic_3": mock.Mock()}
+            topics={
+                "topic_1": mock.Mock(),
+                "topic_2": mock.Mock(),
+                "topic_3": mock.Mock(),
+            }
         )
         kafka_consumer.return_value = mock_consumer
 
-        _consumer = FastConsumerFactory.make_kafka_consumer(bootstrap_servers, group_id, topics)
+        _consumer = FastConsumerFactory.make_kafka_consumer(
+            bootstrap_servers, group_id, topics
+        )
 
         assert _consumer == mock_consumer
 
@@ -578,12 +633,18 @@ class TestFastConsumerFactory:
     ):
         mock_consumer = mock.Mock()
         mock_consumer.list_topics.return_value = mock.Mock(
-            topics={"topic_1": mock.Mock(), "topic_2": mock.Mock(), "topic_3": mock.Mock()}
+            topics={
+                "topic_1": mock.Mock(),
+                "topic_2": mock.Mock(),
+                "topic_3": mock.Mock(),
+            }
         )
         kafka_consumer.return_value = mock_consumer
 
         with pytest.raises(AssertionError):
-            FastConsumerFactory.make_kafka_consumer(bootstrap_servers, group_id, ["topic_4"])
+            FastConsumerFactory.make_kafka_consumer(
+                bootstrap_servers, group_id, ["topic_4"]
+            )
 
         kafka_consumer.assert_called_once_with(
             {
@@ -603,10 +664,16 @@ class TestFastConsumerFactory:
         mock_consumer.subscribe.assert_not_called()
 
     @mock.patch("confluent_kafka.Consumer")
-    def test_init(self, kafka_consumer, name, baseplate, bootstrap_servers, group_id, topics):
+    def test_init(
+        self, kafka_consumer, name, baseplate, bootstrap_servers, group_id, topics
+    ):
         mock_consumer = mock.Mock()
         mock_consumer.list_topics.return_value = mock.Mock(
-            topics={"topic_1": mock.Mock(), "topic_2": mock.Mock(), "topic_3": mock.Mock()}
+            topics={
+                "topic_1": mock.Mock(),
+                "topic_2": mock.Mock(),
+                "topic_3": mock.Mock(),
+            }
         )
         kafka_consumer.return_value = mock_consumer
 
@@ -631,12 +698,18 @@ class TestFastConsumerFactory:
         assert factory.consumer == mock_consumer
 
     @pytest.fixture
-    def make_queue_consumer_factory(self, name, baseplate, bootstrap_servers, group_id, topics):
+    def make_queue_consumer_factory(
+        self, name, baseplate, bootstrap_servers, group_id, topics
+    ):
         @mock.patch("confluent_kafka.Consumer")
         def _make_queue_consumer_factory(kafka_consumer, health_check_fn=None):
             mock_consumer = mock.Mock()
             mock_consumer.list_topics.return_value = mock.Mock(
-                topics={"topic_1": mock.Mock(), "topic_2": mock.Mock(), "topic_3": mock.Mock()}
+                topics={
+                    "topic_1": mock.Mock(),
+                    "topic_2": mock.Mock(),
+                    "topic_3": mock.Mock(),
+                }
             )
             kafka_consumer.return_value = mock_consumer
 
@@ -703,7 +776,11 @@ class TestKafkaConsumerWorker:
             stopped_value.side_effect = [False, False, False, True]
             consumer_worker.run()
 
-        baseplate.make_context_object.mock_calls == [mock.call(), mock.call(), mock.call()]
+        baseplate.make_context_object.mock_calls == [
+            mock.call(),
+            mock.call(),
+            mock.call(),
+        ]
         baseplate.make_server_span.mock_calls == [
             mock.call(context, f"{name}.pump"),
             mock.call(context, f"{name}.pump"),
@@ -726,7 +803,10 @@ class TestKafkaConsumerWorker:
         ]
 
         time.sleep.assert_called_once_with(1)
-        assert consumer_worker.work_queue.put.mock_calls == [mock.call(msg1), mock.call(msg2)]
+        assert consumer_worker.work_queue.put.mock_calls == [
+            mock.call(msg1),
+            mock.call(msg2),
+        ]
 
     def test_stop(self, consumer_worker):
         consumer_worker.stop()

--- a/tests/unit/frameworks/queue_consumer/kafka_tests.py
+++ b/tests/unit/frameworks/queue_consumer/kafka_tests.py
@@ -416,7 +416,8 @@ class TestInOrderConsumerFactory:
                 "heartbeat.interval.ms": 3000,
                 "session.timeout.ms": 10000,
                 "max.poll.interval.ms": 300000,
-                "enable.auto.commit": "false",
+                "enable.auto.commit": "true",
+                "enable.auto.offset.store": "false",
                 "queued.max.messages.kbytes": 10000,
             }
         )
@@ -448,8 +449,9 @@ class TestInOrderConsumerFactory:
                 "heartbeat.interval.ms": 3000,
                 "session.timeout.ms": 10000,
                 "max.poll.interval.ms": 300000,
-                "enable.auto.commit": "false",
+                "enable.auto.commit": "true",
                 "queued.max.messages.kbytes": 100,
+                "enable.auto.offset.store": "false",
             }
         )
         mock_consumer.subscribe.assert_not_called()


### PR DESCRIPTION
## 💸 TL;DR + Details
The InOrderConsumer Kafka Class makes a lot of assumptions that are False and inefficient with how Kafka Processes Events. 

The current logic of using only 1 consumer and commit back the offsets doesn't take into consideration that the upstream messages are sending messages randomly to each partition.  

You would need to enable transactions upstream for the producer, as well as delivering messages with a Key. This would guarantee two things.

1. All messages with a given key are guaranteed to land in a single partition. 

https://docs.confluent.io/platform/current/clients/producer.html#concepts
> The partitioners shipped with Kafka guarantee that all messages with the same non-empty key will be sent to the same partition.
> 
> If the key is provided, the partitioner will hash the key with murmur2 algorithm and divide it by the number of partitions. The result is that the same key is always assigned to the same partition. 

2. Consumers can switch to reading committed transactions instead of uncommitted transactions. 

https://docs.confluent.io/platform/current/installation/configuration/consumer-configs.html#isolation-level

## 📜 Details

So what is this PR doing so differently? 

Technically, this keeps the same exact APIs in place, but only solves 1 problem. Stop committing back to Kafka so frequently. 

Instead of manually committing every offset which swarms Kafka with requests. Store the offset locally and commit the last max seen offset per partition back to Kafka in the auto.commit frequency. 

This keeps the behavior that you're committing every offset, but only delivering it every couple of seconds. 


## One More Detail

My lilnter went a little crazy when committing this. I can revert that. 
