### PR TITLE
Patch gevent to work with tracing

### DIFF
--- a/baseplate/__init__.py
+++ b/baseplate/__init__.py
@@ -10,7 +10,6 @@ import gevent.monkey
 from pkg_resources import DistributionNotFound, get_distribution
 
 from baseplate.lib import UnknownCallerError, config, get_calling_module_name, metrics
-from baseplate.lib.tracing import patch_greenlet_tracing
 
 try:
     __version__ = get_distribution(__name__).version
@@ -18,7 +17,6 @@ except DistributionNotFound:
     # package is not installed
     __version__ = "unknown"
 
-patch_greenlet_tracing()
 
 logger = logging.getLogger(__name__)
 

--- a/baseplate/__init__.py
+++ b/baseplate/__init__.py
@@ -10,6 +10,7 @@ import gevent.monkey
 from pkg_resources import DistributionNotFound, get_distribution
 
 from baseplate.lib import UnknownCallerError, config, get_calling_module_name, metrics
+from baseplate.lib.tracing import patch_greenlet_tracing
 
 try:
     __version__ = get_distribution(__name__).version
@@ -17,6 +18,7 @@ except DistributionNotFound:
     # package is not installed
     __version__ = "unknown"
 
+patch_greenlet_tracing()
 
 logger = logging.getLogger(__name__)
 

--- a/baseplate/lib/tracing.py
+++ b/baseplate/lib/tracing.py
@@ -54,7 +54,7 @@ __IMapUnordered = gevent.pool.IMapUnordered
 
 class Runnable(Protocol):
     @property
-    def trace_context(self) -> Context: ...
+    def bp_trace_context(self) -> Context: ...
 
     run: Callable
 

--- a/baseplate/lib/tracing.py
+++ b/baseplate/lib/tracing.py
@@ -1,5 +1,5 @@
-from collections.abc import Sequence
-from typing import Optional
+from collections.abc import Sequence, Callable
+from typing import Optional, Protocol
 
 import gevent.pool
 from opentelemetry import context
@@ -51,27 +51,29 @@ __Greenlet = gevent.Greenlet
 __IMap = gevent.pool.IMap
 __IMapUnordered = gevent.pool.IMapUnordered
 
+class Runnable(Protocol):
+    @property
+    def trace_context(self) -> Context: ...
+
+    run: Callable
 
 class TracingMixin:
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self : Runnable, *args, **kwargs) -> None: #type: ignore
         self.trace_context = context.get_current()
         super().__init__(*args, **kwargs)
 
-    def run(self) -> None:
+    def run(self : Runnable) -> None:
         context.attach(self.trace_context)
         super().run()
 
 
-class TracedGreenlet(TracingMixin, gevent.Greenlet):
-    pass
+class TracedGreenlet(TracingMixin, gevent.Greenlet): ...
 
 
-class TracedIMapUnordered(TracingMixin, gevent.pool.IMapUnordered):
-    pass
+class TracedIMapUnordered(TracingMixin, gevent.pool.IMapUnordered): ...
 
 
-class TracedIMap(TracedIMapUnordered, gevent.pool.IMap):
-    pass
+class TracedIMap(TracedIMapUnordered, gevent.pool.IMap): ...
 
 
 def patch_greenlet_tracing() -> None:

--- a/baseplate/lib/tracing.py
+++ b/baseplate/lib/tracing.py
@@ -2,10 +2,9 @@ from collections.abc import Sequence
 from typing import Optional
 
 import gevent.pool
-
+from opentelemetry import context
 from opentelemetry.context import Context
 from opentelemetry.sdk.trace.sampling import Decision, Sampler, SamplingResult
-from opentelemetry import trace
 from opentelemetry.trace import Link, SpanKind, TraceState
 from opentelemetry.util.types import Attributes
 from pyrate_limiter import Duration, Limiter, Rate
@@ -46,43 +45,43 @@ class RateLimited(Sampler):
     def get_description(self) -> str:
         return f"RateLimited(fixed rate sampling {self.rps})"
 
+
 # Greenlet tracing utils
 __Greenlet = gevent.Greenlet
 __IMap = gevent.pool.IMap
 __IMapUnordered = gevent.pool.IMapUnordered
 
-class TracingMixin:
-    def __init__(self, *args, **kwargs):
-        self.trace_context = trace.context_api.get_current()
-        super(TracingMixin, self).__init__(*args, **kwargs)
 
