### PR TITLE
Remove non-existent param `app_config` from configure_context docstring

### DIFF
--- a/baseplate/__init__.py
+++ b/baseplate/__init__.py
@@ -406,7 +406,6 @@ class Baseplate:
             context.cache.get("example")
             context.cassandra.foo.execute()
 
-        :param app_config: The raw stringy configuration dictionary.
         :param context_spec: A specification of what the configuration should
             look like.
 


### PR DESCRIPTION
<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 💸 TL;DR
<!-- What's the three sentence summary of purpose of the PR -->

The function `configure_context` does not take a param `app_config`.

https://github.com/reddit/baseplate.py/blob/54c7f5f47fe06a9a6a5dd080031f3500ebcd950f/baseplate/__init__.py#L380

## 📜 Details
[Design Doc](<!-- insert Google Doc link here if applicable -->)

[Jira](<!-- insert Jira link if applicable -->)

<!-- Add additional details required for the PR: breaking changes, screenshots, external dependency changes -->

## 🧪 Testing Steps / Validation
<!-- add details on how this PR has been tested, include reproductions and screenshots where applicable -->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] CI tests (if present) are passing
- [ ] Adheres to code style for repo
- [ ] Contributor License Agreement (CLA) completed if not a Reddit employee
