### PR TITLE
Fix sampler nesting for tracing

### DIFF
--- a/baseplate/server/__init__.py
+++ b/baseplate/server/__init__.py
@@ -226,7 +226,7 @@ class BaseplateBatchSpanProcessor(BatchSpanProcessor):
 def configure_tracing() -> None:
     logger.info("Entering configure tracing function")
     sample_rps = 10
-    sampler = RateLimited(ParentBased(DEFAULT_ON), sample_rps)
+    sampler = ParentBased(RateLimited(DEFAULT_ON, sample_rps))
     otlp_exporter = OTLPSpanExporter()
     propagate.set_global_textmap(
         CompositePropagator(


### PR DESCRIPTION
The parent based sampler should be run first, then if there is no parent we will run the rate-limit sampler. This is causing traces to break in prod at the moment, specifically noticeable with gql.py