-    def run(self):
-        trace.context_api.attach(self.trace_context)
-        super(TracingMixin, self).run()
+class TracingMixin:
+    def __init__(self, *args, **kwargs) -> None:
+        self.trace_context = context.get_current()
+        super().__init__(*args, **kwargs)
+
+    def run(self) -> None:
+        context.attach(self.trace_context)
+        super().run()
 
 
 class TracedGreenlet(TracingMixin, gevent.Greenlet):
-    def __init__(self, *args, **kwargs):
-        super(TracedGreenlet, self).__init__(*args, **kwargs)
+    pass
 
 
 class TracedIMapUnordered(TracingMixin, gevent.pool.IMapUnordered):
-    def __init__(self, *args, **kwargs):
-        super(TracedIMapUnordered, self).__init__(*args, **kwargs)
+    pass
 
 
 class TracedIMap(TracedIMapUnordered, gevent.pool.IMap):
-    def __init__(self, *args, **kwargs):
-        super(TracedIMap, self).__init__(*args, **kwargs)
+    pass
 
 
-def patch_greenlet_tracing():
+def patch_greenlet_tracing() -> None:
     if getattr(gevent, "__rddt_patch", False):
         return
     gevent.__rddt_patch = True
     _replace(TracedGreenlet, TracedIMap, TracedIMapUnordered)
 
-def unpatch_greenlet_tracing():
+
+def unpatch_greenlet_tracing() -> None:
     if not getattr(gevent, "__rddt_patch", False):
         return
     gevent.__rddt_patch = False
@@ -90,7 +89,11 @@ def unpatch_greenlet_tracing():
     _replace(__Greenlet, __IMap, __IMapUnordered)
 
 
-def _replace(g_class, imap_class, imap_unordered_class):
+def _replace(
+    g_class: gevent.Greenlet,
+    imap_class: gevent.pool.IMap,
+    imap_unordered_class: gevent.pool.IMapUnordered,
+) -> None:
     gevent.greenlet.Greenlet = g_class
     gevent.pool.Group.greenlet_class = g_class
     gevent.pool.Greenlet = g_class

--- a/baseplate/lib/tracing.py
+++ b/baseplate/lib/tracing.py
@@ -1,6 +1,8 @@
 from collections.abc import Sequence
 from typing import Optional
 
+import gevent.pool
+
 from opentelemetry.context import Context
 from opentelemetry.sdk.trace.sampling import Decision, Sampler, SamplingResult
 from opentelemetry.trace import Link, SpanKind, TraceState
@@ -42,3 +44,53 @@ class RateLimited(Sampler):
 
     def get_description(self) -> str:
         return f"RateLimited(fixed rate sampling {self.rps})"
+
+# Greenlet tracing utils
+class TracingMixin:
+    def __init__(self, *args, **kwargs):
+        self.trace_context = trace.context_api.get_current()
+        super(TracingMixin, self).__init__(*args, **kwargs)
+
+    def run(self):
+        trace.context_api.attach(self.trace_context)
+        super(TracingMixin, self).run()
+
+
+class TracedGreenlet(TracingMixin, gevent.Greenlet):
+    def __init__(self, *args, **kwargs):
+        super(TracedGreenlet, self).__init__(*args, **kwargs)
+
+
+class TracedIMapUnordered(TracingMixin, gevent.pool.IMapUnordered):
+    def __init__(self, *args, **kwargs):
+        super(TracedIMapUnordered, self).__init__(*args, **kwargs)
+
+
+class TracedIMap(TracedIMapUnordered, gevent.pool.IMap):
+    def __init__(self, *args, **kwargs):
+        super(TracedIMap, self).__init__(*args, **kwargs)
+
+
+def patch_greenlet_tracing():
+    if getattr(gevent, "__rddt_patch", False):
+        return
+    gevent.__rddt_patch = True
+    _replace(TracedGreenlet, TracedIMap, TracedIMapUnordered)
+
+
+def _replace(g_class, imap_class, imap_unordered_class):
+    gevent.greenlet.Greenlet = g_class
+    gevent.pool.Group.greenlet_class = g_class
+    gevent.pool.Greenlet = g_class
+    gevent._imap.Greenlet = g_class
+
+    # replace gevent shortcuts
+    gevent.Greenlet = gevent.greenlet.Greenlet
+    gevent.spawn = gevent.greenlet.Greenlet.spawn
+    gevent.spawn_later = gevent.greenlet.Greenlet.spawn_later
+
+    # replace the original IMap classes with the new one
+    gevent._imap.IMap = imap_class
+    gevent.pool.IMap = imap_class
+    gevent._imap.IMapUnordered = imap_unordered_class
+    gevent.pool.IMapUnordered = imap_unordered_class

