### PR TITLE
Use processor/client module name as thrift rpc service.

### DIFF
--- a/baseplate/clients/thrift.py
+++ b/baseplate/clients/thrift.py
@@ -223,7 +223,7 @@ def _build_thrift_proxy_method(name: str) -> Callable[..., Any]:
         # this is technically incorrect, but we don't currently have a reliable way
         # of getting the name of the service being called, so relying on the name of
         # the client is the best we can do
-        rpc_service = self.namespace
+        rpc_service = self.client_cls.__module__
         rpc_method = name
 
         # RPC specific headers

--- a/baseplate/server/thrift.py
+++ b/baseplate/server/thrift.py
@@ -49,7 +49,7 @@ class GeventServer(StreamServer):
 
         otel_attributes = {
             SpanAttributes.RPC_SYSTEM: "thrift",
-            SpanAttributes.RPC_SERVICE: self.processor.__module__, #self.processor.baseplate.service_name,
+            SpanAttributes.RPC_SERVICE: self.processor.__module__,
             SpanAttributes.NET_HOST_IP: self.server_host,
             SpanAttributes.NET_HOST_PORT: self.server_port,
         }

--- a/baseplate/server/thrift.py
+++ b/baseplate/server/thrift.py
@@ -49,7 +49,7 @@ class GeventServer(StreamServer):
 
         otel_attributes = {
             SpanAttributes.RPC_SYSTEM: "thrift",
-            SpanAttributes.RPC_SERVICE: self.processor.baseplate.service_name,
+            SpanAttributes.RPC_SERVICE: self.processor.__module__, #self.processor.baseplate.service_name,
             SpanAttributes.NET_HOST_IP: self.server_host,
             SpanAttributes.NET_HOST_PORT: self.server_port,
         }

--- a/tests/integration/otel_thrift_tests.py
+++ b/tests/integration/otel_thrift_tests.py
@@ -169,7 +169,7 @@ class ThriftTraceHeaderTests(GeventPatchedTestCase, TestBase):
             thrift_client_span,
             {
                 SpanAttributes.RPC_SYSTEM: "thrift",
-                SpanAttributes.RPC_SERVICE: THRIFT_CLIENT_NAME,
+                SpanAttributes.RPC_SERVICE: "tests.integration.test_thrift.TestService",
                 SpanAttributes.RPC_METHOD: "example",
                 SpanAttributes.NET_PEER_NAME: "localhost",
                 SpanAttributes.NET_PEER_PORT: net_peer_port,
@@ -220,12 +220,12 @@ class ThriftTraceHeaderTests(GeventPatchedTestCase, TestBase):
             thrift_client_span.get_span_context().span_id,
         )
 
-        self.assertEqual(thrift_client_span.name, "example_service/example")
+        self.assertEqual(thrift_client_span.name, "tests.integration.test_thrift.TestService/example")
         self.assertSpanHasAttributes(
             thrift_client_span,
             {
                 SpanAttributes.RPC_SYSTEM: "thrift",
-                SpanAttributes.RPC_SERVICE: "example_service",
+                SpanAttributes.RPC_SERVICE: "tests.integration.test_thrift.TestService",
                 SpanAttributes.RPC_METHOD: "example",
                 SpanAttributes.NET_PEER_IP: "127.0.0.1",
                 SpanAttributes.NET_PEER_NAME: "localhost",
@@ -240,12 +240,12 @@ class ThriftTraceHeaderTests(GeventPatchedTestCase, TestBase):
         )
         self.assertEqual(thrift_client_span.events[0].name, "message")
 
-        self.assertEqual(thrift_server_span.name, "tests.integration.otel_thrift_tests/example")
+        self.assertEqual(thrift_server_span.name, "tests.integration.test_thrift.TestService/example")
         self.assertSpanHasAttributes(
             thrift_server_span,
             {
                 SpanAttributes.RPC_SYSTEM: "thrift",
-                SpanAttributes.RPC_SERVICE: "tests.integration.otel_thrift_tests",
+                SpanAttributes.RPC_SERVICE: "tests.integration.test_thrift.TestService",
                 SpanAttributes.RPC_METHOD: "example",
                 SpanAttributes.NET_HOST_IP: "127.0.0.1",
                 SpanAttributes.NET_HOST_NAME: "localhost",

--- a/tests/integration/otel_thrift_tests.py
+++ b/tests/integration/otel_thrift_tests.py
@@ -220,7 +220,9 @@ class ThriftTraceHeaderTests(GeventPatchedTestCase, TestBase):
             thrift_client_span.get_span_context().span_id,
         )
 
-        self.assertEqual(thrift_client_span.name, "tests.integration.test_thrift.TestService/example")
+        self.assertEqual(
+            thrift_client_span.name, "tests.integration.test_thrift.TestService/example"
+        )
         self.assertSpanHasAttributes(
             thrift_client_span,
             {
@@ -240,7 +242,9 @@ class ThriftTraceHeaderTests(GeventPatchedTestCase, TestBase):
         )
         self.assertEqual(thrift_client_span.events[0].name, "message")
 
-        self.assertEqual(thrift_server_span.name, "tests.integration.test_thrift.TestService/example")
+        self.assertEqual(
+            thrift_server_span.name, "tests.integration.test_thrift.TestService/example"
+        )
         self.assertSpanHasAttributes(
             thrift_server_span,
             {


### PR DESCRIPTION
The goal is to have both ends of the rpc class the same across frameworks, similar to how grpc operates.

This should align us with the upcoming baseplate.go changes. 

https://github.com/reddit/baseplate.go/pull/686

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 💸 TL;DR
<!-- What's the three sentence summary of purpose of the PR -->

## 📜 Details
[Design Doc](<!-- insert Google Doc link here if applicable -->)

[Jira](<!-- insert Jira link if applicable -->)

<!-- Add additional details required for the PR: breaking changes, screenshots, external dependency changes -->

## 🧪 Testing Steps / Validation
<!-- add details on how this PR has been tested, include reproductions and screenshots where applicable -->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] CI tests (if present) are passing
- [ ] Adheres to code style for repo
- [ ] Contributor License Agreement (CLA) completed if not a Reddit employee
