### PR TITLE
Recreate session when making new client

### DIFF
--- a/baseplate/sidecars/secrets_fetcher.py
+++ b/baseplate/sidecars/secrets_fetcher.py
@@ -153,6 +153,7 @@ class VaultClientFactory:
         session = requests.Session()
         session.headers["User-Agent"] = (
             f"baseplate.py-{self.__class__.__name__}/{baseplate_version}"
+        )
         return session
 
     def _make_client(self) -> "VaultClient":


### PR DESCRIPTION
requests has a memory leak from our observation of containers experiencing OOMs for this sidecar. It appears that the underlying session is keeping sockets alive. Calling close on the session should clean things up. We don't want to do this all the time because the point is to reuse connections in the pool. However, when we expire a client we can take that opportunity to recreate the session. Over time this should let us clean up the memory help by the session while having a minimal impact on connection reuse.

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 💸 TL;DR
<!-- What's the three sentence summary of purpose of the PR -->

## 📜 Details
[Design Doc](<!-- insert Google Doc link here if applicable -->)

[Jira](<!-- insert Jira link if applicable -->)

<!-- Add additional details required for the PR: breaking changes, screenshots, external dependency changes -->

## 🧪 Testing Steps / Validation
<!-- add details on how this PR has been tested, include reproductions and screenshots where applicable -->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] CI tests (if present) are passing
- [ ] Adheres to code style for repo
- [ ] Contributor License Agreement (CLA) completed if not a Reddit employee