--- a/baseplate/lib/tracing.py
+++ b/baseplate/lib/tracing.py
@@ -1,5 +1,5 @@
 from collections.abc import Callable, Sequence
-from typing import Optional, Protocol
+from typing import Any, Optional, Protocol
 
 import gevent.pool
 from opentelemetry import context
@@ -60,12 +60,12 @@ class Runnable(Protocol):
 
 
 class TracingMixin:
-    def __init__(self: Runnable, *args, **kwargs) -> None:  # type: ignore
-        self.trace_context = context.get_current()
+    def __init__(self: Runnable, *args: Any, **kwargs: Any) -> None:
+        self.bp_trace_context = context.get_current()
         super().__init__(*args, **kwargs)
 
     def run(self: Runnable) -> None:
-        context.attach(self.trace_context)
+        context.attach(self.bp_trace_context)
         super().run()
 
 

--- a/baseplate/lib/tracing.py
+++ b/baseplate/lib/tracing.py
@@ -5,6 +5,7 @@ import gevent.pool
 
 from opentelemetry.context import Context
 from opentelemetry.sdk.trace.sampling import Decision, Sampler, SamplingResult
+from opentelemetry import trace
 from opentelemetry.trace import Link, SpanKind, TraceState
 from opentelemetry.util.types import Attributes
 from pyrate_limiter import Duration, Limiter, Rate

--- a/baseplate/lib/tracing.py
+++ b/baseplate/lib/tracing.py
@@ -1,4 +1,4 @@
-from collections.abc import Sequence, Callable
+from collections.abc import Callable, Sequence
 from typing import Optional, Protocol
 
 import gevent.pool
@@ -51,18 +51,20 @@ __Greenlet = gevent.Greenlet
 __IMap = gevent.pool.IMap
 __IMapUnordered = gevent.pool.IMapUnordered
 
+
 class Runnable(Protocol):
     @property
     def trace_context(self) -> Context: ...
 
     run: Callable
 
+
 class TracingMixin:
-    def __init__(self : Runnable, *args, **kwargs) -> None: #type: ignore
+    def __init__(self: Runnable, *args, **kwargs) -> None:  # type: ignore
         self.trace_context = context.get_current()
         super().__init__(*args, **kwargs)
 
-    def run(self : Runnable) -> None:
+    def run(self: Runnable) -> None:
         context.attach(self.trace_context)
         super().run()
 

--- a/baseplate/lib/tracing.py
+++ b/baseplate/lib/tracing.py
@@ -47,6 +47,10 @@ class RateLimited(Sampler):
         return f"RateLimited(fixed rate sampling {self.rps})"
 
 # Greenlet tracing utils
+__Greenlet = gevent.Greenlet
+__IMap = gevent.pool.IMap
+__IMapUnordered = gevent.pool.IMapUnordered
+
 class TracingMixin:
     def __init__(self, *args, **kwargs):
         self.trace_context = trace.context_api.get_current()
@@ -77,6 +81,13 @@ def patch_greenlet_tracing():
         return
     gevent.__rddt_patch = True
     _replace(TracedGreenlet, TracedIMap, TracedIMapUnordered)
+
+def unpatch_greenlet_tracing():
+    if not getattr(gevent, "__rddt_patch", False):
+        return
+    gevent.__rddt_patch = False
+
+    _replace(__Greenlet, __IMap, __IMapUnordered)
 
 
 def _replace(g_class, imap_class, imap_unordered_class):

--- a/bin/baseplate-serve
+++ b/bin/baseplate-serve
@@ -8,9 +8,11 @@
 from gevent.monkey import patch_all
 
 from baseplate.server.monkey import patch_stdlib_queues
+from baseplate.lib.tracing import patch_greenlet_tracing
 
 patch_all()
 patch_stdlib_queues()
+patch_greenlet_tracing()
 
 try:
     import psycopg2

