### PR TITLE
Feat: KV store on RequestContext class

### DIFF
--- a/baseplate/__init__.py
+++ b/baseplate/__init__.py
@@ -192,7 +192,7 @@ class RequestContext:
         self.__prefix = prefix
         self.__wrapped = wrapped
         if kv is None:
-            self.kv = dict()
+            self.kv = {}
         else:
             self.kv = kv
 

--- a/baseplate/__init__.py
+++ b/baseplate/__init__.py
@@ -241,7 +241,7 @@ class RequestContext:
             prefix=self.__prefix,
             span=self.span,
             wrapped=self,
-            kv=self.kv.copy()
+            kv=self.kv.copy(),
         )
 
 

--- a/baseplate/__init__.py
+++ b/baseplate/__init__.py
@@ -193,6 +193,8 @@ class RequestContext:
         self.__wrapped = wrapped
         if kv is None:
             self.kv = dict()
+        else:
+            self.kv = kv
 
         # the context and span reference eachother (unfortunately) so we can't
         # construct 'em both with references from the start. however, we can

--- a/baseplate/__init__.py
+++ b/baseplate/__init__.py
@@ -186,10 +186,13 @@ class RequestContext:
         prefix: Optional[str] = None,
         span: Optional["Span"] = None,
         wrapped: Optional["RequestContext"] = None,
+        kv: Optional[Dict[str, Any]] = None,
     ):
         self.__context_config = context_config
         self.__prefix = prefix
         self.__wrapped = wrapped
+        if kv is None:
+            self.kv = dict()
 
         # the context and span reference eachother (unfortunately) so we can't
         # construct 'em both with references from the start. however, we can

--- a/baseplate/__init__.py
+++ b/baseplate/__init__.py
@@ -241,6 +241,7 @@ class RequestContext:
             prefix=self.__prefix,
             span=self.span,
             wrapped=self,
+            kv=self.kv.copy()
         )
 
 

--- a/baseplate/server/__init__.py
+++ b/baseplate/server/__init__.py
@@ -52,6 +52,7 @@ from opentelemetry.sdk.trace.export import BatchSpanProcessor
 from opentelemetry.sdk.trace.sampling import DEFAULT_ON
 from opentelemetry.sdk.trace.sampling import ParentBased
 from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
+from opentelemetry.instrumentation.threading import ThreadingInstrumentor
 
 from baseplate import Baseplate
 from baseplate.lib import warn_deprecated

--- a/baseplate/server/__init__.py
+++ b/baseplate/server/__init__.py
@@ -52,7 +52,6 @@ from opentelemetry.sdk.trace.export import BatchSpanProcessor
 from opentelemetry.sdk.trace.sampling import DEFAULT_ON
 from opentelemetry.sdk.trace.sampling import ParentBased
 from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
-from opentelemetry.instrumentation.threading import ThreadingInstrumentor
 
 from baseplate import Baseplate
 from baseplate.lib import warn_deprecated


### PR DESCRIPTION
Add a `kv` field to the baseplate `RequestContext` object to allow passing arbitrary data.

This can be used to explicitly pass opentelemetry context across processes, for example with our internal graphql codebase we can do things like:

Attach to context in kv store

```
trace.context_api.attach(context.kv["otel"])
```

Store span in context:
```
trace.set_span_in_context(span, context.kv["otel"])
```

Of course this can be used for other non-tracing purposes as well.