### PR TITLE
Initialize tracing export code to run earlier in the startup process.

### DIFF
--- a/baseplate/server/__init__.py
+++ b/baseplate/server/__init__.py
@@ -331,7 +331,6 @@ def load_app_and_run_server() -> None:
         logger.info("Metrics are not configured, Prometheus metrics will not be exported.")
 
     configure_logging(config, args.debug)
-    configure_tracing()
 
     app = make_app(config.app)
     listener = make_listener(args.bind)

--- a/bin/baseplate-serve
+++ b/bin/baseplate-serve
@@ -21,6 +21,7 @@ except ImportError:
     pass
 
 
-from baseplate.server import load_app_and_run_server
+from baseplate.server import configure_tracing, load_app_and_run_server
 
+configure_tracing()
 load_app_and_run_server()


### PR DESCRIPTION
This avoids a race-condition with our gevent patching.

Resolves the error that looks like:
```
Traceback (most recent call last):
  File "src/gevent/_abstract_linkable.py", line 287, in gevent._gevent_c_abstract_linkable.AbstractLinkable._notify_links
  File "src/gevent/_abstract_linkable.py", line 333, in gevent._gevent_c_abstract_linkable.AbstractLinkable._notify_links
AssertionError: (None, <callback at 0x7f72a5936040 args=([],)>)
2024-05-01T14:26:07Z <callback at 0x7f72a5936040 args=([],)> failed with AssertionError
```

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 💸 TL;DR
<!-- What's the three sentence summary of purpose of the PR -->

## 📜 Details
[Design Doc](<!-- insert Google Doc link here if applicable -->)

[Jira](<!-- insert Jira link if applicable -->)

<!-- Add additional details required for the PR: breaking changes, screenshots, external dependency changes -->

## 🧪 Testing Steps / Validation
<!-- add details on how this PR has been tested, include reproductions and screenshots where applicable -->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] CI tests (if present) are passing
- [ ] Adheres to code style for repo
- [ ] Contributor License Agreement (CLA) completed if not a Reddit employee