--- a/tests/unit/lib/tracing.py
+++ b/tests/unit/lib/tracing.py
@@ -1,0 +1,57 @@
+import logging
+import unittest
+
+import gevent
+from gevent import select
+from opentelemetry import trace
+from opentelemetry.test.test_base import TestBase
+
+from baseplate.lib.tracing import patch_greenlet_tracing, unpatch_greenlet_tracing
+
+
+logger = logging.getLogger(__name__)
+
+class PatchedTestCase(unittest.TestCase):
+    def setUp(self):
+        super().setUp()
+        patch_greenlet_tracing()
+
+    def tearDown(self):
+        super().tearDown()
+        unpatch_greenlet_tracing()
+
+class TestGevent(PatchedTestCase, TestBase):
+    def test_context_with_patch(self):
+        """Trace context is passed to greenlets"""
+
+        def gr1():
+            with trace.get_tracer("gr1").start_as_current_span("child") as c:
+                select.select([], [], [], 2)
+
+        with trace.get_tracer(__name__).start_as_current_span("parent") as p:
+            gevent.joinall([
+                           gevent.spawn(gr1),
+            ])
+
+
+        finished_spans = self.get_finished_spans()
+        self.assertGreater(len(finished_spans), 0)
+        self.assertEqual(finished_spans[0].parent.span_id, finished_spans[1].context.span_id)
+
+    def test_context_without_patch(self):
+        """Trace context is not passed if we explicitly don't patch"""
+        unpatch_greenlet_tracing()
+
+        def gr1():
+            with trace.get_tracer("gr1").start_as_current_span("child") as c:
+                select.select([], [], [], 2)
+
+        with trace.get_tracer(__name__).start_as_current_span("parent") as p:
+            gevent.joinall([
+                           gevent.spawn(gr1),
+            ])
+
+
+        finished_spans = self.get_finished_spans()
+        self.assertGreater(len(finished_spans), 0)
+        self.assertIsNone(finished_spans[0].parent)

--- a/tests/unit/lib/tracing.py
+++ b/tests/unit/lib/tracing.py
@@ -8,8 +8,8 @@ from opentelemetry.test.test_base import TestBase
 
 from baseplate.lib.tracing import patch_greenlet_tracing, unpatch_greenlet_tracing
 
-
 logger = logging.getLogger(__name__)
+
 
 class PatchedTestCase(unittest.TestCase):
     def setUp(self):
@@ -20,19 +20,21 @@ class PatchedTestCase(unittest.TestCase):
         super().tearDown()
         unpatch_greenlet_tracing()
 
+
 class TestGevent(PatchedTestCase, TestBase):
     def test_context_with_patch(self):
         """Trace context is passed to greenlets"""
 
         def gr1():
-            with trace.get_tracer("gr1").start_as_current_span("child") as c:
+            with trace.get_tracer("gr1").start_as_current_span("child"):
                 select.select([], [], [], 2)
 
-        with trace.get_tracer(__name__).start_as_current_span("parent") as p:
-            gevent.joinall([
-                           gevent.spawn(gr1),
-            ])
-
+        with trace.get_tracer(__name__).start_as_current_span("parent"):
+            gevent.joinall(
+                [
+                    gevent.spawn(gr1),
+                ]
+            )
 
         finished_spans = self.get_finished_spans()
         self.assertGreater(len(finished_spans), 0)
@@ -43,14 +45,15 @@ class TestGevent(PatchedTestCase, TestBase):
         unpatch_greenlet_tracing()
 
         def gr1():
-            with trace.get_tracer("gr1").start_as_current_span("child") as c:
+            with trace.get_tracer("gr1").start_as_current_span("child"):
                 select.select([], [], [], 2)
 
-        with trace.get_tracer(__name__).start_as_current_span("parent") as p:
-            gevent.joinall([
-                           gevent.spawn(gr1),
-            ])
-
+        with trace.get_tracer(__name__).start_as_current_span("parent"):
+            gevent.joinall(
+                [
+                    gevent.spawn(gr1),
+                ]
+            )
 
         finished_spans = self.get_finished_spans()
         self.assertGreater(len(finished_spans), 0)


### PR DESCRIPTION
Instrument gevent so that it passes opentelemetry context to greenlets. We already have a similar implementation deployed to reddit's internal graphql service. After receiving a bug report from other services missing trace context propagation the fix is being move into baseplate.py.

I've verified that this fix resolves an issue where log lines inside of a greenlet were missing the tracing info.