### PR TITLE
tracing: Only decode the traceparent and tracestate headers

### DIFF
--- a/baseplate/frameworks/thrift/__init__.py
+++ b/baseplate/frameworks/thrift/__init__.py
@@ -84,7 +84,7 @@ class _ContextAwareHandler:
                 try:
                     # this is only for w3c trace headers
                     key = k.decode()
-                    if key == "traceparent" or key == "tracestate":
+                    if key in ["traceparent", "tracestate", "Trace", "Span", "Sampled", "Flags"]:
                         header_dict[key] = v.decode()
                 except UnicodeDecodeError:
                     self.logger.info(f"Unable to decode header {k.decode()}, ignoring.")

--- a/baseplate/frameworks/thrift/__init__.py
+++ b/baseplate/frameworks/thrift/__init__.py
@@ -58,6 +58,16 @@ PROM_ACTIVE = Gauge(
     ["thrift_method"],
     multiprocess_mode="livesum",
 )
+W3C_HEADERS: frozenset[bytes] = frozenset(
+    (
+        b"traceparent",
+        b"tracestate",
+        b"trace",
+        b"span",
+        b"sampled",
+        b"flags",
+    )
+)
 
 
 class _ContextAwareHandler:
@@ -83,11 +93,10 @@ class _ContextAwareHandler:
             for k, v in headers.items():
                 try:
                     # this is only for w3c trace headers
-                    key = k.decode()
-                    if key in ["traceparent", "tracestate", "Trace", "Span", "Sampled", "Flags"]:
-                        header_dict[key] = v.decode()
+                    if k.lower() in W3C_HEADERS:
+                        header_dict[k.decode()] = v.decode()
                 except UnicodeDecodeError:
-                    self.logger.info(f"Unable to decode header {k.decode()}, ignoring.")
+                    self.logger.info(f"Unable to decode header {k!r}={v!r}, ignoring.")
 
             ctx = propagator.extract(header_dict)
             logger.debug("Extracted trace headers. [ctx=%s, header_dict=%s]", ctx, header_dict)

--- a/baseplate/frameworks/thrift/__init__.py
+++ b/baseplate/frameworks/thrift/__init__.py
@@ -96,7 +96,7 @@ class _ContextAwareHandler:
                     if k.lower() in W3C_HEADERS:
                         header_dict[k.decode()] = v.decode()
                 except UnicodeDecodeError:
-                    self.logger.info(f"Unable to decode header {k!r}={v!r}, ignoring.")
+                    self.logger.debug(f"Unable to decode header {k!r}={v!r}, ignoring.")
 
             ctx = propagator.extract(header_dict)
             logger.debug("Extracted trace headers. [ctx=%s, header_dict=%s]", ctx, header_dict)

--- a/baseplate/frameworks/thrift/__init__.py
+++ b/baseplate/frameworks/thrift/__init__.py
@@ -82,7 +82,10 @@ class _ContextAwareHandler:
             header_dict = {}
             for k, v in headers.items():
                 try:
-                    header_dict[k.decode()] = v.decode()
+                    # this is only for w3c trace headers
+                    key = k.decode()
+                    if key == "traceparent" or key == "tracestate":
+                        header_dict[key] = v.decode()
                 except UnicodeDecodeError:
                     self.logger.info(f"Unable to decode header {k.decode()}, ignoring.")
 


### PR DESCRIPTION
We all change the UnicodeDecodeError exception to be a debug message. This really shouldn't happen oncee we are restricting the headers to tracestate and traceparent though.
